### PR TITLE
Inji 235 get issuer config endpoint response modification

### DIFF
--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -46,8 +46,10 @@ public class IssuersController {
 
         IssuerDTO issuerConfig = issuersService.getIssuerConfig(issuerId);
         responseWrapper.setResponse(issuerConfig);
+
         if (issuerConfig == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorDTO(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode(), PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage()));
+            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode(), PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseWrapper);
         }
 
         return ResponseEntity.status(HttpStatus.OK).body(responseWrapper);

--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -47,8 +47,7 @@ public class IssuersController {
         IssuerDTO issuerConfig = issuersService.getIssuerConfig(issuerId);
         responseWrapper.setResponse(issuerConfig);
         if (issuerConfig == null) {
-            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode(), PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorDTO(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode(), PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage()));
         }
 
         return ResponseEntity.status(HttpStatus.OK).body(responseWrapper);

--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -23,11 +23,12 @@ public class IssuersController {
     @Autowired
     IssuersService issuersService;
 
+    private static final String ID = "mosip.mimoto.issuers";
+
     @GetMapping()
     public ResponseEntity<Object> getAllIssuers() {
         ResponseWrapper<IssuersDTO> responseWrapper = new ResponseWrapper<>();
-        //TODO: Modify id
-        responseWrapper.setId("mosip.inji.properties");
+        responseWrapper.setId(ID);
         responseWrapper.setVersion("v1");
         responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
         responseWrapper.setResponse(issuersService.getAllIssuers());
@@ -38,8 +39,7 @@ public class IssuersController {
     @GetMapping("/{issuer-id}")
     public ResponseEntity<Object> getIssuerConfig(@PathVariable("issuer-id") String issuerId) {
         ResponseWrapper<Object> responseWrapper = new ResponseWrapper<>();
-        //TODO: Modify id
-        responseWrapper.setId("mosip.inji.properties");
+        responseWrapper.setId(ID);
         responseWrapper.setVersion("v1");
         responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
 

--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -1,7 +1,10 @@
 package io.mosip.mimoto.controller;
 
 import io.mosip.mimoto.core.http.ResponseWrapper;
+import io.mosip.mimoto.dto.ErrorDTO;
+import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.exception.PlatformErrorMessages;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +14,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(value = "/issuers")
@@ -39,7 +44,12 @@ public class IssuersController {
         responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
 
 
-        responseWrapper.setResponse(issuersService.getIssuerConfig(issuerId));
+        IssuerDTO issuerConfig = issuersService.getIssuerConfig(issuerId);
+        responseWrapper.setResponse(issuerConfig);
+        if (issuerConfig == null) {
+            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode(), PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
+        }
 
         return ResponseEntity.status(HttpStatus.OK).body(responseWrapper);
     }

--- a/src/main/java/io/mosip/mimoto/exception/InvalidIssuerIdException.java
+++ b/src/main/java/io/mosip/mimoto/exception/InvalidIssuerIdException.java
@@ -5,7 +5,7 @@ public class InvalidIssuerIdException extends BaseUncheckedException {
     /**
      * Unique id for serialization
      */
-    private static final long serialVersionUID = -5350213197226295789L;
+    private static final long serialVersionUID = -5350213127226295789L;
 
     /**
      * Constructor with errorCode, and errorMessage

--- a/src/main/java/io/mosip/mimoto/exception/InvalidIssuerIdException.java
+++ b/src/main/java/io/mosip/mimoto/exception/InvalidIssuerIdException.java
@@ -1,0 +1,24 @@
+package io.mosip.mimoto.exception;
+
+public class InvalidIssuerIdException extends BaseUncheckedException {
+
+    /**
+     * Unique id for serialization
+     */
+    private static final long serialVersionUID = -5350213197226295789L;
+
+    /**
+     * Constructor with errorCode, and errorMessage
+     *
+     * @param errorCode    The error code for this exception
+     * @param errorMessage The error message for this exception
+     */
+    public InvalidIssuerIdException(String errorCode, String errorMessage) {
+        super(errorCode, errorMessage);
+    }
+
+    public InvalidIssuerIdException(String errorMessage) {
+        super(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode(), errorMessage);
+    }
+
+}

--- a/src/main/java/io/mosip/mimoto/exception/PlatformErrorMessages.java
+++ b/src/main/java/io/mosip/mimoto/exception/PlatformErrorMessages.java
@@ -80,7 +80,8 @@ public enum PlatformErrorMessages {
     MIMOTO_IDP_AUTHENTICATE_EXCEPTION(PlatformConstants.PREFIX + "031", "Idp authenticate exception occured"),
     MIMOTO_IDP_CONSENT_EXCEPTION(PlatformConstants.PREFIX + "032", "Idp consent exception occured"),
     MIMOTO_IDP_OTP_EXCEPTION(PlatformConstants.PREFIX + "033", "IDP Otp error occured"),
-    MIMOTO_IDP_GENERIC_EXCEPTION(PlatformConstants.PREFIX + "034", "Could not get response from server");
+    MIMOTO_IDP_GENERIC_EXCEPTION(PlatformConstants.PREFIX + "034", "Could not get response from server"),
+    INVALID_ISSUER_ID_EXCEPTION(PlatformConstants.PREFIX + "035", "Invalid issuer ID");
 
     /** The error message. */
     private final String errorMessage;

--- a/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 
-import static io.mosip.mimoto.service.IssuersServiceTest.getIssuerDTO;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -121,13 +120,25 @@ public class InjiControllerTest {
                 .andExpect(status().isOk());
     }
 
-    String issuersJsonString = "{\"issuers\": [{\"id\": \"id1\",\"displayName\": \"Issuer 1\",\"logoUrl\": \"logo url\",\"clientId\": 123,\"redirectionUri\": \"/redirection\",\"serviceConfiguration\": {\"authorizationEndpoint\": \"/authorize\",\"tokenEndpoint\": \"/access_token\",\"revocationEndpoint\": \"/revoke\"}},{  \"id\": \"id2\",  \"displayName\": \"Issuer 2\",  \"logoUrl\": \"logo url\",  \"clientId\": 123,  \"wellKnownEndpoint\": \"/.well-known\"}  ]}";
+    static IssuerDTO getIssuerDTO(String issuerName) {
+        IssuerDTO issuer = new IssuerDTO();
+        issuer.setId(issuerName + "id");
+        issuer.setDisplayName(issuerName);
+        issuer.setLogoUrl("/logo");
+        issuer.setClientId("123");
+        if (issuerName.equals("Issuer1")) issuer.setWellKnownEndpoint("/.well-known");
+        else {
+            issuer.setRedirectionUri(null);
+            issuer.setServiceConfiguration(null);
+            issuer.setAdditionalHeaders(null);
+        }
+        return issuer;
+    }
 
     @Test
     public void getAllIssuersTest() throws Exception {
         IssuersDTO issuers = new IssuersDTO();
-        List<String> issuerConfigRelatedFields = List.of("additionalHeaders", "serviceConfiguration", "redirectionUri");
-        issuers.setIssuers((List.of(getIssuerDTO("Issuer1", issuerConfigRelatedFields), getIssuerDTO("Issuer2", issuerConfigRelatedFields))));
+        issuers.setIssuers((List.of(getIssuerDTO("Issuer1"), getIssuerDTO("Issuer2"))));
         Mockito.when(issuersService.getAllIssuers()).thenReturn(issuers);
 
         mockMvc.perform(get("/issuers").accept(MediaType.APPLICATION_JSON_VALUE))
@@ -148,7 +159,7 @@ public class InjiControllerTest {
 
     @Test
     public void getIssuerConfigTest() throws Exception {
-        Mockito.when(issuersService.getIssuerConfig("id1")).thenReturn(getIssuerDTO("Issuer1", Collections.emptyList()));
+        Mockito.when(issuersService.getIssuerConfig("id1")).thenReturn(getIssuerDTO("Issuer1"));
         Mockito.when(issuersService.getIssuerConfig("invalidId")).thenReturn(null);
 
         mockMvc.perform(get("/issuers/id1").accept(MediaType.APPLICATION_JSON_VALUE))

--- a/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
@@ -164,9 +164,10 @@ public class InjiControllerTest {
 
         mockMvc.perform(get("/issuers/id1").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
-        mockMvc.perform(get("/issuers/invalidId").accept(MediaType.APPLICATION_JSON_VALUE)).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode())))
-                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
+        mockMvc.perform(get("/issuers/invalidId").accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode())))
+                .andExpect(jsonPath("$.errorMessage", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
@@ -166,8 +166,8 @@ public class InjiControllerTest {
                 .andExpect(status().isOk());
         mockMvc.perform(get("/issuers/invalidId").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.errorCode", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode())))
-                .andExpect(jsonPath("$.errorMessage", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
+                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode())))
+                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
@@ -12,6 +12,7 @@ import io.mosip.mimoto.dto.mimoto.*;
 import io.mosip.mimoto.dto.resident.*;
 import io.mosip.mimoto.exception.ApisResourceAccessException;
 import io.mosip.mimoto.exception.BaseUncheckedException;
+import io.mosip.mimoto.exception.PlatformErrorMessages;
 import io.mosip.mimoto.model.Event;
 import io.mosip.mimoto.model.EventModel;
 import io.mosip.mimoto.service.RestClientService;
@@ -142,6 +143,9 @@ public class InjiControllerTest {
 
         mockMvc.perform(get("/issuers/id1").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk());
+        mockMvc.perform(get("/issuers/invalidId").accept(MediaType.APPLICATION_JSON_VALUE)).andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is( PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode())))
+                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -36,7 +36,7 @@ public class IssuersServiceTest {
     List<String> issuerConfigRelatedFields = List.of("additionalHeaders", "serviceConfiguration", "redirectionUri");
 
 
-    private static IssuerDTO getIssuerDTO(String issuerName, List<String> nullFields) {
+    public static IssuerDTO getIssuerDTO(String issuerName, List<String> nullFields) {
         IssuerDTO issuer = new IssuerDTO();
         issuer.setId(issuerName + "id");
         issuer.setDisplayName(issuerName);

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -36,7 +36,7 @@ public class IssuersServiceTest {
     List<String> issuerConfigRelatedFields = List.of("additionalHeaders", "serviceConfiguration", "redirectionUri");
 
 
-    public static IssuerDTO getIssuerDTO(String issuerName, List<String> nullFields) {
+     static IssuerDTO getIssuerDTO(String issuerName, List<String> nullFields) {
         IssuerDTO issuer = new IssuerDTO();
         issuer.setId(issuerName + "id");
         issuer.setDisplayName(issuerName);


### PR DESCRIPTION
 Return "bad request" response when invalid issuer id is passed to "get issuer config" (/issuers/{invalid-IssuerId}) endpoint