### PR TITLE
Return Error response when reading issuers list from mosip-config fails

### DIFF
--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -7,6 +7,8 @@ import io.mosip.mimoto.dto.IssuersDTO;
 import io.mosip.mimoto.exception.ApiNotAccessibleException;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +31,8 @@ public class IssuersController {
 
     private static final String ID = "mosip.mimoto.issuers";
 
+    private final Logger logger = LoggerFactory.getLogger(IssuersController.class);
+
     @GetMapping()
     public ResponseEntity<Object> getAllIssuers() {
         ResponseWrapper<IssuersDTO> responseWrapper = new ResponseWrapper<>();
@@ -38,6 +42,7 @@ public class IssuersController {
         try {
             responseWrapper.setResponse(issuersService.getAllIssuers());
         } catch (ApiNotAccessibleException | IOException e) {
+            logger.error("Exception occurred while fetching issuers ",e);
             responseWrapper.setErrors(List.of(new ErrorDTO(API_NOT_ACCESSIBLE_EXCEPTION.getCode(), API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
         }
@@ -57,6 +62,7 @@ public class IssuersController {
         try {
             issuerConfig = issuersService.getIssuerConfig(issuerId);
         } catch (ApiNotAccessibleException | IOException exception) {
+            logger.error("Exception occurred while fetching issuers ",exception);
             responseWrapper.setErrors(List.of(new ErrorDTO(API_NOT_ACCESSIBLE_EXCEPTION.getCode(), API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
         }

--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -5,7 +5,6 @@ import io.mosip.mimoto.dto.ErrorDTO;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.IssuersDTO;
 import io.mosip.mimoto.exception.ApiNotAccessibleException;
-import io.mosip.mimoto.exception.PlatformErrorMessages;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.util.List;
+
+import static io.mosip.mimoto.exception.PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION;
+import static io.mosip.mimoto.exception.PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION;
 
 @RestController
 @RequestMapping(value = "/issuers")
@@ -36,7 +38,7 @@ public class IssuersController {
         try {
             responseWrapper.setResponse(issuersService.getAllIssuers());
         } catch (ApiNotAccessibleException | IOException e) {
-            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getCode(), PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+            responseWrapper.setErrors(List.of(new ErrorDTO(API_NOT_ACCESSIBLE_EXCEPTION.getCode(), API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
         }
 
@@ -55,14 +57,14 @@ public class IssuersController {
         try {
             issuerConfig = issuersService.getIssuerConfig(issuerId);
         } catch (ApiNotAccessibleException | IOException exception) {
-            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getCode(), PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+            responseWrapper.setErrors(List.of(new ErrorDTO(API_NOT_ACCESSIBLE_EXCEPTION.getCode(), API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
         }
 
         responseWrapper.setResponse(issuerConfig);
 
         if (issuerConfig == null) {
-            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode(), PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
+            responseWrapper.setErrors(List.of(new ErrorDTO(INVALID_ISSUER_ID_EXCEPTION.getCode(), INVALID_ISSUER_ID_EXCEPTION.getMessage())));
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseWrapper);
         }
 

--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -4,6 +4,7 @@ import io.mosip.mimoto.core.http.ResponseWrapper;
 import io.mosip.mimoto.dto.ErrorDTO;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
 import io.mosip.mimoto.exception.PlatformErrorMessages;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.DateUtils;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -31,7 +33,12 @@ public class IssuersController {
         responseWrapper.setId(ID);
         responseWrapper.setVersion("v1");
         responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
-        responseWrapper.setResponse(issuersService.getAllIssuers());
+        try {
+            responseWrapper.setResponse(issuersService.getAllIssuers());
+        } catch (ApiNotAccessibleException | IOException e) {
+            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getCode(), PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
+        }
 
         return ResponseEntity.status(HttpStatus.OK).body(responseWrapper);
     }
@@ -44,7 +51,14 @@ public class IssuersController {
         responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
 
 
-        IssuerDTO issuerConfig = issuersService.getIssuerConfig(issuerId);
+        IssuerDTO issuerConfig;
+        try {
+            issuerConfig = issuersService.getIssuerConfig(issuerId);
+        } catch (ApiNotAccessibleException | IOException exception) {
+            responseWrapper.setErrors(List.of(new ErrorDTO(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getCode(), PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseWrapper);
+        }
+
         responseWrapper.setResponse(issuerConfig);
 
         if (issuerConfig == null) {

--- a/src/main/java/io/mosip/mimoto/service/IssuersService.java
+++ b/src/main/java/io/mosip/mimoto/service/IssuersService.java
@@ -2,9 +2,12 @@ package io.mosip.mimoto.service;
 
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+
+import java.io.IOException;
 
 public interface IssuersService {
-    IssuersDTO getAllIssuers();
+    IssuersDTO getAllIssuers() throws ApiNotAccessibleException, IOException;
 
-    IssuerDTO getIssuerConfig(String issuerId);
+    IssuerDTO getIssuerConfig(String issuerId) throws ApiNotAccessibleException, IOException;
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
@@ -7,8 +7,6 @@ import io.mosip.mimoto.dto.IssuersDTO;
 import io.mosip.mimoto.exception.ApiNotAccessibleException;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.Utilities;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,22 +18,15 @@ public class IssuersServiceImpl implements IssuersService {
     @Autowired
     private Utilities utilities;
 
-    private final Logger logger = LoggerFactory.getLogger(IssuersServiceImpl.class);
-
     @Override
     public IssuersDTO getAllIssuers() throws ApiNotAccessibleException, IOException {
-        IssuersDTO issuers = new IssuersDTO();
-        try {
-            String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
-            if (issuersConfigJsonValue == null) {
-                throw new ApiNotAccessibleException();
-            }
-            Gson gsonWithIssuerDataOnlyFilter = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
-            issuers = gsonWithIssuerDataOnlyFilter.fromJson(issuersConfigJsonValue, IssuersDTO.class);
-        } catch (IOException | ApiNotAccessibleException exception) {
-            logger.error(exception.getMessage());
-            throw exception;
+        IssuersDTO issuers;
+        String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
+        if (issuersConfigJsonValue == null) {
+            throw new ApiNotAccessibleException();
         }
+        Gson gsonWithIssuerDataOnlyFilter = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
+        issuers = gsonWithIssuerDataOnlyFilter.fromJson(issuersConfigJsonValue, IssuersDTO.class);
 
         return issuers;
     }
@@ -44,21 +35,16 @@ public class IssuersServiceImpl implements IssuersService {
     @Override
     public IssuerDTO getIssuerConfig(String issuerId) throws ApiNotAccessibleException, IOException {
         IssuerDTO issuerDTO = null;
-        try {
-            String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
-            if (issuersConfigJsonValue == null) {
-                throw new ApiNotAccessibleException();
-            }
-            IssuersDTO issuers = new Gson().fromJson(issuersConfigJsonValue, IssuersDTO.class);
-            Optional<IssuerDTO> issuerConfigResp = issuers.getIssuers().stream()
-                    .filter(issuer -> issuer.getId().equals(issuerId))
-                    .findFirst();
-            if (issuerConfigResp.isPresent())
-                issuerDTO = issuerConfigResp.get();
-        } catch (IOException | ApiNotAccessibleException exception) {
-            logger.error(exception.getMessage());
-            throw exception;
+        String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
+        if (issuersConfigJsonValue == null) {
+            throw new ApiNotAccessibleException();
         }
+        IssuersDTO issuers = new Gson().fromJson(issuersConfigJsonValue, IssuersDTO.class);
+        Optional<IssuerDTO> issuerConfigResp = issuers.getIssuers().stream()
+                .filter(issuer -> issuer.getId().equals(issuerId))
+                .findFirst();
+        if (issuerConfigResp.isPresent())
+            issuerDTO = issuerConfigResp.get();
         return issuerDTO;
     }
 }

--- a/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/InjiControllerTest.java
@@ -43,6 +43,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.*;
 
+import static io.mosip.mimoto.exception.PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION;
+import static io.mosip.mimoto.exception.PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -161,8 +163,8 @@ public class InjiControllerTest {
 
         mockMvc.perform(get("/issuers").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getCode())))
-                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(API_NOT_ACCESSIBLE_EXCEPTION.getCode())))
+                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
     }
 
     @Test
@@ -177,13 +179,13 @@ public class InjiControllerTest {
 
         mockMvc.perform(get("/issuers/invalidId").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getCode())))
-                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION.getMessage())));
+                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(INVALID_ISSUER_ID_EXCEPTION.getCode())))
+                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(INVALID_ISSUER_ID_EXCEPTION.getMessage())));
 
         mockMvc.perform(get("/issuers/id1").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getCode())))
-                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+                .andExpect(jsonPath("$.errors[0].errorCode", Matchers.is(API_NOT_ACCESSIBLE_EXCEPTION.getCode())))
+                .andExpect(jsonPath("$.errors[0].errorMessage", Matchers.is(API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.IssuersDTO;
 import io.mosip.mimoto.dto.ServiceConfiguration;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
 import io.mosip.mimoto.service.impl.IssuersServiceImpl;
 import io.mosip.mimoto.util.Utilities;
 import org.junit.Before;
@@ -15,6 +16,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +38,7 @@ public class IssuersServiceTest {
     List<String> issuerConfigRelatedFields = List.of("additionalHeaders", "serviceConfiguration", "redirectionUri");
 
 
-     static IssuerDTO getIssuerDTO(String issuerName, List<String> nullFields) {
+    static IssuerDTO getIssuerDTO(String issuerName, List<String> nullFields) {
         IssuerDTO issuer = new IssuerDTO();
         issuer.setId(issuerName + "id");
         issuer.setDisplayName(issuerName);
@@ -68,7 +70,7 @@ public class IssuersServiceTest {
     }
 
     @Test
-    public void shouldReturnIssuersWithIssuerConfigAsNull() {
+    public void shouldReturnIssuersWithIssuerConfigAsNull() throws ApiNotAccessibleException, IOException {
         IssuersDTO expectedIssuers = new IssuersDTO();
         List<IssuerDTO> issuers = new ArrayList<>(List.of(getIssuerDTO("Issuer1", issuerConfigRelatedFields), getIssuerDTO("Issuer2", issuerConfigRelatedFields)));
         expectedIssuers.setIssuers(issuers);
@@ -78,8 +80,15 @@ public class IssuersServiceTest {
         assertEquals(expectedIssuers, allIssuers);
     }
 
+    @Test(expected = ApiNotAccessibleException.class)
+    public void shouldThrowApiNotAccessibleExceptionWhenIssuersJsonStringIsNullForGettingAllIssuers() throws IOException, ApiNotAccessibleException {
+        Mockito.when(utilities.getIssuersConfigJsonValue()).thenReturn(null);
+
+        issuersService.getAllIssuers();
+    }
+
     @Test
-    public void shouldReturnIssuerDataAndConfigForTheIssuerIdIfExist() {
+    public void shouldReturnIssuerDataAndConfigForTheIssuerIdIfExist() throws ApiNotAccessibleException, IOException {
         IssuerDTO expectedIssuer = getIssuerDTO("Issuer1", issuerConfigRelatedFields);
 
         IssuerDTO issuer = issuersService.getIssuerConfig("Issuer1id");
@@ -88,9 +97,16 @@ public class IssuersServiceTest {
     }
 
     @Test
-    public void shouldReturnNullIfTheIssuerIdNotExists() {
+    public void shouldReturnNullIfTheIssuerIdNotExists() throws ApiNotAccessibleException, IOException {
         IssuerDTO issuer = issuersService.getIssuerConfig("Issuer3id");
 
         assertNull(issuer);
+    }
+
+    @Test(expected = ApiNotAccessibleException.class)
+    public void shouldThrowApiNotAccessibleExceptionWhenIssuersJsonStringIsNullForGettingIssuerConfig() throws IOException, ApiNotAccessibleException {
+        Mockito.when(utilities.getIssuersConfigJsonValue()).thenReturn(null);
+
+        issuersService.getIssuerConfig("Issuers1id");
     }
 }


### PR DESCRIPTION
Mimoto Issuers endpoints
 url: /issuers
url: /issuers/{issuer_id}
Response - when failed to read the issuers json from config-server (mosip-config)

```
{
    "id": "mosip.mimoto.issuers",
    "version": "v1",
    "str": null,
    "responsetime": "2023-08-25T06:44:45.504Z",
    "metadata": null,
    "response": null,
    "errors": [
        {
            "errorCode": "RESIDENT-APP-026",
            "errorMessage": "Api not accessible failure"
        }
    ]
}


```