### PR TITLE
APIs for inji web

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,9 @@
         <commons-codec>1.15</commons-codec>
         <swagger.version>2.9.2</swagger.version>
         <springdoc.version>1.5.10</springdoc.version>
-
-
+        <flying-saucer-pdf-version>9.3.1</flying-saucer-pdf-version>
+        <josup-version>1.16.2</josup-version>
+        <jjwt-version>0.9.1</jjwt-version>
         <sonar.coverage.exclusions>
             **/constant/**,**/config/**,**/httpfilter/**,**/cache/**,**/dto/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/security/**,**/*Config.java,**/*BootApplication.java,**/*VertxApplication.java,**/cbeffutil/**,**/core.http/**,**/util/**
         </sonar.coverage.exclusions>
@@ -146,6 +147,20 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.xhtmlrenderer</groupId>
+            <artifactId>flying-saucer-pdf-openpdf</artifactId>
+            <version>${flying-saucer-pdf-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${josup-version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -364,6 +379,11 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>9.25.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>${jjwt-version}</version>
         </dependency>
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>

--- a/src/main/java/io/mosip/mimoto/controller/V2IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/V2IssuersController.java
@@ -1,0 +1,163 @@
+package io.mosip.mimoto.controller;
+
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import io.mosip.mimoto.core.http.ResponseWrapper;
+import io.mosip.mimoto.dto.ErrorDTO;
+import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.dto.idp.TokenResponseDTO;
+import io.mosip.mimoto.dto.v2.IssuerSupportedCredentialsResponse;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.exception.PlatformErrorMessages;
+import io.mosip.mimoto.service.IdpService;
+import io.mosip.mimoto.service.IssuersService;
+import io.mosip.mimoto.service.V2IssuersService;
+import io.mosip.mimoto.util.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.*;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.mosip.mimoto.exception.PlatformErrorMessages.*;
+import static io.mosip.mimoto.exception.PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION;
+
+@RestController
+@RequestMapping(value = "v2/issuers")
+public class V2IssuersController {
+
+    @Autowired
+    V2IssuersService v2IssuersService;
+
+    private final Logger logger = LoggerFactory.getLogger(V2IssuersController.class);
+
+    private static final String ID = "mosip.mimoto.issuers";
+
+    @Autowired
+    IdpService idpService;
+
+    @Autowired
+    IssuersService issuersService;
+
+    @Value("${mosip.oidc.esignet.token.endpoint}")
+    String tokenEndpoint;
+
+    @GetMapping
+    public ResponseEntity<Object> getAllIssuers(@RequestParam(required = false) String search){
+        ResponseWrapper<IssuersDTO> responseWrapper = new ResponseWrapper<>();
+        responseWrapper.setId(ID);
+        responseWrapper.setVersion("v2");
+        responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
+
+        try {
+            responseWrapper.setResponse(v2IssuersService.getAllIssuers(search));
+        } catch (ApiNotAccessibleException | IOException e) {
+            logger.error("Exception occurred while fetching issuers ", e);
+            responseWrapper.setErrors(List.of(new ErrorDTO(API_NOT_ACCESSIBLE_EXCEPTION.getCode(), API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseWrapper);
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseWrapper);
+    }
+
+    @GetMapping("/{issuer-id}/credentials-supported")
+    public ResponseEntity<Object> getCredentialsSupportedForIssuer(@PathVariable("issuer-id") String issuerId,
+                                                                   @RequestParam(required = false) String search) {
+        ResponseWrapper<Object> responseWrapper = new ResponseWrapper<>();
+        responseWrapper.setId(ID);
+        responseWrapper.setVersion("v2");
+        responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
+        IssuerSupportedCredentialsResponse credentialsSupported;
+        try {
+            credentialsSupported = v2IssuersService.getCredentialsSupported(issuerId, search);
+        }catch (ApiNotAccessibleException | IOException exception){
+            logger.error("Exception occurred while fetching issuers ", exception);
+            responseWrapper.setErrors(List.of(new ErrorDTO(API_NOT_ACCESSIBLE_EXCEPTION.getCode(), API_NOT_ACCESSIBLE_EXCEPTION.getMessage())));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseWrapper);
+        }
+        responseWrapper.setResponse(credentialsSupported);
+
+        if (credentialsSupported.getSupportedCredentials().isEmpty()) {
+            logger.error("invalid issuer id passed - {}", issuerId);
+            responseWrapper.setErrors(List.of(new ErrorDTO(INVALID_ISSUER_ID_EXCEPTION.getCode(), INVALID_ISSUER_ID_EXCEPTION.getMessage())));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseWrapper);
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseWrapper);
+    }
+
+    @PostMapping(value = "/get-token/issuer", consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
+    public ResponseEntity getToken(@RequestParam Map<String, String> params, @RequestParam String issuer) {
+        logger.debug("Started Token Call get-token-> " + params.toString());
+        try {
+            IssuerDTO issuerDTO = null;
+            Reader reader = new InputStreamReader(Objects.requireNonNull(this.getClass()
+                    .getResourceAsStream("/v2-issuers-config.json")));
+            IssuersDTO issuersDto = new Gson().fromJson(reader, IssuersDTO.class);
+            Optional<IssuerDTO> issuerConfigResp = issuersDto.getIssuers().stream()
+                    .filter(issuerResponse -> issuerResponse.getCredential_issuer().equals(issuer))
+                    .findFirst();
+            if (issuerConfigResp.isPresent()) issuerDTO = issuerConfigResp.get();
+            logger.info("Issuer DTO is > " + issuerDTO);
+            return ResponseEntity.status(HttpStatus.OK).body(getTokenResponseFromParams(params, issuerDTO));
+        } catch (Exception ex){
+            logger.error("Exception Occured while invoking the get-token endpoint", ex);
+            ResponseWrapper response = getErrorResponse(PlatformErrorMessages.MIMOTO_IDP_GENERIC_EXCEPTION.getCode(), ex.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
+    }
+    public TokenResponseDTO getTokenResponseFromParams(Map<String, String> params, IssuerDTO issuer){
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<MultiValueMap<String, String>> request = idpService.constructGetTokenRequest(params, issuer);
+        return  restTemplate.postForObject(tokenEndpoint, request, TokenResponseDTO.class);
+    }
+
+    public ResponseWrapper getErrorResponse(String errorCode, String errorMessage) {
+        List<ErrorDTO> errors = getErrors(errorCode, errorMessage);
+        ResponseWrapper responseWrapper = new ResponseWrapper();
+        responseWrapper.setResponse(null);
+        responseWrapper.setResponsetime(DateUtils.getRequestTimeString());
+        responseWrapper.setId(ID);
+        responseWrapper.setErrors(errors);
+        return responseWrapper;
+    }
+
+    private List<ErrorDTO> getErrors(String errorCode, String errorMessage) {
+        ErrorDTO errorDTO = new ErrorDTO(errorCode, errorMessage);
+        return Lists.newArrayList(errorDTO);
+    }
+
+    @GetMapping("/{issuer-id}/credentials/{credentials-supported-id}/download")
+    public ResponseEntity generatePdfForVCCredentials(@RequestHeader("Bearer") String token,
+                                                      @PathVariable("issuer-id") String issuerId,
+                                                      @PathVariable("credentials-supported-id") String credentialsSupportedId) {
+
+        try{
+            ByteArrayInputStream inputStream =  v2IssuersService.generatePdfForVerifiableCredentials(token, issuerId, credentialsSupportedId);
+            return ResponseEntity
+                    .ok()
+                    .contentType(MediaType.APPLICATION_PDF)
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"Test.pdf\"")
+                    .body(new InputStreamResource(inputStream));
+        }catch (Exception e){
+            logger.error("Error at generating PDF", e);
+        }
+       return null;
+    }
+
+
+}

--- a/src/main/java/io/mosip/mimoto/controller/V2IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/V2IssuersController.java
@@ -14,6 +14,7 @@ import io.mosip.mimoto.service.IdpService;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.service.V2IssuersService;
 import io.mosip.mimoto.util.DateUtils;
+import io.mosip.mimoto.util.Utilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,11 +27,8 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static io.mosip.mimoto.exception.PlatformErrorMessages.*;
@@ -52,6 +50,9 @@ public class V2IssuersController {
 
     @Autowired
     IssuersService issuersService;
+
+    @Autowired
+    Utilities utilities;
 
     @Value("${mosip.oidc.esignet.token.endpoint}")
     String tokenEndpoint;
@@ -100,14 +101,12 @@ public class V2IssuersController {
         return ResponseEntity.status(HttpStatus.OK).body(responseWrapper);
     }
 
-    @PostMapping(value = "/get-token/issuer", consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
-    public ResponseEntity getToken(@RequestParam Map<String, String> params, @RequestParam String issuer) {
+    @PostMapping(value = "/get-token/{issuer}", consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
+    public ResponseEntity getToken(@RequestParam Map<String, String> params, @PathVariable String issuer) {
         logger.debug("Started Token Call get-token-> " + params.toString());
         try {
             IssuerDTO issuerDTO = null;
-            Reader reader = new InputStreamReader(Objects.requireNonNull(this.getClass()
-                    .getResourceAsStream("/v2-issuers-config.json")));
-            IssuersDTO issuersDto = new Gson().fromJson(reader, IssuersDTO.class);
+            IssuersDTO issuersDto = new Gson().fromJson(utilities.getV2IssuersConfigJsonValue(), IssuersDTO.class);
             Optional<IssuerDTO> issuerConfigResp = issuersDto.getIssuers().stream()
                     .filter(issuerResponse -> issuerResponse.getCredential_issuer().equals(issuer))
                     .findFirst();

--- a/src/main/java/io/mosip/mimoto/dto/v2/CredentialDefinitionResponseDto.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/CredentialDefinitionResponseDto.java
@@ -1,0 +1,12 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class CredentialDefinitionResponseDto {
+    private List<String> type;
+    private Map<String, CredentialDisplayResponseDto> credentialSubject;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/CredentialDisplayResponseDto.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/CredentialDisplayResponseDto.java
@@ -1,0 +1,10 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CredentialDisplayResponseDto {
+    private List<CredentialIssuerDisplayResponse> display;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/CredentialIssuerDisplayResponse.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/CredentialIssuerDisplayResponse.java
@@ -1,0 +1,9 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+@Data
+public class CredentialIssuerDisplayResponse {
+    private String name;
+    private String locale;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/CredentialIssuerWellKnownResponse.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/CredentialIssuerWellKnownResponse.java
@@ -1,0 +1,12 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CredentialIssuerWellKnownResponse {
+    private String credential_issuer;
+    private String credential_endpoint;
+    private List<CredentialsSupportedResponse> credentials_supported;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/CredentialSupportedDisplayResponse.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/CredentialSupportedDisplayResponse.java
@@ -1,0 +1,27 @@
+package io.mosip.mimoto.dto.v2;
+
+import com.google.gson.annotations.Expose;
+import io.mosip.mimoto.dto.LogoDTO;
+import lombok.Data;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class CredentialSupportedDisplayResponse {
+    @Expose
+    @NotBlank
+    String name;
+    @Expose
+    @Valid
+    LogoDTO logo;
+    @Expose
+    @NotBlank
+    String locale;
+    @Expose
+    @NotBlank
+    String background_color;
+    @Expose
+    @NotBlank
+    String text_color;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/CredentialsSupportedResponse.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/CredentialsSupportedResponse.java
@@ -1,0 +1,15 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class CredentialsSupportedResponse {
+    private String format;
+    private String id;
+    private String scope;
+    private List<String> proof_types_supported;
+    private CredentialDefinitionResponseDto credential_definition;
+    private List<CredentialSupportedDisplayResponse> display;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/IssuerSupportedCredentialsResponse.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/IssuerSupportedCredentialsResponse.java
@@ -1,0 +1,11 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class IssuerSupportedCredentialsResponse {
+    private String authorization_endpoint;
+    private List<CredentialsSupportedResponse> supportedCredentials;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialDefinition.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialDefinition.java
@@ -1,0 +1,24 @@
+package io.mosip.mimoto.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+public class VCCredentialDefinition {
+
+    @JsonProperty("@context")
+    private List<@NotBlank String> context;
+
+    @NotEmpty
+    private List<@NotBlank String> type;
+
+    private Map<String, Object> credentialSubject;
+
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialIssueBody.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialIssueBody.java
@@ -1,0 +1,13 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+@Data
+public class VCCredentialIssueBody {
+    private VCCredentialProperties credential;
+    private String credentialSchemaId;
+    private String createdAt;
+    private String createdBy;
+    private String updatedAt;
+    private String updatedBy;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialProperties.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialProperties.java
@@ -21,7 +21,7 @@ public class VCCredentialProperties {
     private Map<String, Object> credentialSubject;
 
     @JsonProperty("@context")
-    private List<@NotBlank String> context;
+    private Object context;
 
     @NotEmpty
     private List<@NotBlank String> type;

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialProperties.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialProperties.java
@@ -1,0 +1,28 @@
+package io.mosip.mimoto.dto.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class VCCredentialProperties {
+    private String issuer;
+
+    private String id;
+
+    private String issuanceDate;
+
+    private VCCredentialResponseProof proof;
+
+    private Map<String, Object> credentialSubject;
+
+    @JsonProperty("@context")
+    private List<@NotBlank String> context;
+
+    @NotEmpty
+    private List<@NotBlank String> type;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialRequest.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialRequest.java
@@ -1,0 +1,25 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+
+@Data
+@Builder
+public class VCCredentialRequest {
+
+    @NotBlank
+    private String format;
+
+    @Valid
+    @NotNull
+    private VCCredentialRequestProof proof;
+
+    @Valid
+    @NotNull
+    private VCCredentialDefinition credential_definition;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialRequestProof.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialRequestProof.java
@@ -1,0 +1,19 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@Builder
+public class VCCredentialRequestProof {
+
+
+    @NotBlank
+    private String proof_type;
+
+    private String jwt;
+
+    private String cwt;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialResponse.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialResponse.java
@@ -1,0 +1,18 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+public class VCCredentialResponse {
+
+    @NotBlank
+    private String format;
+
+    @Valid
+    @NotNull
+    private VCCredentialIssueBody credential;
+}

--- a/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialResponseProof.java
+++ b/src/main/java/io/mosip/mimoto/dto/v2/VCCredentialResponseProof.java
@@ -1,0 +1,19 @@
+package io.mosip.mimoto.dto.v2;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class VCCredentialResponseProof {
+    @NotBlank
+    private String type;
+    @NotBlank
+    private String created;
+    @NotBlank
+    private String proofPurpose;
+    @NotBlank
+    private String verificationMethod;
+    @NotBlank
+    private String jws;
+}

--- a/src/main/java/io/mosip/mimoto/service/V2IssuersService.java
+++ b/src/main/java/io/mosip/mimoto/service/V2IssuersService.java
@@ -1,0 +1,17 @@
+package io.mosip.mimoto.service;
+
+import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.dto.v2.IssuerSupportedCredentialsResponse;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+public interface V2IssuersService {
+    IssuersDTO getAllIssuers(String search) throws ApiNotAccessibleException, IOException;
+
+
+    IssuerSupportedCredentialsResponse getCredentialsSupported(String issuerId, String search) throws ApiNotAccessibleException, IOException;
+
+    ByteArrayInputStream generatePdfForVerifiableCredentials(String token, String issuerId, String credentialsSupportedId) throws Exception;
+}

--- a/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
@@ -66,11 +66,11 @@ public class V2IssuersServiceImpl implements V2IssuersService {
     }
 
     public IssuersDTO getIssuersDtoFromJson() throws IOException, ApiNotAccessibleException {
-        String v2IssuersConfigJsonValue = utilities.getV2IssuersConfigJsonValue();
-        if (v2IssuersConfigJsonValue == null) {
+        String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
+        if (issuersConfigJsonValue == null) {
             throw new ApiNotAccessibleException();
         }
-        return new Gson().fromJson(v2IssuersConfigJsonValue, IssuersDTO.class);
+        return new Gson().fromJson(issuersConfigJsonValue, IssuersDTO.class);
     }
 
     @Override

--- a/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
@@ -160,7 +160,7 @@ public class V2IssuersServiceImpl implements V2IssuersService {
                         .build())
                 .credential_definition(VCCredentialDefinition.builder()
                         .type(credentialsSupportedResponse.getCredential_definition().getType())
-                        .context(List.of("https://challabeehyv.github.io/mimoto-config/insurance-context.json"))
+                        .context(List.of("https://www.w3.org/2018/credentials/v1"))
                         .build())
                 .build();
     }

--- a/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
@@ -1,0 +1,208 @@
+package io.mosip.mimoto.service.impl;
+
+import com.google.gson.Gson;
+import io.mosip.mimoto.dto.*;
+import io.mosip.mimoto.dto.v2.*;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.service.IssuersService;
+import io.mosip.mimoto.service.V2IssuersService;
+import io.mosip.mimoto.util.JoseUtil;
+import io.mosip.mimoto.util.RestApiClient;
+import io.mosip.mimoto.util.Utilities;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+import java.io.*;
+import java.security.PublicKey;
+import java.text.ParseException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class V2IssuersServiceImpl implements V2IssuersService {
+
+    @Autowired
+    RestApiClient restApiClient;
+
+    @Autowired
+    private Utilities utilities;
+
+    @Autowired
+    IssuersService issuersService;
+
+    @Autowired
+    SpringTemplateEngine springTemplateEngine;
+
+    @Autowired
+    JoseUtil joseUtil;
+
+    @Value("${mosip.oidc.p12.filename}")
+    private String fileName;
+
+    @Value("${mosip.oidc.p12.password}")
+    private String cyptoPassword;
+
+    @Value("${mosip.oidc.p12.path}")
+    String keyStorePath;
+
+    @Override
+    public IssuersDTO getAllIssuers(String search) throws ApiNotAccessibleException, IOException {
+        IssuersDTO allIssuers = getIssuersDtoFromJson();
+
+        if (!StringUtils.isEmpty(search)) {
+            List<IssuerDTO> filteredIssuers = allIssuers.getIssuers().stream()
+                    .filter(issuer -> issuer.getCredential_issuer().toLowerCase().contains(search.toLowerCase()))
+                    .collect(Collectors.toList());
+            allIssuers.setIssuers(filteredIssuers);
+            return allIssuers;
+        }
+        return allIssuers;
+    }
+
+    public IssuersDTO getIssuersDtoFromJson() throws IOException, ApiNotAccessibleException {
+        String v2IssuersConfigJsonValue = utilities.getV2IssuersConfigJsonValue();
+        if (v2IssuersConfigJsonValue == null) {
+            throw new ApiNotAccessibleException();
+        }
+        return new Gson().fromJson(v2IssuersConfigJsonValue, IssuersDTO.class);
+    }
+
+    @Override
+    public IssuerSupportedCredentialsResponse getCredentialsSupported(String issuerId, String search) throws ApiNotAccessibleException, IOException {
+        IssuerSupportedCredentialsResponse supportedCredentialsWithAuthorizationEndPoint = new IssuerSupportedCredentialsResponse();
+
+        IssuersDTO issuersDto = getIssuersDtoFromJson();
+        Optional<IssuerDTO> issuerConfigResp = issuersDto.getIssuers().stream()
+                .filter(issuer -> issuer.getCredential_issuer().equals(issuerId))
+                .findFirst();
+        if (issuerConfigResp.isPresent()) {
+            IssuerDTO issuerDto = issuerConfigResp.get();
+            CredentialIssuerWellKnownResponse response = restApiClient.getApi(issuerDto.getCredential_issuer(), CredentialIssuerWellKnownResponse.class);
+            if (response == null) {
+                response = getCredentialWllKnownFromJson();
+            }
+            List<CredentialsSupportedResponse> issuerCredentialsSupported = response.getCredentials_supported();
+            supportedCredentialsWithAuthorizationEndPoint.setAuthorization_endpoint(issuerDto.getAuthorization_endpoint());
+            supportedCredentialsWithAuthorizationEndPoint.setSupportedCredentials(issuerCredentialsSupported);
+            if (!StringUtils.isEmpty(search)){
+                supportedCredentialsWithAuthorizationEndPoint.setSupportedCredentials(issuerCredentialsSupported
+                        .stream()
+                        .filter(credentialsSupportedResponse -> credentialsSupportedResponse.getDisplay().get(0).getName().toLowerCase().contains(search.toLowerCase()))
+                        .collect(Collectors.toList()));
+            }
+            return supportedCredentialsWithAuthorizationEndPoint;
+        }
+        return supportedCredentialsWithAuthorizationEndPoint;
+    }
+
+    private CredentialIssuerWellKnownResponse getCredentialWllKnownFromJson() throws IOException, ApiNotAccessibleException {
+        String v2CredentialsSupportedResponseJson = utilities.getV2CredentialsSupportedConfigJsonValue();
+        if (v2CredentialsSupportedResponseJson == null){
+            throw new ApiNotAccessibleException();
+        }
+        return new Gson().fromJson(v2CredentialsSupportedResponseJson, CredentialIssuerWellKnownResponse.class);
+    }
+
+    @Override
+    public ByteArrayInputStream generatePdfForVerifiableCredentials(String accessToken, String issuerId, String credentialsSupportedId) throws Exception {
+        IssuersDTO allIssuers = getIssuersDtoFromJson();
+        Optional<IssuerDTO> issuerConfigResp = allIssuers.getIssuers().stream()
+                .filter(issuer -> issuer.getCredential_issuer().equals(issuerId))
+                .findFirst();
+        if (issuerConfigResp.isPresent()){
+            CredentialIssuerWellKnownResponse credentialIssuerResponse = restApiClient.getApi(issuerConfigResp.get().getWellKnownEndpoint(), CredentialIssuerWellKnownResponse.class); //TODO: check which url to pass
+            if (credentialIssuerResponse == null) {
+                credentialIssuerResponse = getCredentialWllKnownFromJson();
+            }
+            Optional<CredentialsSupportedResponse> credentialsSupportedResponse = credentialIssuerResponse.getCredentials_supported().stream()
+                    .filter(credentialsSupported -> credentialsSupported.getId().equals(credentialsSupportedId))
+                    .findFirst();
+            if (credentialsSupportedResponse.isPresent()) {
+                LinkedHashMap<String, String> vcPropertiesFromWellKnown = new LinkedHashMap<>();
+                Map<String, CredentialDisplayResponseDto> credentialSubject = credentialsSupportedResponse.get().getCredential_definition().getCredentialSubject();
+                credentialSubject.keySet().forEach(VCProperty -> vcPropertiesFromWellKnown.put(VCProperty, credentialSubject.get(VCProperty).getDisplay().get(0).getName()));
+                String backgroundColor = credentialsSupportedResponse.get().getDisplay().get(0).getBackground_color();
+                String textColor = credentialsSupportedResponse.get().getDisplay().get(0).getText_color();
+                VCCredentialRequest vcCredentialRequest = generateVCCredentialRequest(issuerConfigResp.get(), credentialsSupportedResponse.get(), accessToken);
+                VCCredentialResponse vcCredentialResponse = restApiClient.postApi(credentialIssuerResponse.getCredential_endpoint(), MediaType.APPLICATION_JSON,
+                        vcCredentialRequest, VCCredentialResponse.class, accessToken);
+                Map<String, Object> credentialProperties = vcCredentialResponse.getCredential().getCredential().getCredentialSubject();
+                LinkedHashMap<String,Object> displayProperties = new LinkedHashMap<>();
+                vcPropertiesFromWellKnown.keySet().forEach(vcProperty -> displayProperties.put(vcPropertiesFromWellKnown.get(vcProperty), credentialProperties.get(vcProperty)));
+                String credentialSupportedLogoUrl =   credentialsSupportedResponse.get().getDisplay()
+                        .stream()
+                        .map(display -> display.getLogo().getUrl())
+                        .findFirst()
+                        .orElse("");
+                return getPdfResourceFromVcProperties(displayProperties, textColor, backgroundColor,
+                        credentialSupportedLogoUrl, issuerId,
+                        issuerConfigResp.get().getDisplay().stream().map(d -> d.getLogo().getUrl()).findFirst().orElse(""));
+            }
+        }
+        throw new RuntimeException("Invalid Credential Supported id passed");
+    }
+
+    private VCCredentialRequest generateVCCredentialRequest(IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String accessToken) throws ParseException {
+        PublicKey publicKeyString = joseUtil.getPublicKeyString(keyStorePath, fileName, issuerDTO.getClient_alias(), cyptoPassword);
+        String jwt = joseUtil.generateJwt(publicKeyString, keyStorePath, fileName, issuerDTO.getClient_alias(),
+                cyptoPassword, issuerDTO.getCredential_audience(), issuerDTO.getClient_id(), accessToken);
+        return VCCredentialRequest.builder()
+                .format(credentialsSupportedResponse.getFormat())
+                .proof(VCCredentialRequestProof.builder()
+                        .proof_type(credentialsSupportedResponse.getProof_types_supported().get(0))
+                        .jwt(jwt)
+                        .build())
+                .credential_definition(VCCredentialDefinition.builder()
+                        .type(credentialsSupportedResponse.getCredential_definition().getType())
+                        .context(List.of("https://www.w3.org/2018/credentials/v1"))
+                        .build())
+                .build();
+    }
+
+    private ByteArrayInputStream getPdfResourceFromVcProperties(LinkedHashMap<String, Object> displayProperties, String textColor,
+                                                                String backgroundColor, String credentialSupportedLogoUrl,
+                                                                String issuerName, String issuerLogoUrl) {
+        Map<String, Object> data = new HashMap<>();
+        Context context = new Context();
+        LinkedHashMap<String, Object> headerProperties = new LinkedHashMap<>();
+        LinkedHashMap<String, Object> rowProperties = new LinkedHashMap<>();
+
+        displayProperties.entrySet().stream()
+                .forEachOrdered(entry -> {
+                    if (headerProperties.size() < 2) {
+                        headerProperties.put(entry.getKey(), entry.getValue());
+                    } else {
+                        rowProperties.put(entry.getKey(), entry.getValue());
+                    }
+                });
+
+        int rowPropertiesCount =  rowProperties.size();
+        data.put("logoUrl", credentialSupportedLogoUrl);
+        data.put("headerProperties", headerProperties);
+        data.put("rowProperties", rowProperties);
+        data.put("keyFontColor", textColor);
+        data.put("bgColor", backgroundColor);
+        data.put("rowPropertiesMargin", rowPropertiesCount % 2 == 0 ? (rowPropertiesCount/2 -1)*40 : (rowPropertiesCount/2)*40); //for adjusting the height in pdf for dynamic properties
+        data.put("titleLogo", issuerLogoUrl);
+        data.put("titleName", issuerName);
+
+        context.setVariables(data);
+        String html = springTemplateEngine.process("CredentialTemplate", context);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ITextRenderer renderer = new ITextRenderer();
+        renderer.setDocumentFromString(html);
+        renderer.layout();
+        renderer.createPDF(outputStream);
+        return new ByteArrayInputStream(outputStream.toByteArray());
+    }
+}
+
+
+

--- a/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/V2IssuersServiceImpl.java
@@ -85,7 +85,7 @@ public class V2IssuersServiceImpl implements V2IssuersService {
             IssuerDTO issuerDto = issuerConfigResp.get();
             CredentialIssuerWellKnownResponse response = restApiClient.getApi(issuerDto.getCredential_issuer(), CredentialIssuerWellKnownResponse.class);
             if (response == null) {
-                response = getCredentialWllKnownFromJson();
+                response = getCredentialWellKnownFromJson();
             }
             List<CredentialsSupportedResponse> issuerCredentialsSupported = response.getCredentials_supported();
             supportedCredentialsWithAuthorizationEndPoint.setAuthorization_endpoint(issuerDto.getAuthorization_endpoint());
@@ -101,7 +101,7 @@ public class V2IssuersServiceImpl implements V2IssuersService {
         return supportedCredentialsWithAuthorizationEndPoint;
     }
 
-    private CredentialIssuerWellKnownResponse getCredentialWllKnownFromJson() throws IOException, ApiNotAccessibleException {
+    private CredentialIssuerWellKnownResponse getCredentialWellKnownFromJson() throws IOException, ApiNotAccessibleException {
         String v2CredentialsSupportedResponseJson = utilities.getV2CredentialsSupportedConfigJsonValue();
         if (v2CredentialsSupportedResponseJson == null){
             throw new ApiNotAccessibleException();
@@ -118,7 +118,7 @@ public class V2IssuersServiceImpl implements V2IssuersService {
         if (issuerConfigResp.isPresent()){
             CredentialIssuerWellKnownResponse credentialIssuerResponse = restApiClient.getApi(issuerConfigResp.get().getWellKnownEndpoint(), CredentialIssuerWellKnownResponse.class); //TODO: check which url to pass
             if (credentialIssuerResponse == null) {
-                credentialIssuerResponse = getCredentialWllKnownFromJson();
+                credentialIssuerResponse = getCredentialWellKnownFromJson();
             }
             Optional<CredentialsSupportedResponse> credentialsSupportedResponse = credentialIssuerResponse.getCredentials_supported().stream()
                     .filter(credentialsSupported -> credentialsSupported.getId().equals(credentialsSupportedId))
@@ -160,7 +160,7 @@ public class V2IssuersServiceImpl implements V2IssuersService {
                         .build())
                 .credential_definition(VCCredentialDefinition.builder()
                         .type(credentialsSupportedResponse.getCredential_definition().getType())
-                        .context(List.of("https://www.w3.org/2018/credentials/v1"))
+                        .context(List.of("https://challabeehyv.github.io/mimoto-config/insurance-context.json"))
                         .build())
                 .build();
     }

--- a/src/main/java/io/mosip/mimoto/util/JoseUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/JoseUtil.java
@@ -2,12 +2,16 @@ package io.mosip.mimoto.util;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.RSAKeyProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.util.X509CertUtils;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.SignedJWT;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.mosip.kernel.core.logger.spi.Logger;
 import io.mosip.kernel.core.util.CryptoUtil;
 import io.mosip.mimoto.core.http.ResponseWrapper;
@@ -16,7 +20,6 @@ import io.mosip.mimoto.dto.mimoto.WalletBindingInternalResponseDto;
 import io.mosip.mimoto.dto.mimoto.WalletBindingResponseDto;
 import org.jose4j.jws.JsonWebSignature;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -28,6 +31,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.text.ParseException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
@@ -153,5 +157,64 @@ public class JoseUtil {
                 .withExpiresAt(expiresAt)
                 .withIssuedAt(issuedAt)
                 .sign(Algorithm.RSA256(null, privateKey));
+    }
+
+    public PublicKey getPublicKeyString(String keyStorePath, String fileName, String alias, String cyptoPassword){
+        String keyStorePathWithFileName = keyStorePath + fileName;
+        try {
+            KeyStore.PrivateKeyEntry privateKeyEntry = cryptoCoreUtil.loadP12(keyStorePathWithFileName, alias, cyptoPassword);
+            PublicKey publicKey = privateKeyEntry.getCertificate().getPublicKey();
+            return publicKey;
+        } catch (IOException e) {
+            logger.error("Exception happened while loading the p12 file for invoking token call.");
+        }
+        return null;
+    }
+
+    public String generateJwt(PublicKey publicJwk, String keyStorePath, String fileName, String alias, String cyptoPassword, String audience, String clientId, String accessToken) throws ParseException {
+        RSAKey jwk = new RSAKey.Builder((java.security.interfaces.RSAPublicKey) publicJwk)
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(JWSAlgorithm.RS256)
+                .build();
+
+        Map<String, Object> header = new HashMap<>();
+
+        header.put("alg", ALG_RS256);
+        header.put("typ", "openid4vci-proof+jwt");
+        header.put("jwk", jwk.getRequiredParams());
+
+
+        String keyStorePathWithFileName = keyStorePath + fileName;
+        Date issuedAt = Date.from(Instant.now());
+        Date expiresAt = Date.from(Instant.now().plusMillis(120000000));
+        RSAPrivateKey privateKey = null;
+        try {
+            KeyStore.PrivateKeyEntry privateKeyEntry = cryptoCoreUtil.loadP12(keyStorePathWithFileName, alias, cyptoPassword);
+            privateKey = (RSAPrivateKey) privateKeyEntry.getPrivateKey();
+        } catch (IOException e) {
+            logger.error("Exception happened while loading the p12 file for invoking token call.");
+        }
+        SignedJWT jwt = (SignedJWT) JWTParser.parse(accessToken);
+        Map<String, Object> jsonObject = jwt.getPayload().toJSONObject();
+        String cNounce = (String) jsonObject.get("c_nonce");
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("sub", clientId);
+        payload.put("aud", audience);
+        payload.put("nonce", cNounce);
+        payload.put("iss", clientId);
+        payload.put("exp", expiresAt.toInstant().getEpochSecond());
+        payload.put("iat", issuedAt.toInstant().getEpochSecond());
+
+        return Jwts.builder()
+                .setHeader(header)
+                .setIssuer(clientId)
+                .setSubject(clientId)
+                .setAudience(audience)
+                .setExpiration(expiresAt)
+                .setIssuedAt(issuedAt)
+                .setClaims(payload)
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
     }
 }

--- a/src/main/java/io/mosip/mimoto/util/JoseUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/JoseUtil.java
@@ -170,7 +170,7 @@ public class JoseUtil {
         }
         return null;
     }
-
+    //Added this Util for generating JWT as the existing Jwt builder will not allow to have a custom header "typ"
     public String generateJwt(PublicKey publicJwk, String keyStorePath, String fileName, String alias, String cyptoPassword, String audience, String clientId, String accessToken) throws ParseException {
         RSAKey jwk = new RSAKey.Builder((java.security.interfaces.RSAPublicKey) publicJwk)
                 .keyUse(KeyUse.SIGNATURE)

--- a/src/main/java/io/mosip/mimoto/util/RestApiClient.java
+++ b/src/main/java/io/mosip/mimoto/util/RestApiClient.java
@@ -163,6 +163,41 @@ public class RestApiClient {
         return result;
     }
 
+    public <T> T postApi(String uri, MediaType mediaType, Object requestType, Class<?> responseClass, String bearerToken){
+        T result = null;
+        try {
+            result = (T) plainRestTemplate.postForObject(uri, setRequestHeader(requestType, mediaType, bearerToken), responseClass);
+        } catch (Exception e) {
+            logger.error("RestApiClient::postApi()::error uri: {} {} {}", uri, e.getMessage(), e);
+        }
+        return result;
+    }
+
+    private HttpEntity<Object> setRequestHeader(Object requestType, MediaType mediaType, String bearerToken){
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<String, String>();
+        if (mediaType != null) {
+            headers.add(CONTENT_TYPE, mediaType.toString());
+        }
+        headers.add("Authorization", "Bearer "+bearerToken);
+        if (requestType != null) {
+            try {
+                HttpEntity<Object> httpEntity = (HttpEntity<Object>) requestType;
+                HttpHeaders httpHeader = httpEntity.getHeaders();
+                Iterator<String> iterator = httpHeader.keySet().iterator();
+                while (iterator.hasNext()) {
+                    String key = iterator.next();
+                    if (!(headers.containsKey(CONTENT_TYPE) && key.equals(CONTENT_TYPE)))
+                        headers.add(key, Objects.requireNonNull(httpHeader.get(key)).get(0));
+                }
+
+                return new HttpEntity<Object>(httpEntity.getBody(), headers);
+            } catch (ClassCastException | NullPointerException e) {
+                return new HttpEntity<Object>(requestType, headers);
+            }
+        } else
+            return new HttpEntity<Object>(headers);
+    }
+
     private HttpEntity<Object> setRequestHeader(Object requestType, MediaType mediaType) throws IOException {
         return setRequestHeader(requestType, mediaType, false);
     }

--- a/src/main/java/io/mosip/mimoto/util/Utilities.java
+++ b/src/main/java/io/mosip/mimoto/util/Utilities.java
@@ -103,6 +103,12 @@ public class Utilities {
     @Value("${mosip.openid.issuers}")
     private String getIssuersConfigJson;
 
+    @Value("${mosip.openid.v2.issuers}")
+    private String getV2IssuersConfigJson;
+
+    @Value("$mosip.openid.v2.issuer.credentialSupported}")
+    private String getIssuerCredentialSupportedJson;
+
     private String mappingJsonString = null;
 
     private String identityMappingJsonString = null;
@@ -111,10 +117,22 @@ public class Utilities {
 
     private String issuersConfigJsonString = null;
 
+    private String v2IssuersConfigJsonString = null;
+
+    private String v2CredentialsSupportedJsonString = null;
+
 //    uncomment for running mimoto Locally to populate the issuers json
 //    public Utilities(@Value("classpath:mimoto-issuers-config.json") Resource resource) throws IOException {
 //        issuersConfigJsonString = (Files.readString(resource.getFile().toPath()));
 //    }
+    public Utilities(@Value("classpath:v2-issuers-config.json") Resource v2Resource,
+                     @Value("classpath:/wellKnownIssuer/Insurance.json") Resource v2CredentialsSupportedResource,
+                     @Value("classpath:mimoto-issuers-config.json") Resource resource) throws IOException{
+                issuersConfigJsonString = (Files.readString(resource.getFile().toPath()));
+
+        v2IssuersConfigJsonString = (Files.readString(v2Resource.getFile().toPath()));
+        v2CredentialsSupportedJsonString = (Files.readString(v2CredentialsSupportedResource.getFile().toPath()));
+    }
 
     public JSONObject getTemplate() throws JsonParseException, JsonMappingException, IOException {
         return objectMapper.readValue(classLoader.getResourceAsStream(defaultTemplate), JSONObject.class);
@@ -282,6 +300,16 @@ public class Utilities {
     public String getIssuersConfigJsonValue() throws IOException {
         return  (issuersConfigJsonString != null && !issuersConfigJsonString.isEmpty()) ?
                 issuersConfigJsonString : getJson(configServerFileStorageURL, getIssuersConfigJson);
+    }
+
+    public String getV2IssuersConfigJsonValue() throws IOException{
+        return (v2IssuersConfigJsonString != null && !v2IssuersConfigJsonString.isEmpty()) ?
+                v2IssuersConfigJsonString : getJson(configServerFileStorageURL, getV2IssuersConfigJson);
+    }
+
+    public String getV2CredentialsSupportedConfigJsonValue() throws IOException{
+        return (v2CredentialsSupportedJsonString != null && !v2CredentialsSupportedJsonString.isEmpty()) ?
+                v2CredentialsSupportedJsonString : getJson(configServerFileStorageURL, getIssuerCredentialSupportedJson);
     }
 
 

--- a/src/main/java/io/mosip/mimoto/util/Utilities.java
+++ b/src/main/java/io/mosip/mimoto/util/Utilities.java
@@ -117,20 +117,16 @@ public class Utilities {
 
     private String issuersConfigJsonString = null;
 
-    private String v2IssuersConfigJsonString = null;
-
     private String v2CredentialsSupportedJsonString = null;
 
 //    uncomment for running mimoto Locally to populate the issuers json
 //    public Utilities(@Value("classpath:mimoto-issuers-config.json") Resource resource) throws IOException {
 //        issuersConfigJsonString = (Files.readString(resource.getFile().toPath()));
 //    }
-    public Utilities(@Value("classpath:v2-issuers-config.json") Resource v2Resource,
-                     @Value("classpath:/wellKnownIssuer/Insurance.json") Resource v2CredentialsSupportedResource,
-                     @Value("classpath:mimoto-issuers-config.json") Resource resource) throws IOException{
-                issuersConfigJsonString = (Files.readString(resource.getFile().toPath()));
+    public Utilities(@Value("classpath:/wellKnownIssuer/Insurance.json") Resource v2CredentialsSupportedResource,
+                     @Value("classpath:v2-issuers-config.json") Resource resource) throws IOException{
 
-        v2IssuersConfigJsonString = (Files.readString(v2Resource.getFile().toPath()));
+        issuersConfigJsonString = (Files.readString(resource.getFile().toPath()));
         v2CredentialsSupportedJsonString = (Files.readString(v2CredentialsSupportedResource.getFile().toPath()));
     }
 
@@ -300,11 +296,6 @@ public class Utilities {
     public String getIssuersConfigJsonValue() throws IOException {
         return  (issuersConfigJsonString != null && !issuersConfigJsonString.isEmpty()) ?
                 issuersConfigJsonString : getJson(configServerFileStorageURL, getIssuersConfigJson);
-    }
-
-    public String getV2IssuersConfigJsonValue() throws IOException{
-        return (v2IssuersConfigJsonString != null && !v2IssuersConfigJsonString.isEmpty()) ?
-                v2IssuersConfigJsonString : getJson(configServerFileStorageURL, getV2IssuersConfigJson);
     }
 
     public String getV2CredentialsSupportedConfigJsonValue() throws IOException{

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,7 +1,7 @@
 
 # MOSIP
 mosipbox.public.url=https://api-internal.dev2.mosip.net
-public.internet.url=https://api.dev2.mosip.net
+public.internet.url=http://localhost:8088
 public.url=https://api-internal.dev2.mosip.net
 keycloak.internal.url=https://iam.dev2.mosip.net/
 
@@ -200,11 +200,46 @@ wallet.binding.partner.api.key=Aci9jg28B8mO_LDfDXo3ZTp5_HKgEMun2tYyHCa1e8k
 
 # OpenID
 mosip.openid.issuers=mimoto-issuers-config.json
-#configurations related to openid4vc
+mosip.openid.v2.issuers=v2-issuers-config.json
+mosip.openid.v2.issuer.credentialSupported=/wellKnownIssuer/Insurance.json
+mosip.oidc.esignet.token.endpoint=http://localhost:8088/v1/esignet/oauth/v2/token
+mosip.oidc.esignet.aud=http://localhost:8088/v1/esignet/oauth/v2/token
+mosip.oidc.client.id=DhOcUzRwfHJcOLvfOEXPApqWbz
 mosip.oidc.client.assertion.type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
 mosip.oidc.p12.filename=oidckeystore.p12
 mosip.oidc.p12.password=5YBx6QT2wbY8Ls6w
 mosip.oidc.p12.path=certs/
+mosip.oidc.p12.alias=mpartner-default-mimotooidc
+
+mosip.esignet.host=http://localhost:8088
+
+# Inji properties
+mosip.inji.allowedAuthType=demo,otp,bio-Finger,bio-Iris,bio-Face
+mosip.inji.allowedEkycAuthType=demo,otp,bio-Finger,bio-Iris,bio-Face
+mosip.inji.allowedInternalAuthType=otp,bio-Finger,bio-Iris,bio-Face
+mosip.inji.faceSdkModelUrl=null
+# model download maximum retry
+mosip.inji.modelDownloadMaxRetry=10
+# maximum number of retry for downloading vc
+mosip.inji.vcDownloadMaxRetry=10
+# pool interval in milli seconds
+mosip.inji.vcDownloadPoolInterval=6000
+# validate binding audience url to be sent in token
+mosip.inji.audience=ida-binding
+# issuer to be sent in token
+mosip.inji.issuer=residentapp
+# warning screen domain name -- mimoto host
+mosip.inji.warningDomainName=http://localhost:8088/
+# inji documentation url
+mosip.inji.aboutInjiUrl=https://docs.mosip.io/inji
+# minimum storage space required for making audit entry in MB
+mosip.inji.minStorageRequiredForAuditEntry=2
+# minimum storage space required for downloading / receiving vc in MB
+mosip.inji.minStorageRequired=5
+#timeout for vc download api via openid4vci flow in milliseconds
+mosip.inji.openId4VCIDownloadVCTimeout=30000
+
+mosip.security.origins=*
 
 
 

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -160,7 +160,8 @@ CREATEDATASHARE=${mosipbox.public.url}/v1/datashare/create
 DECRYPTPINBASSED=${mosipbox.public.url}/v1/keymanager/decryptWithPin
 
 # config.server.file.storage.uri=${spring.cloud.config.uri}/${spring.application.name}/${spring.profiles.active}/${spring.cloud.config.label}/
-config.server.file.storage.uri=${mosipbox.public.url}/config/print/mz/develop2-v3/
+#config.server.file.storage.uri=${mosipbox.public.url}/config/print/mz/develop2-v3/
+config.server.file.storage.uri=https://challabeehyv.github.io/mimoto-config/
 
 # websub authentication - auth adapter
 mosip.iam.adapter.clientid=mpartner-default-mobile
@@ -199,10 +200,9 @@ wallet.binding.partner.api.key=Aci9jg28B8mO_LDfDXo3ZTp5_HKgEMun2tYyHCa1e8k
 #wallet.binding.partner.api.key=14378
 
 # OpenID
-mosip.openid.issuers=mimoto-issuers-config.json
+mosip.openid.issuers=v2-issuers-config.json
 mosip.openid.v2.issuers=v2-issuers-config.json
 mosip.openid.v2.issuer.credentialSupported=/wellKnownIssuer/Insurance.json
-mosip.oidc.esignet.token.endpoint=http://localhost:8088/v1/esignet/oauth/v2/token
 mosip.oidc.esignet.aud=http://localhost:8088/v1/esignet/oauth/v2/token
 mosip.oidc.client.id=DhOcUzRwfHJcOLvfOEXPApqWbz
 mosip.oidc.client.assertion.type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -7,8 +7,8 @@ spring.application.name=mimoto
 management.endpoint.health.show-details=always
 management.endpoints.web.exposure.include=info,health,refresh
 
-server.port=8088
-server.servlet.context-path=/v1/mimoto
+server.port=8089
+server.servlet.context-path=/residentmobileapp
 health.config.enabled=false
 
 openapi.info.title=${spring.application.name}

--- a/src/main/resources/templates/CredentialTemplate.html
+++ b/src/main/resources/templates/CredentialTemplate.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Identity Card</title>
+</head>
+
+<body th:style="${keyFontColor != null} ? 'color: ' + ${keyFontColor} : ''">
+<div th:style="${bgColor != null} ? 'background: ' + ${bgColor} + '; border: 2px black solid; border-radius: 15px; padding: 10px;' : 'border: 2px black solid; border-radius: 15px; padding: 10px;'">
+    <div style="text-align: center; padding-top: 10px;font-weight:bold">
+        <img style="width: 20px; margin-right: 10px; vertical-align: middle;" th:src="${titleLogo}" alt="Logo" />
+        <span style="font-size: 16px; vertical-align: middle;" th:text="${titleName}"></span>
+    </div>
+<!--    <div style="padding-top:10px">-->
+<!--        <div style="text-align: center; margin-bottom: 20px;font-size:16px" th:text="${titleName}"></div>-->
+<!--    </div>-->
+    <div style="margin:20px;">
+        <img style="width: 100px; float: left; margin-right: 100px;" src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRe3oPvKsA05otgZYGFZmxk5WHLYTFKWOFaNA" alt="Logo" />
+
+        <!-- Upper properties on the right -->
+        <div style="overflow: auto;">
+            <div th:each="entry : ${headerProperties}" style="margin-bottom: 10px;">
+                <div style="font-size: 16px; margin-bottom: 5px;" th:text="${entry.key}"></div>
+                <div style="font-weight: bold; font-size: 16px; margin-left: 10px;" th:text="${entry.value}"></div>
+            </div>
+        </div>
+    </div>
+    <div style="margin-left:20px">
+        <div th:each="entry : ${rowProperties}" style="margin-bottom: 10px;float:left;width:250px">
+            <div style="font-size: 16px; margin-bottom: 5px;" th:text="${entry.key}"></div>
+            <div style="font-weight: bold; font-size: 16px;" th:text="${entry.value}"></div>
+        </div>
+    </div>
+<!--    <div style="text-align: right; margin-top:70px">-->
+    <div th:style="'text-align: right; margin-top:' + ${rowPropertiesMargin} + 'px'">
+        <img style="width: 100px;" th:src="${logoUrl}" alt="Logo" />
+    </div>
+</div>
+</body>
+
+
+</html>

--- a/src/main/resources/v2-issuers-config.json
+++ b/src/main/resources/v2-issuers-config.json
@@ -1,0 +1,41 @@
+{
+  "issuers": [
+    {
+      "credential_issuer": "Insurance Department",
+      "display": [
+        {
+          "name": "Insurance Department",
+          "logo": {
+            "url": "https://imgs.search.brave.com/m_qtRC1Tukm-fxidbwkAdnWgoEjPktSyG-juAd6e8NM/rs:fit:860:0:0/g:ce/aHR0cHM6Ly9icmFu/ZGVwcy5jb20vbG9n/by1kb3dubG9hZC9M/L0xJQy1sb2dvLXZl/Y3Rvci0wMS5zdmc.svg",
+            "alt_text": "Lic-Logo"
+          },
+          "title": "Download via LIC",
+          "description": "Enter your policy number to download your card.",
+          "language": "en"
+        }
+      ],
+      "protocol": "OpenId4VCI",
+      "client_id": "aPeBSsrNISNrhEjQeJhikwvfMABC",
+      "client_alias": "mpartner-default-mimotooidc",
+      "scopes_supported": [
+        "sunbird_rc_insurance_vc_ldp"
+      ],
+      "additional_headers": {
+        "Accept": "application/json"
+      },
+      ".well-known": "http://localhost:8088/v1/esignet/.well-known",
+      "redirect_uri": "http://localhost:3001",
+      "authorization_endpoint": "http://localhost:3001/authorize",
+      "authorization_audience": "http://localhost:8088/v1/esignet/oauth/token",
+      "proxy_token_endpoint": "http://localhost:8088/v1/esignet/oauth/v2/token",
+      "token_endpoint": "http://localhost:8088/v1/esignet/oauth/v2/token",
+      "credential_endpoint": "http://localhost:8088/v1/esignet/vci/credential",
+      "credential_type": [
+        "VerifiableCredential",
+        "HealthInsuranceCredential",
+        "LifeInsuranceCredential"
+      ],
+      "credential_audience": "http://localhost:8088/v1/esignet"
+    }
+  ]
+}

--- a/src/main/resources/v2-issuers-config.json
+++ b/src/main/resources/v2-issuers-config.json
@@ -28,7 +28,7 @@
       "authorization_endpoint": "http://localhost:3001/authorize",
       "authorization_audience": "http://localhost:8088/v1/esignet/oauth/token",
       "proxy_token_endpoint": "http://localhost:8088/v1/esignet/oauth/v2/token",
-      "token_endpoint": "http://localhost:8088/v1/esignet/oauth/v2/token",
+      "token_endpoint": "https://${mosip.api.public.host}/residentmobileapp/get-token/Insurance Department",
       "credential_endpoint": "http://localhost:8088/v1/esignet/vci/credential",
       "credential_type": [
         "VerifiableCredential",

--- a/src/main/resources/wellKnownIssuer/Insurance.json
+++ b/src/main/resources/wellKnownIssuer/Insurance.json
@@ -4,8 +4,8 @@
   "credentials_supported": [
     {
       "format": "ldp_vc",
-      "id": "HealthInsuranceCredential_ldp",
-      "scope": "health_insurance_identity_vc_ldp",
+      "id": "InsuranceCredential",
+      "scope": "sunbird_rc_insurance_vc_ldp",
       "cryptographic_binding_methods_supported": [
         "did:jwk"
       ],
@@ -73,7 +73,7 @@
       },
       "display": [
         {
-          "name": "Health Insurance Credentials",
+          "name": "Insurance Credential",
           "locale": "en",
           "logo": {
             "url": "https://image.similarpng.com/very-thumbnail/2021/06/Medical-health-care-logo-design-template-on-transparent-background-PNG.png",

--- a/src/main/resources/wellKnownIssuer/Insurance.json
+++ b/src/main/resources/wellKnownIssuer/Insurance.json
@@ -18,7 +18,7 @@
       "credential_definition": {
         "type": [
           "VerifiableCredential",
-          "HealthInsuranceCredential"
+          "InsuranceCredential"
         ],
         "credentialSubject": {
           "policyNumber": {
@@ -77,7 +77,7 @@
           "locale": "en",
           "logo": {
             "url": "https://image.similarpng.com/very-thumbnail/2021/06/Medical-health-care-logo-design-template-on-transparent-background-PNG.png",
-            "alt_text": "health insurance logo"
+            "alt_text": "insurance logo"
           },
           "background_color": "#76b5c5",
           "text_color": "#716E6D"
@@ -87,7 +87,7 @@
     {
       "format": "ldp_vc",
       "id": "LifeInsuranceCredential_ldp",
-      "scope": "life_insurance_identity_vc_ldp",
+      "scope": "life_insurance_vc_ldp",
       "cryptographic_binding_methods_supported": [
         "did:jwk"
       ],

--- a/src/main/resources/wellKnownIssuer/Insurance.json
+++ b/src/main/resources/wellKnownIssuer/Insurance.json
@@ -1,0 +1,170 @@
+{
+  "credential_issuer": "Insurance Department",
+  "credential_endpoint": "http://localhost:8088/v1/esignet/vci/credential",
+  "credentials_supported": [
+    {
+      "format": "ldp_vc",
+      "id": "HealthInsuranceCredential_ldp",
+      "scope": "health_insurance_identity_vc_ldp",
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "cryptographic_suites_supported": [
+        "RsaSignature2018"
+      ],
+      "proof_types_supported": [
+        "jwt"
+      ],
+      "credential_definition": {
+        "type": [
+          "VerifiableCredential",
+          "HealthInsuranceCredential"
+        ],
+        "credentialSubject": {
+          "policyNumber": {
+            "display": [
+              {
+                "name": "Policy Number",
+                "locale": "en"
+              }
+            ]
+          },
+          "fullName": {
+            "display": [
+              {
+                "name": "Full Name",
+                "locale": "en"
+              }
+            ]
+          },
+          "policyName": {
+            "display": [
+              {
+                "name": "Policy Name",
+                "locale": "en"
+              }
+            ]
+          },
+          "dob": {
+            "display": [
+              {
+                "name": "Date Of Birth",
+                "locale": "en"
+              }
+            ]
+          },
+          "gender": {
+            "display": [
+              {
+                "name": "Gender",
+                "locale": "en"
+              }
+            ]
+          },
+          "expiresOn": {
+            "display": [
+              {
+                "name": "Expiry Date",
+                "locale": "en"
+              }
+            ]
+          }
+        }
+      },
+      "display": [
+        {
+          "name": "Health Insurance Credentials",
+          "locale": "en",
+          "logo": {
+            "url": "https://image.similarpng.com/very-thumbnail/2021/06/Medical-health-care-logo-design-template-on-transparent-background-PNG.png",
+            "alt_text": "health insurance logo"
+          },
+          "background_color": "#76b5c5",
+          "text_color": "#716E6D"
+        }
+      ]
+    },
+    {
+      "format": "ldp_vc",
+      "id": "LifeInsuranceCredential_ldp",
+      "scope": "life_insurance_identity_vc_ldp",
+      "cryptographic_binding_methods_supported": [
+        "did:jwk"
+      ],
+      "cryptographic_suites_supported": [
+        "RsaSignature2018"
+      ],
+      "proof_types_supported": [
+        "jwt"
+      ],
+      "credential_definition": {
+        "type": [
+          "VerifiableCredential",
+          "LifeInsuranceCredential"
+        ],
+        "credentialSubject": {
+          "policyNumber": {
+            "display": [
+              {
+                "name": "Policy Number",
+                "locale": "en"
+              }
+            ]
+          },
+          "fullName": {
+            "display": [
+              {
+                "name": "Full Name",
+                "locale": "en"
+              }
+            ]
+          },
+          "policyName": {
+            "display": [
+              {
+                "name": "Policy Name",
+                "locale": "en"
+              }
+            ]
+          },
+          "dob": {
+            "display": [
+              {
+                "name": "Date Of Birth",
+                "locale": "en"
+              }
+            ]
+          },
+          "gender": {
+            "display": [
+              {
+                "name": "Gender",
+                "locale": "en"
+              }
+            ]
+          },
+          "expiresOn": {
+            "display": [
+              {
+                "name": "Expiry Date",
+                "locale": "en"
+              }
+            ]
+          }
+        }
+      },
+      "display": [
+        {
+          "name": "Life Insurance Credentials",
+          "locale": "en",
+          "logo": {
+            "url": "https://image.similarpng.com/very-thumbnail/2021/06/Family-care-logo-template-on-transparent-background-PNG.png",
+            "alt_text": "life insurance logo"
+          },
+          "background_color": "#B34622",
+          "text_color": "#FFFFFF"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/java/io/mosip/mimoto/service/V2IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/V2IssuersServiceTest.java
@@ -1,0 +1,168 @@
+package io.mosip.mimoto.service;
+
+import com.google.gson.Gson;
+import io.mosip.mimoto.dto.DisplayDTO;
+import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.dto.LogoDTO;
+import io.mosip.mimoto.dto.v2.*;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.service.impl.V2IssuersServiceImpl;
+import io.mosip.mimoto.util.RestApiClient;
+import io.mosip.mimoto.util.Utilities;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+@SpringBootTest
+public class V2IssuersServiceTest {
+
+    @InjectMocks
+    V2IssuersServiceImpl v2IssuersService = new V2IssuersServiceImpl();
+
+    @Mock
+    Utilities utilities;
+
+    @Mock
+    public RestApiClient restApiClient;
+
+    static IssuerDTO getIssuerDTO(String issuerName) {
+        LogoDTO logo = new LogoDTO();
+        logo.setUrl("/logo");
+        logo.setAlt_text("logo-url");
+        DisplayDTO display = new DisplayDTO();
+        display.setName(issuerName);
+        display.setLanguage("en");
+        display.setLogo(logo);
+        IssuerDTO issuer = new IssuerDTO();
+        issuer.setCredential_issuer(issuerName + "id");
+        issuer.setDisplay(Collections.singletonList(display));
+        issuer.setClient_id("123");
+        issuer.setWellKnownEndpoint("/.well-known");
+        return issuer;
+    }
+
+    static CredentialsSupportedResponse getCredentialSupportedResponse(String credentialSupportedName){
+        LogoDTO logo = new LogoDTO();
+        logo.setUrl("/logo");
+        logo.setAlt_text("logo-url");
+        CredentialSupportedDisplayResponse credentialSupportedDisplay = new CredentialSupportedDisplayResponse();
+        credentialSupportedDisplay.setLogo(logo);
+        credentialSupportedDisplay.setName(credentialSupportedName);
+        credentialSupportedDisplay.setLocale("en");
+        credentialSupportedDisplay.setText_color("#FFFFFF");
+        credentialSupportedDisplay.setBackground_color("#B34622");
+        CredentialIssuerDisplayResponse credentialIssuerDisplayResponse = new CredentialIssuerDisplayResponse();
+        credentialIssuerDisplayResponse.setName("Given Name");
+        credentialIssuerDisplayResponse.setLocale("en");
+        CredentialDisplayResponseDto credentialDisplayResponseDto = new CredentialDisplayResponseDto();
+        credentialDisplayResponseDto.setDisplay(Collections.singletonList(credentialIssuerDisplayResponse));
+        CredentialDefinitionResponseDto credentialDefinitionResponseDto = new CredentialDefinitionResponseDto();
+        credentialDefinitionResponseDto.setType(List.of("VerifiableCredential", credentialSupportedName));
+        credentialDefinitionResponseDto.setCredentialSubject(Map.of("name", credentialDisplayResponseDto));
+        CredentialsSupportedResponse credentialsSupportedResponse = new CredentialsSupportedResponse();
+        credentialsSupportedResponse.setFormat("ldp_vc");
+        credentialsSupportedResponse.setId(credentialSupportedName+"id");
+        credentialsSupportedResponse.setScope(credentialSupportedName+"_vc_ldp");
+        credentialsSupportedResponse.setDisplay(Collections.singletonList(credentialSupportedDisplay));
+        credentialsSupportedResponse.setProof_types_supported(Collections.singletonList("jwt"));
+        credentialsSupportedResponse.setCredential_definition(credentialDefinitionResponseDto);
+        return credentialsSupportedResponse;
+    }
+
+    static CredentialIssuerWellKnownResponse getCredentialIssuerWellKnownResponseDto(String issuerName, List<CredentialsSupportedResponse> credentialsSupportedResponses){
+        CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = new CredentialIssuerWellKnownResponse();
+        credentialIssuerWellKnownResponse.setCredential_issuer(issuerName);
+        credentialIssuerWellKnownResponse.setCredential_endpoint("/credential_endpoint");
+        credentialIssuerWellKnownResponse.setCredentials_supported(credentialsSupportedResponses);
+        return credentialIssuerWellKnownResponse;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        IssuersDTO issuers = new IssuersDTO();
+        issuers.setIssuers(List.of(getIssuerDTO("Issuer1")));
+        CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = getCredentialIssuerWellKnownResponseDto("Issuer1",
+                List.of(getCredentialSupportedResponse("CredentialSupported1"), getCredentialSupportedResponse("CredentialSupported2")));
+        Mockito.when(utilities.getV2CredentialsSupportedConfigJsonValue()).thenReturn(new Gson().toJson(credentialIssuerWellKnownResponse));
+        Mockito.when(utilities.getV2IssuersConfigJsonValue()).thenReturn(new Gson().toJson(issuers));
+    }
+
+    @Test(expected = ApiNotAccessibleException.class)
+    public void shouldThrowApiNotAccessibleExceptionWhenIssuersDtoIsNullForGettingIssuersLIst() throws IOException, ApiNotAccessibleException {
+        Mockito.when(utilities.getV2IssuersConfigJsonValue()).thenReturn(null);
+        v2IssuersService.getAllIssuers(null);
+    }
+
+    @Test
+    public void shouldReturnIssuersWithIssuerConfig() throws ApiNotAccessibleException, IOException {
+        IssuersDTO expectedIssuers = new IssuersDTO();
+        List<IssuerDTO> issuers = new ArrayList<>(List.of(getIssuerDTO("Issuer1")));
+        expectedIssuers.setIssuers(issuers);
+
+        IssuersDTO allIssuers = v2IssuersService.getAllIssuers(null);
+
+        assertEquals(expectedIssuers, allIssuers);
+    }
+
+    @Test
+    public void shouldReturnNullIfTheIssuerIdNotExistsForIssuerList() throws ApiNotAccessibleException, IOException {
+        IssuersDTO issuers = v2IssuersService.getAllIssuers("Issuer2");
+        assertTrue(issuers.getIssuers().isEmpty());
+    }
+
+
+    @Test(expected = ApiNotAccessibleException.class)
+    public void shouldThrowApiNotAccessibleExceptionWhenCredentialsSupportedJsonStringIsNullForGettingCredentialsSupportedList() throws Exception {
+        Mockito.when(utilities.getV2CredentialsSupportedConfigJsonValue()).thenReturn(null);
+        Mockito.when(restApiClient.getApi(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn(null);
+        v2IssuersService.getCredentialsSupported("Issuer1id", null);
+    }
+
+    @Test
+    public void shouldReturnIssuerCredentialSupportedResponseForTheIssuerIdIfExist() throws Exception {
+        IssuerSupportedCredentialsResponse expectedIssuerCredentialsSupported = new IssuerSupportedCredentialsResponse();
+       List<CredentialsSupportedResponse> credentialsSupportedResponses =List.of(getCredentialSupportedResponse("CredentialSupported1"),
+               getCredentialSupportedResponse("CredentialSupported2"));
+
+       String authorization_endpoint = getIssuerDTO("Issuer1").getAuthorization_endpoint();
+       expectedIssuerCredentialsSupported.setSupportedCredentials(credentialsSupportedResponses);
+       expectedIssuerCredentialsSupported.setAuthorization_endpoint(authorization_endpoint);
+
+        Mockito.when(restApiClient.getApi(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn(null);
+        IssuerSupportedCredentialsResponse issuerSupportedCredentialsResponse = v2IssuersService.getCredentialsSupported("Issuer1id", null);
+        assertEquals(issuerSupportedCredentialsResponse, expectedIssuerCredentialsSupported);
+    }
+
+    @Test
+    public void shouldReturnNullIfTheIssuerIdNotExists() throws ApiNotAccessibleException, IOException {
+        IssuerSupportedCredentialsResponse issuerSupportedCredentialsResponse = v2IssuersService.getCredentialsSupported("Issuer3id", null);
+        assertNull(issuerSupportedCredentialsResponse.getSupportedCredentials());
+        assertNull(issuerSupportedCredentialsResponse.getAuthorization_endpoint());
+    }
+
+    @Test
+    public void shouldParseHtmlStringToDocument() {
+        String htmlContent = "<html><body><h1>Hello World!</h1></body></html>";
+        Document doc = Jsoup.parse(htmlContent);
+        assertNotNull(doc);
+    }
+
+}

--- a/src/test/java/io/mosip/mimoto/service/V2IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/V2IssuersServiceTest.java
@@ -107,7 +107,7 @@ public class V2IssuersServiceTest {
 
     @Test(expected = ApiNotAccessibleException.class)
     public void shouldThrowApiNotAccessibleExceptionWhenIssuersDtoIsNullForGettingIssuersLIst() throws IOException, ApiNotAccessibleException {
-        Mockito.when(utilities.getIssuersConfigJsonString()).thenReturn(null);
+        Mockito.when(utilities.getIssuersConfigJsonValue()).thenReturn(null);
         v2IssuersService.getAllIssuers(null);
     }
 

--- a/src/test/java/io/mosip/mimoto/service/V2IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/V2IssuersServiceTest.java
@@ -102,12 +102,12 @@ public class V2IssuersServiceTest {
         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = getCredentialIssuerWellKnownResponseDto("Issuer1",
                 List.of(getCredentialSupportedResponse("CredentialSupported1"), getCredentialSupportedResponse("CredentialSupported2")));
         Mockito.when(utilities.getV2CredentialsSupportedConfigJsonValue()).thenReturn(new Gson().toJson(credentialIssuerWellKnownResponse));
-        Mockito.when(utilities.getV2IssuersConfigJsonValue()).thenReturn(new Gson().toJson(issuers));
+        Mockito.when(utilities.getIssuersConfigJsonValue()).thenReturn(new Gson().toJson(issuers));
     }
 
     @Test(expected = ApiNotAccessibleException.class)
     public void shouldThrowApiNotAccessibleExceptionWhenIssuersDtoIsNullForGettingIssuersLIst() throws IOException, ApiNotAccessibleException {
-        Mockito.when(utilities.getV2IssuersConfigJsonValue()).thenReturn(null);
+        Mockito.when(utilities.getIssuersConfigJsonString()).thenReturn(null);
         v2IssuersService.getAllIssuers(null);
     }
 


### PR DESCRIPTION
- Get issuers v2 API(New API for issuer discovery)
- Get issuer by id v2 API (Credential types supported from well known file)
- Generate PDF API

The v2 convention is only for separation for now. Once there is  a goahead for merge to develop, will move these APIs into existing controller post refactor

Note: application properties file has localhost reference for now as we don't have dev e-signet instance deployed. will update the variables once we have an active dev e-signet instance