### PR TITLE
[INJIMOB-1458] add supported credentials attribute in issuers config

### DIFF
--- a/src/main/java/io/mosip/mimoto/dto/IssuerDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/IssuerDTO.java
@@ -5,13 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
 import java.util.Map;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 
 @Data
@@ -46,27 +47,37 @@ public class IssuerDTO {
     @NotBlank
     String authorization_audience;
     @JsonInclude(NON_NULL)
-    @NotBlank
     String token_endpoint;
     @JsonInclude(NON_NULL)
     @NotBlank
     String proxy_token_endpoint;
     @JsonInclude(NON_NULL)
-    @NotBlank
     String credential_endpoint;
     @JsonInclude(NON_NULL)
     @NotEmpty
     List<String> credential_type;
     @JsonInclude(NON_NULL)
-    @NotBlank
     String credential_audience;
     @JsonInclude(NON_NULL)
     @NotBlank
     String client_alias;
     @JsonInclude(NON_NULL)
     Map<String, String> additional_headers;
+    @JsonInclude(NON_NULL)
+    List<SupportedCredential> credentials_supported;
     @Expose
     @JsonInclude(NON_NULL)
     @NotBlank
     String enabled;
+}
+
+
+@Data
+class SupportedCredential {
+    @NotEmpty
+    String format;
+    Map<String, Object> credential_definition;
+    String scope;
+    @JsonInclude(NON_NULL)
+    List<Object> display;
 }

--- a/src/main/resources/mimoto-issuers-config.json
+++ b/src/main/resources/mimoto-issuers-config.json
@@ -10,7 +10,7 @@
             "alt_text": "mosip logo"
           },
           "title": "Download MOSIP Credentials via OTP",
-          "description":"Download credentials by providing UIN, VID or AID",
+          "description": "Download credentials by providing UIN, VID or AID",
           "language": "en"
         },
         {
@@ -30,7 +30,7 @@
             "alt_text": "मोसिप लोगो"
           },
           "title": "OTP के माध्यम से MOSIP क्रेडेंशियल डाउनलोड करें",
-          "description":"यूआईएन, वीआईडी या एआईडी प्रदान करके क्रेडेंशियल डाउनलोड करें",
+          "description": "यूआईएन, वीआईडी या एआईडी प्रदान करके क्रेडेंशियल डाउनलोड करें",
           "language": "hi"
         },
         {
@@ -50,7 +50,7 @@
             "alt_text": "mosip சின்னம்"
           },
           "title": "OTP வழியாக MOSIP சான்றுகளைப் பதிவிறக்கவும்",
-          "description":"UIN, VID அல்லது AID ஐ வழங்குவதன் மூலம் நற்சான்றிதழ்களைப் பதிவிறக்கவும்",
+          "description": "UIN, VID அல்லது AID ஐ வழங்குவதன் மூலம் நற்சான்றிதழ்களைப் பதிவிறக்கவும்",
           "language": "ta"
         },
         {
@@ -60,7 +60,7 @@
             "alt_text": "logo ng mosip"
           },
           "title": "I-download ang Mga Kredensyal ng MOSIP sa pamamagitan ng OTP",
-          "description":"Mag-download ng mga kredensyal sa pamamagitan ng pagbibigay ng UIN, VID o AID",
+          "description": "Mag-download ng mga kredensyal sa pamamagitan ng pagbibigay ng UIN, VID o AID",
           "language": "fil"
         }
       ],
@@ -87,7 +87,7 @@
             "alt_text": "شعار موسيب"
           },
           "title": "قم بتنزيل بيانات اعتماد MOSIP",
-          "description": "توفير UIN أو VIDقم بتنزيل بيانات الاعتماد عن طريق" ,
+          "description": "توفير UIN أو VIDقم بتنزيل بيانات الاعتماد عن طريق",
           "language": "ar"
         },
         {
@@ -97,7 +97,7 @@
             "alt_text": "मोसिप लोगो"
           },
           "title": "MOSIP क्रेडेंशियल डाउनलोड करेंं",
-          "description":"यूआईएन या वीआईडी प्रदान करके क्रेडेंशियल डाउनलोड करें",
+          "description": "यूआईएन या वीआईडी प्रदान करके क्रेडेंशियल डाउनलोड करें",
           "language": "hi"
         },
         {
@@ -117,7 +117,7 @@
             "alt_text": "mosip லோகோ"
           },
           "title": "MOSIP சான்றுகளைப் பதிவிறக்கவும்",
-          "description":"UIN அல்லது VIDஐ வழங்குவதன் மூலம் நற்சான்றிதழ்களைப் பதிவிறக்கவும்",
+          "description": "UIN அல்லது VIDஐ வழங்குவதன் மூலம் நற்சான்றிதழ்களைப் பதிவிறக்கவும்",
           "language": "ta"
         },
         {
@@ -127,15 +127,19 @@
             "alt_text": "logo ng mosip"
           },
           "title": "I-download ang Mga Kredensyal ng MOSIP",
-          "description":"Mag-download ng mga kredensyal sa pamamagitan ng pagbibigay ng UIN o VID",
+          "description": "Mag-download ng mga kredensyal sa pamamagitan ng pagbibigay ng UIN o VID",
           "language": "fil"
         }
       ],
       "protocol": "OpenId4VCI",
       "client_id": "${mimoto.oidc.partner.clientid}",
       "client_alias": "mpartner-default-mimotooidc",
-      "scopes_supported": ["mosip_identity_vc_ldp"],
-      "additional_headers": { "Accept": "application/json" },
+      "scopes_supported": [
+        "mosip_identity_vc_ldp"
+      ],
+      "additional_headers": {
+        "Accept": "application/json"
+      },
       ".well-known": "https://${mosip.esignet.host}/.well-known/openid-credential-issuer",
       "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
       "authorization_endpoint": "https://${mosip.esignet.host}/authorize",
@@ -143,7 +147,10 @@
       "token_endpoint": "https://${mosip.api.public.host}/residentmobileapp/get-token/ESignet",
       "proxy_token_endpoint": "https://${mosip.api.public.host}/v1/esignet/oauth/v2/token",
       "credential_endpoint": "https://${mosip.api.public.host}/v1/esignet/vci/credential",
-      "credential_type": ["VerifiableCredential", "MOSIPVerifiableCredential"],
+      "credential_type": [
+        "VerifiableCredential",
+        "MOSIPVerifiableCredential"
+      ],
       "credential_audience": "https://${mosip.esignet.host}/v1/esignet",
       "enabled": "false"
     },
@@ -214,8 +221,12 @@
       "protocol": "OpenId4VCI",
       "client_id": "${mimoto.oidc.sunbird.partner.clientid}",
       "client_alias": "esignet-sunbird-partner",
-      "scopes_supported": ["sunbird_rc_insurance_vc_ldp"],
-      "additional_headers": { "Accept": "application/json" },
+      "scopes_supported": [
+        "sunbird_rc_insurance_vc_ldp"
+      ],
+      "additional_headers": {
+        "Accept": "application/json"
+      },
       ".well-known": "https://vijay151096.github.io/did-testing/openid-credential-issuer.json",
       "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
       "authorization_endpoint": "https://${mosip.esignet.mock.host}/authorize",
@@ -223,9 +234,89 @@
       "token_endpoint": "https://${mosip.api.public.host}/residentmobileapp/get-token/Sunbird",
       "proxy_token_endpoint": "https://${mosip.esignet.mock.host}/v1/esignet/oauth/v2/token",
       "credential_endpoint": "https://${mosip.esignet.mock.host}/v1/esignet/vci/credential",
-      "credential_type": ["VerifiableCredential", "InsuranceCredential"],
+      "credential_type": [
+        "VerifiableCredential",
+        "InsuranceCredential"
+      ],
       "credential_audience": "https://${mosip.esignet.mock.host}/v1/esignet",
       "enabled": "false"
+    },
+    {
+      "credential_issuer": "HealthCoverageZ",
+      "display": [
+        {
+          "name": "HealthCoverageZ Verifiable Credential",
+          "logo": {
+            "url": "https://sunbird.org/images/sunbird-logo-new.png",
+            "alt_text": "a square logo of a HealthCoverageZ"
+          },
+          "language": "en",
+          "title": "Download HealthCoverageZ Credentials",
+          "description": "Download credentials with your Policy Number"
+        }
+      ],
+      "protocol": "OpenId4VCI",
+      "client_id": "${mimoto.oidc.sunbird.partner.clientid}",
+      "client_alias": "esignet-sunbird-partner",
+      "additional_headers": {
+        "Accept": "application/json"
+      },
+      ".well-known": "https://esignet.qa-inji.mosip.net/.well-known/openid-credential-issuer",
+      "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
+      "authorization_endpoint": "https://issuer-host/authorize",
+      "authorization_audience": "https://issuer-host/v1/esignet/oauth/v2/token",
+      "token_endpoint": "https://issuer-public-host/residentmobileapp/get-token/HealthCoverageZ",
+      "proxy_token_endpoint": "https://issuer-host/v1/esignet/oauth/v2/token",
+      "enabled": "true"
+    },
+    {
+      "credential_issuer": "ProtectionPlus+",
+      "display": [
+        {
+          "name": "ProtectionPlus+ Verifiable Credential",
+          "logo": {
+            "url": "https://sunbird.org/images/sunbird-logo-new.png",
+            "alt_text": "a square logo of a Sunbird"
+          },
+          "language": "en",
+          "title": "Download ProtectionPlus+ Credentials",
+          "description": "Download credentials with your Policy Number"
+        }
+      ],
+      "protocol": "OpenId4VCI",
+      "client_id": "${mimoto.oidc.sunbird.partner.clientid}",
+      "client_alias": "esignet-sunbird-partner",
+      "scopes_supported": [
+        "sunbird_rc_insurance_vc_ldp"
+      ],
+      "additional_headers": {
+        "Accept": "application/json"
+      },
+      "credentials_supported": [
+        {
+          "format": "ldp_vc",
+          "id": "VehicleInsuranceCredential",
+          "credential_definition": {
+            "type": [
+              "VerifiableCredential",
+              "InsuranceCredential"
+            ]
+          },
+          "scope": "vehicle_insurance_vc_ldp"
+        }
+      ],
+      "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
+      "authorization_endpoint": "https://issuer-host/authorize",
+      "authorization_audience": "https://issuer-host/v1/esignet/oauth/v2/token",
+      "token_endpoint": "https://issuer-public-host/residentmobileapp/get-token/ProtectionPlus+",
+      "proxy_token_endpoint": "https://issuer-host/v1/esignet/oauth/v2/token",
+      "credential_endpoint": "https://issuer-host/v1/esignet/vci/credential",
+      "credential_type": [
+        "VerifiableCredential",
+        "InsuranceCredential"
+      ],
+      "credential_audience": "https://issuer-host",
+      "enabled": "true"
     }
   ]
 }


### PR DESCRIPTION
In case of 
- wellknown is available, all the required data will be taken from the well known
- well known is unavailable, all the required data will be taken from mosip-config in the consumers

For this reason, credentials_supported attribute is added to the mosip-config which mimics the well known's structure with the following attribute as mandatory - Credentials_supported* (array of objects)

credentials_supported will have below structure
1. format*
2. id*
3. credential_definition*
      3.1  credentialSubject (optional)
      3.2  scope*
      3.3 display (Optional)
  

