### PR TITLE
[INJIMOB-1862] refactor CredentialIssuerWellknownResponseValidator

### DIFF
--- a/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
@@ -42,6 +42,9 @@ public class IssuersServiceImpl implements IssuersService {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private CredentialIssuerWellknownResponseValidator credentialIssuerWellknownResponseValidator;
+
 
     @Override
     public IssuersDTO getAllIssuers(String search) throws ApiNotAccessibleException{
@@ -110,7 +113,7 @@ public class IssuersServiceImpl implements IssuersService {
                     String wellknownResponse = restApiClient.getApi(issuerDTO.getWellknown_endpoint(), String.class);
                     try {
                         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = objectMapper.readValue(wellknownResponse, CredentialIssuerWellKnownResponse.class);
-                        new CredentialIssuerWellknownResponseValidator().validate(credentialIssuerWellKnownResponse, validator);
+                        credentialIssuerWellknownResponseValidator.validate(credentialIssuerWellKnownResponse, validator);
                         return credentialIssuerWellKnownResponse;
                     } catch (JsonProcessingException | ApiNotAccessibleException | InvalidWellknownResponseException e) {
                         throw new RuntimeException(e);

--- a/src/main/java/io/mosip/mimoto/util/CredentialIssuerWellknownResponseValidator.java
+++ b/src/main/java/io/mosip/mimoto/util/CredentialIssuerWellknownResponseValidator.java
@@ -8,11 +8,17 @@ import io.mosip.mimoto.exception.InvalidWellknownResponseException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import java.util.Set;
 
+@Component
 public class CredentialIssuerWellknownResponseValidator {
+
+    public static final String MSO_MDOC = "mso_mdoc";
+    public static final String LDP_VC = "ldp_vc";
+
     public void validate(CredentialIssuerWellKnownResponse response, Validator validator) throws ApiNotAccessibleException, InvalidWellknownResponseException {
         Set<ConstraintViolation<CredentialIssuerWellKnownResponse>> violations = validator.validate(response);
         if (!violations.isEmpty()) {
@@ -25,7 +31,7 @@ public class CredentialIssuerWellknownResponseValidator {
 
         for (CredentialsSupportedResponse supportedCredentialConfiguration : response.getCredentialConfigurationsSupported().values()) {
             //TODO: Extract the vc specific validations to separate classes
-            if (supportedCredentialConfiguration.getFormat().equals("mso_mdoc")) {
+            if (MSO_MDOC.equals(supportedCredentialConfiguration.getFormat())) {
                 if (StringUtils.isBlank(supportedCredentialConfiguration.getDoctype())) {
                     throw new InvalidWellknownResponseException("Mandatory field 'doctype' missing");
                 }
@@ -34,7 +40,7 @@ public class CredentialIssuerWellknownResponseValidator {
                 }
             }
 
-            if (supportedCredentialConfiguration.getFormat().equals("ldp_vc")) {
+            if (LDP_VC.equals(supportedCredentialConfiguration.getFormat())) {
                 if (supportedCredentialConfiguration.getCredentialDefinition() == null) {
                     throw new InvalidWellknownResponseException("credentialDefinition: must not be null");
                 }

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -9,6 +9,7 @@ import io.mosip.mimoto.exception.ApiNotAccessibleException;
 import io.mosip.mimoto.exception.InvalidIssuerIdException;
 import io.mosip.mimoto.service.impl.CredentialServiceImpl;
 import io.mosip.mimoto.service.impl.IssuersServiceImpl;
+import io.mosip.mimoto.util.CredentialIssuerWellknownResponseValidator;
 import io.mosip.mimoto.util.RestApiClient;
 import io.mosip.mimoto.util.Utilities;
 import jakarta.validation.Validator;
@@ -31,6 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IssuersServiceTest {
@@ -49,6 +51,9 @@ public class IssuersServiceTest {
 
     @Mock
     Utilities utilities;
+
+    @Mock
+    CredentialIssuerWellknownResponseValidator credentialIssuerWellknownResponseValidator;
 
     @Mock
     ObjectMapper objectMapper;
@@ -105,7 +110,7 @@ public class IssuersServiceTest {
         Mockito.when(restApiClient.getApi(wellKnownUrl , String.class))
                 .thenReturn(getExpectedWellKnownJson());
         Mockito.when(objectMapper.readValue(getExpectedWellKnownJson(), CredentialIssuerWellKnownResponse.class)).thenReturn(expextedCredentialIssuerWellKnownResponse);
-        Mockito.when(validator.validate(any())).thenReturn(Collections.emptySet());
+        lenient().when(validator.validate(any())).thenReturn(Collections.emptySet());
 
         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse=issuersService.getIssuerWellknown(issuerId);
         assertEquals(expextedCredentialIssuerWellKnownResponse,credentialIssuerWellKnownResponse);

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -110,7 +110,7 @@ public class IssuersServiceTest {
         Mockito.when(restApiClient.getApi(wellKnownUrl , String.class))
                 .thenReturn(getExpectedWellKnownJson());
         Mockito.when(objectMapper.readValue(getExpectedWellKnownJson(), CredentialIssuerWellKnownResponse.class)).thenReturn(expextedCredentialIssuerWellKnownResponse);
-        lenient().when(validator.validate(any())).thenReturn(Collections.emptySet());
+        lenient().when(validator.validate(expextedCredentialIssuerWellKnownResponse)).thenReturn(Collections.emptySet());
 
         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse=issuersService.getIssuerWellknown(issuerId);
         assertEquals(expextedCredentialIssuerWellKnownResponse,credentialIssuerWellKnownResponse);


### PR DESCRIPTION
refactorings include
- make wellknown validator a component
- replace value.equals(constant) with constant.equals(value) to avoid NullPointerException
- extract constants for VC formats to avoid magic strings

**_Note:_**
`Mockito.when(validator.validate(any())...` is replaced with `lenient().when(validator.validate(any(...` to avoid unnecessary Mockito stubbing issue
<img width="1572" alt="image" src="https://github.com/user-attachments/assets/03564c9f-f815-496c-9ec0-02c205a4f412">
