### PR TITLE
[INJIWEB-1203] fetch authorization_audience & proxy_token_endpoint from issuers config rather than fetching from auth server wellknown in issuers and specific issuer endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.mosip</groupId>
     <artifactId>mimoto</artifactId>
-    <version>0.15.0-SNAPSHOT</version>
+    <version>0.17.0-SNAPSHOT</version>
     <name>mimoto</name>
     <url>https://github.com/mosip/mimoto</url>
     <description>Mobile server backend supporting Inji.</description>

--- a/src/main/java/io/mosip/mimoto/dto/IssuerDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/IssuerDTO.java
@@ -29,17 +29,19 @@ public class IssuerDTO {
     @Schema(description = "Client Id of the Onboarded Mimoto OIDC Client")
     String client_id;
     @URL
+    @NotBlank
     @Schema(description = "Wellknown endpoint of the credential issuer")
     String wellknown_endpoint;
     @NotBlank
     @Schema(description = "Redirect URI configured while creating the OIDC Client")
     String redirect_uri;
-    @JsonInclude(NON_NULL)
+    @NotBlank
     @Schema(description = "Authorization Audience for retrieving Token from token endpoint")
     String authorization_audience;
     @Schema(description = "Mimoto Token Endpoint Fetching the Token From Authorization Server with Client Assertion")
     String token_endpoint;
     @URL
+    @NotBlank
     @Schema(description = "Token Endpoint for Fetching the Token From Authorization Server")
     String proxy_token_endpoint;
     @NotBlank

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
@@ -119,7 +119,7 @@ public class CredentialServiceImpl implements CredentialService {
     @Override
     public ByteArrayInputStream downloadCredentialAsPDF(String issuerId, String credentialType, TokenResponseDTO response, String credentialValidity, String locale) throws Exception {
         IssuerDTO issuerDTO = issuersService.getIssuerDetails(issuerId);
-        CredentialIssuerConfigurationResponse issuerConfigurationResponse = issuersService.getIssuerConfiguration(issuerDTO.getCredential_issuer_host());
+        CredentialIssuerConfigurationResponse issuerConfigurationResponse = issuersService.getIssuerConfiguration(issuerId);
         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = new CredentialIssuerWellKnownResponse(
                 issuerConfigurationResponse.getCredentialIssuer(),
                 issuerConfigurationResponse.getAuthorizationServers(),

--- a/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
@@ -80,18 +80,13 @@ public class IssuersServiceImpl implements IssuersService {
 
     @Override
     public IssuersDTO getAllIssuers() throws ApiNotAccessibleException, IOException {
-
         IssuersDTO issuersDTO;
         String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
         if (issuersConfigJsonValue == null) {
             throw new ApiNotAccessibleException();
         }
 
-        try {
-            issuersDTO = objectMapper.readValue(issuersConfigJsonValue, IssuersDTO.class);
-        } catch (Exception e) {
-            throw e;
-        }
+        issuersDTO = objectMapper.readValue(issuersConfigJsonValue, IssuersDTO.class);
 
         return issuersDTO;
     }

--- a/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
@@ -79,7 +79,7 @@ public class IssuersServiceImpl implements IssuersService {
     }
 
     @Override
-    public IssuersDTO getAllIssuers() throws ApiNotAccessibleException, AuthorizationServerWellknownResponseException, IOException, InvalidWellknownResponseException {
+    public IssuersDTO getAllIssuers() throws ApiNotAccessibleException, IOException {
 
         IssuersDTO issuersDTO;
         String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
@@ -91,11 +91,6 @@ public class IssuersServiceImpl implements IssuersService {
             issuersDTO = objectMapper.readValue(issuersConfigJsonValue, IssuersDTO.class);
         } catch (Exception e) {
             throw e;
-        }
-        for (IssuerDTO issuerDTO : issuersDTO.getIssuers()) {
-            if (!issuerDTO.getProtocol().equals("OTP")) {
-                updateIssuerWithAuthServerConfig(issuerDTO);
-            }
         }
 
         return issuersDTO;
@@ -114,22 +109,5 @@ public class IssuersServiceImpl implements IssuersService {
                 credentialIssuerWellKnownResponse.getCredentialConfigurationsSupported(),
                 authorizationServerWellKnownResponse
         );
-    }
-
-    private void updateIssuerWithAuthServerConfig(IssuerDTO issuerDTO)  {
-        CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = null;
-        try {
-            credentialIssuerWellKnownResponse = issuerWellknownService.getWellknown(issuerDTO.getCredential_issuer_host());
-            AuthorizationServerWellKnownResponse authorizationServerWellKnownResponse = authorizationServerService.getWellknown(credentialIssuerWellKnownResponse.getAuthorizationServers().get(0));
-            String tokenEndpoint = authorizationServerWellKnownResponse.getTokenEndpoint();
-            issuerDTO.setAuthorization_audience(tokenEndpoint);
-            issuerDTO.setProxy_token_endpoint(tokenEndpoint);
-        } catch (ApiNotAccessibleException | IOException | AuthorizationServerWellknownResponseException |
-                 InvalidWellknownResponseException e) {
-            log.error("Exception occurred while fetching issuer wellknown ", e);
-            issuerDTO.setAuthorization_audience("");
-            issuerDTO.setProxy_token_endpoint("");
-        }
-
     }
 }

--- a/src/test/java/io/mosip/mimoto/controller/IssuersControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/IssuersControllerTest.java
@@ -92,13 +92,13 @@ public class IssuersControllerTest {
                                 Matchers.hasKey("proxy_token_endpoint"),
                                 Matchers.hasKey("token_endpoint"),
                                 Matchers.hasKey("credential_issuer_host"),
+                                Matchers.hasKey("authorization_audience"),
                                 Matchers.not(Matchers.hasKey("redirect_url")),
                                 Matchers.not(Matchers.hasKey("authorization_endpoint")),
                                 Matchers.not(Matchers.hasKey("credential_endpoint")),
                                 Matchers.not(Matchers.hasKey("credential_audience")),
                                 Matchers.not(Matchers.hasKey("additional_headers")),
-                                Matchers.not(Matchers.hasKey("scopes_supported")),
-                                Matchers.not(Matchers.hasKey("authorization_audience"))
+                                Matchers.not(Matchers.hasKey("scopes_supported"))
                         )
                 )));
 
@@ -134,14 +134,14 @@ public class IssuersControllerTest {
                                 Matchers.hasKey("wellknown_endpoint"),
                                 Matchers.hasKey("proxy_token_endpoint"),
                                 Matchers.hasKey("token_endpoint"),
+                                Matchers.hasKey("authorization_audience"),
                                 Matchers.hasKey("credential_issuer_host"),
                                 Matchers.not(Matchers.hasKey("redirect_url")),
                                 Matchers.not(Matchers.hasKey("authorization_endpoint")),
                                 Matchers.not(Matchers.hasKey("credential_endpoint")),
                                 Matchers.not(Matchers.hasKey("credential_audience")),
                                 Matchers.not(Matchers.hasKey("additional_headers")),
-                                Matchers.not(Matchers.hasKey("scopes_supported")),
-                                Matchers.not(Matchers.hasKey("authorization_audience"))
+                                Matchers.not(Matchers.hasKey("scopes_supported"))
                         )
                 )));
 

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -202,6 +202,6 @@ public class IssuersServiceTest {
 
         assertEquals("RESIDENT-APP-042 --> Invalid Authorization Server well-known from server:\n" +
                 "well-known api is not accessible", actualException.getMessage());
-        verify(authorizationServerService, times(3)).getWellknown(authServerWellknownUrl);
+        verify(authorizationServerService, times(1)).getWellknown(authServerWellknownUrl);
     }
 }


### PR DESCRIPTION
- In issuers validation config file if we fetch these fields from Auth Server wellknown and if the issuer or auth server wellknown is down then mimoto is throwing the error while launching the service and not starting the mimoto but we don't want to stop the entire mimoto if a particular issuer is not available, so to avoid this we will fetch it from config itself as part of /issuers and /issuers/{issuer_id} endpoints but we will not be using them from here and continue fetching them as part of new endpoint /issuers/{issuerId}/configuration call.