### PR TITLE
[Injiweb 1429] fix the issues noticed in the pdf generation based on the locale value passed

### DIFF
--- a/docs/api-documentation-openapi.json
+++ b/docs/api-documentation-openapi.json
@@ -1604,7 +1604,7 @@
                 "tags": [
                     "Trusted Issuers"
                 ],
-                "description": "This API provides the complete configuration details for the specific issuers passed in the path variable. Since version 0.16.0, this endpoint is deprecated and will be removed in a future release.",
+                "description": "This API provides the complete configuration details for the specific issuers passed in the path variable.",
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/src/main/java/io/mosip/mimoto/controller/CredentialShareController.java
+++ b/src/main/java/io/mosip/mimoto/controller/CredentialShareController.java
@@ -93,7 +93,7 @@ public class CredentialShareController {
             utilities.getDataPath(),
             String.format(CredentialShareServiceImpl.VC_REQUEST_FILE_NAME, eventModel.getEvent().getTransactionId())
         );
-        // Only process event if request id file exists in the storange.
+        // Only process event if request id file exists in the storage.
         if (vcRequestIdPath.toFile().exists()) {
             boolean documentGenerated = credentialShareService.generateDocuments(eventModel);
             log.info("Credential share process status: {} for event id: {}", documentGenerated, eventModel.getEvent().getId());

--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -76,10 +76,6 @@ public class IssuersController {
         }
     }
 
-    /**
-     * @deprecated Since version 0.16.0, this endpoint is deprecated and will be removed in a future release.
-     */
-    @Deprecated(since = "0.16.0", forRemoval = true)
     @Operation(summary = SwaggerLiteralConstants.ISSUERS_GET_SPECIFIC_ISSUER_SUMMARY, description = SwaggerLiteralConstants.ISSUERS_GET_SPECIFIC_ISSUER_DESCRIPTION)
     @GetMapping(value = "/{issuer-id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ResponseWrapper<IssuerDTO>> getIssuerConfig(@PathVariable("issuer-id") String issuerId) {

--- a/src/main/java/io/mosip/mimoto/dto/DataShareResponseDto.java
+++ b/src/main/java/io/mosip/mimoto/dto/DataShareResponseDto.java
@@ -2,10 +2,11 @@ package io.mosip.mimoto.dto;
 
 import java.util.List;
 
+import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 @Data
+@Builder
 public class DataShareResponseDto extends BaseRestResponseDTO {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
@@ -100,7 +100,7 @@ public class CredentialServiceImpl implements CredentialService {
     CredentialsVerifier credentialsVerifier;
 
     @PostConstruct
-    public void init(){
+    public void init() {
         pixelPass = new PixelPass();
         credentialsVerifier = new CredentialsVerifier();
     }
@@ -163,8 +163,8 @@ public class CredentialServiceImpl implements CredentialService {
     }
 
     public ByteArrayInputStream generatePdfForVerifiableCredentials(String credentialType, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        LinkedHashMap<String, Object> displayProperties = loadDisplayPropertiesFromWellknown(vcCredentialResponse, credentialsSupportedResponse, locale);
-        Map<String, Object> data = getPdfResourceFromVcProperties(displayProperties, credentialsSupportedResponse,  vcCredentialResponse, issuerDTO, dataShareUrl, credentialValidity, locale);
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties = loadDisplayPropertiesFromWellknown(vcCredentialResponse, credentialsSupportedResponse, locale);
+        Map<String, Object> data = getPdfResourceFromVcProperties(displayProperties, credentialsSupportedResponse, vcCredentialResponse, issuerDTO, dataShareUrl, credentialValidity, locale);
         return renderVCInCredentialTemplate(data, issuerDTO.getIssuer_id(), credentialType);
     }
 
@@ -172,7 +172,7 @@ public class CredentialServiceImpl implements CredentialService {
         log.info("Initiated the VC Verification : Started");
         String credentialString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
         VerificationResult verificationResult = credentialsVerifier.verify(credentialString, CredentialFormat.LDP_VC);
-        if(!verificationResult.getVerificationStatus()){
+        if (!verificationResult.getVerificationStatus()) {
             throw new VCVerificationException(verificationResult.getVerificationErrorCode().toLowerCase(), verificationResult.getVerificationMessage());
         }
         log.info("Completed the VC Verification : Completed -> result : " + verificationResult);
@@ -180,36 +180,36 @@ public class CredentialServiceImpl implements CredentialService {
     }
 
     @NotNull
-    private static LinkedHashMap<String, Object> loadDisplayPropertiesFromWellknown(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse, String locale) {
-        LinkedHashMap<String,Object> displayProperties = new LinkedHashMap<>();
+    private static LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> loadDisplayPropertiesFromWellknown(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse, String locale) {
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties = new LinkedHashMap<>();
         Map<String, Object> credentialProperties = vcCredentialResponse.getCredential().getCredentialSubject();
-
-        LinkedHashMap<String, String> vcPropertiesFromWellKnown = new LinkedHashMap<>();
+        LinkedHashMap<String, CredentialIssuerDisplayResponse> vcPropertiesFromWellKnown = new LinkedHashMap<>();
         Map<String, CredentialDisplayResponseDto> credentialSubject = credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject();
         credentialSubject.keySet().forEach(VCProperty -> {
             Optional<CredentialIssuerDisplayResponse> filteredResponse = credentialSubject.get(VCProperty)
                     .getDisplay().stream()
-                    .filter(obj ->
-                        LocaleUtils.matchesLocale(obj.getLocale(), locale)
-                    )
+                    .filter(obj -> "undefined".equals(locale) || LocaleUtils.matchesLocale(obj.getLocale(), locale))// if locale is not undefined use it to fetch the wellknown properties otherwise return the properties of the first display object which has language field
                     .findFirst();
-            String filteredValue = filteredResponse.isPresent() ? filteredResponse.get().getName() : "" ;
-            vcPropertiesFromWellKnown.put(VCProperty, filteredValue);
+
+            if (filteredResponse.isPresent()) {
+                CredentialIssuerDisplayResponse filteredValue = filteredResponse.get();
+                vcPropertiesFromWellKnown.put(VCProperty, filteredValue);
+            }
         });
 
         List<String> orderProperty = credentialsSupportedResponse.getOrder();
 
         List<String> fieldProperties = orderProperty == null ? new ArrayList<>(vcPropertiesFromWellKnown.keySet()) : orderProperty;
         fieldProperties.forEach(vcProperty -> {
-            if(credentialProperties.get(vcProperty) != null) {
-                displayProperties.put(vcProperty,Map.of(vcPropertiesFromWellKnown.get(vcProperty), credentialProperties.get(vcProperty)));
+            if (vcPropertiesFromWellKnown.get(vcProperty) != null && credentialProperties.get(vcProperty) != null) {
+                displayProperties.put(vcProperty, Map.of(vcPropertiesFromWellKnown.get(vcProperty), credentialProperties.get(vcProperty)));
             }
         });
         return displayProperties;
     }
 
 
-    private Map<String, Object> getPdfResourceFromVcProperties(LinkedHashMap<String, Object> displayProperties, CredentialsSupportedResponse credentialsSupportedResponse, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, String dataShareUrl, String credentialValidity, String locale) throws IOException, WriterException {
+    private Map<String, Object> getPdfResourceFromVcProperties(LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties, CredentialsSupportedResponse credentialsSupportedResponse, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, String dataShareUrl, String credentialValidity, String locale) throws IOException, WriterException {
         Map<String, Object> data = new HashMap<>();
         LinkedHashMap<String, Object> rowProperties = new LinkedHashMap<>();
         String backgroundColor = credentialsSupportedResponse.getDisplay().get(0).getBackgroundColor();
@@ -221,28 +221,31 @@ public class CredentialServiceImpl implements CredentialService {
         displayProperties.entrySet().stream()
                 .forEachOrdered(entry -> {
                     String originalKey = entry.getKey();
-                    Object entryValue = entry.getValue();
+                    Map<CredentialIssuerDisplayResponse, Object> properties = entry.getValue();
 
                     // Process the inner map
-                    ((Map<?, ?>) entryValue).entrySet().stream()
+                    ((Map<CredentialIssuerDisplayResponse, ?>) properties).entrySet().stream()
                             .forEachOrdered(innerEntry -> {
-                                String propertyKey = innerEntry.getKey().toString();
-                                Object currentValue = innerEntry.getValue();
+                                // loadDisplayPropertiesFromWellknown method returns both name and locale field values of the matching display obj in the response
+                                CredentialIssuerDisplayResponse matchingWellknownDisplayObj = innerEntry.getKey();
+                                String nameFromDisplayObj = matchingWellknownDisplayObj.getName();
+                                String localeFromDisplayObj = matchingWellknownDisplayObj.getLocale();
+                                Object propertyValFromDownloadedVcResponse = innerEntry.getValue();
                                 String value = "";
 
-                                if (currentValue instanceof Map) {
+                                if (propertyValFromDownloadedVcResponse instanceof Map) {
                                     // If the value is a Map, handle it as a Map
-                                    value = handleMap(currentValue);
-                                } else if (currentValue instanceof List) {
+                                    value = handleMap(propertyValFromDownloadedVcResponse);
+                                } else if (propertyValFromDownloadedVcResponse instanceof List) {
                                     // If the value is a List, handle it as a List
-                                    value = handleList(currentValue);
+                                    value = handleList(propertyValFromDownloadedVcResponse, localeFromDisplayObj);
                                 } else {
                                     // Otherwise, just convert to string
-                                    value = currentValue.toString();
+                                    value = propertyValFromDownloadedVcResponse.toString();
                                 }
 
                                 // Put the result into the rowProperties map
-                                rowProperties.put(originalKey, Map.of(propertyKey, value));
+                                rowProperties.put(originalKey, Map.of(nameFromDisplayObj, value));
                             });
 
                 });
@@ -260,7 +263,7 @@ public class CredentialServiceImpl implements CredentialService {
         return data;
     }
 
-    private String handleList(Object list) {
+    private String handleList(Object list, String locale) {
         if (list instanceof List) {
             List<?> castedList = (List<?>) list;
             if (castedList.isEmpty()) return "";
@@ -268,7 +271,7 @@ public class CredentialServiceImpl implements CredentialService {
                 return castedList.stream().map(String.class::cast).collect(Collectors.joining(", "));
             } else if (castedList.get(0) instanceof Map) {
                 return ((List<Map<?, ?>>) castedList).stream()
-                        .filter(obj -> obj.containsKey("language"))
+                        .filter(obj -> LocaleUtils.matchesLocale(obj.get("language").toString(), locale))
                         .map(obj -> obj.get("value").toString())
                         .findFirst()
                         .orElse("");
@@ -288,7 +291,7 @@ public class CredentialServiceImpl implements CredentialService {
 
     @NotNull
     private ByteArrayInputStream renderVCInCredentialTemplate(Map<String, Object> data, String issuerId, String credentialType) throws IOException {
-        String  credentialTemplate = utilities.getCredentialSupportedTemplateString(issuerId, credentialType);
+        String credentialTemplate = utilities.getCredentialSupportedTemplateString(issuerId, credentialType);
         Properties props = new Properties();
         props.setProperty("resource.loader", "class");
         props.setProperty("class.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");

--- a/src/main/java/io/mosip/mimoto/util/LocaleUtils.java
+++ b/src/main/java/io/mosip/mimoto/util/LocaleUtils.java
@@ -3,18 +3,11 @@ package io.mosip.mimoto.util;
 import java.util.Locale;
 
 public class LocaleUtils {
-    // Method to check if the localeString matches the 2-letter or 3-letter code
+    // Method to convert the input locale strings into 3-letter codes and compare
     public static boolean matchesLocale(String localeString1, String localeString2) {
-        Locale locale1 = Locale.forLanguageTag(localeString1);
+        String locale1Iso3Language = Locale.forLanguageTag(localeString1).getISO3Language(); // 3-letter code for locale1
+        String locale2Iso3Language = Locale.forLanguageTag(localeString2).getISO3Language(); // 3-letter code for locale2
 
-        // Check if localeString1 (from the object) matches either the 2-letter or 3-letter code of localeString2
-        if (localeString1.length() == 2) {
-            String iso3Language = locale1.getISO3Language(); // 3-letter code for locale1
-            return localeString1.equals(localeString2) || iso3Language.equals(localeString2);
-        } else if (localeString1.length() == 3) {
-            String iso2Language = locale1.getLanguage(); // 2-letter code for locale1
-            return localeString1.equals(localeString2) || iso2Language.equals(localeString2);
-        }
-        return false;
+        return locale1Iso3Language.equals(locale2Iso3Language);
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/CredentialServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialServiceTest.java
@@ -132,6 +132,7 @@ public class CredentialServiceTest {
         Mockito.when(credentialsVerifier.verify(any(String.class), eq(CredentialFormat.LDP_VC))).thenReturn(verificationResult);
         Mockito.when(objectMapper.writeValueAsString(vc.getCredential())).thenReturn("vc");
         Boolean verificationStatus = credentialService.verifyCredential(vc);
+
         assertTrue(verificationStatus);
     }
 
@@ -141,13 +142,13 @@ public class CredentialServiceTest {
         VerificationResult verificationResult = new VerificationResult(false, "Verification failed for the provided credentials", "Verification Failed!");
         Mockito.when(credentialsVerifier.verify(any(String.class), eq(CredentialFormat.LDP_VC))).thenReturn(verificationResult);
         Mockito.when(objectMapper.writeValueAsString(vc.getCredential())).thenReturn("vc");
-        String expetcedExceptionMsg = "verification failed! --> Verification failed for the provided credentials";
+        String expectedExceptionMsg = "verification failed! --> Verification failed for the provided credentials";
 
         VCVerificationException actualException = assertThrows(VCVerificationException.class, () ->
                 credentialService.verifyCredential(vc)
         );
 
-        assertEquals(expetcedExceptionMsg,actualException.getMessage());
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
@@ -20,6 +20,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.PathMatcher;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(MockitoJUnitRunner.class)
 
@@ -33,6 +35,7 @@ public class DataShareServiceTest {
     PathMatcher pathMatcher;
     @InjectMocks
     DataShareServiceImpl dataShareService;
+    PresentationRequestDTO presentationRequestDTO;
 
     @Before
     public void setUp(){
@@ -40,6 +43,8 @@ public class DataShareServiceTest {
         ReflectionTestUtils.setField(dataShareService, "dataShareCreateUrl", "https://test-url");
         ReflectionTestUtils.setField(dataShareService, "dataShareGetUrlPattern", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*");
         ReflectionTestUtils.setField(dataShareService, "maxRetryCount", 1);
+        presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
+        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test")).thenReturn(true);
     }
 
     @Test
@@ -68,41 +73,37 @@ public class DataShareServiceTest {
 
     @Test
     public void downloadCredentialWhenRequestIsProper() throws Exception {
-        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
         VCCredentialResponse vcCredentialResponseDTO = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
         String credentialString = TestUtilities.getObjectAsString(vcCredentialResponseDTO);
         Mockito.when(restApiClient.getApiWithCustomHeaders(Mockito.eq("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test"), Mockito.eq(String.class), Mockito.any(HttpHeaders.class)))
                 .thenReturn(credentialString);
-        Mockito.when(objectMapper.readValue(Mockito.eq(credentialString), Mockito.eq(VCCredentialResponse.class)))
-                        .thenReturn(vcCredentialResponseDTO);
-        Mockito.when(pathMatcher.match(Mockito.eq("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*"),Mockito.eq("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test"))).thenReturn(true);
+        Mockito.when(objectMapper.readValue(credentialString, VCCredentialResponse.class))
+                .thenReturn(vcCredentialResponseDTO);
+
         VCCredentialResponse actualVCCredentialResponse = dataShareService.downloadCredentialFromDataShare(presentationRequestDTO);
+
         Assert.assertEquals(vcCredentialResponseDTO, actualVCCredentialResponse);
     }
 
-    @Test(expected = InvalidCredentialResourceException.class)
-    public void throwServiceUnavailableExceptionWhenCredentialIsNotFetched() throws Exception {
-        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
-        dataShareService.downloadCredentialFromDataShare(presentationRequestDTO);
-    }
-
-    @Test(expected = InvalidCredentialResourceException.class)
-    public void throwResourceExpiredExceptionWhenCredentialIsExpired() throws Exception {
-        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
-        VCCredentialResponse vcCredentialResponseDTO = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
-        vcCredentialResponseDTO.setCredential(null);
-        dataShareService.downloadCredentialFromDataShare(presentationRequestDTO);
-
-    }
-
-    @Test(expected = InvalidCredentialResourceException.class)
-    public void throwInvalidResourceExceptionWhenResourceURLDoesnotMatchPattern() throws Exception {
-        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
+    @Test
+    public void throwInvalidResourceExceptionWhenResourceURLDoesNotMatchPattern() {
         presentationRequestDTO.setResource("test-resource");
-        VCCredentialResponse vcCredentialResponseDTO = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
-        vcCredentialResponseDTO.setCredential(null);
-        dataShareService.downloadCredentialFromDataShare(presentationRequestDTO);
+        String expectedExceptionMsg = "invalid_resource --> The requested resource is invalid.";
 
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
+    }
+
+    @Test
+    public void throwInvalidResourceExceptionOnDownloadingCredentialFromDataShareFailure() {
+        Mockito.when(restApiClient.getApiWithCustomHeaders(Mockito.eq("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test"), Mockito.eq(String.class), Mockito.any(HttpHeaders.class)))
+                .thenReturn(null);
+        String expectedExceptionMsg = "server_unavailable --> The server is not reachable right now.";
+
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
     }
 
 }

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -3,10 +3,7 @@ package io.mosip.mimoto.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
-import io.mosip.mimoto.dto.openid.presentation.PresentationDefinitionDTO;
 import io.mosip.mimoto.dto.openid.presentation.PresentationRequestDTO;
-import io.mosip.mimoto.exception.ApiNotAccessibleException;
-import io.mosip.mimoto.exception.InvalidVerifierException;
 import io.mosip.mimoto.exception.VPNotCreatedException;
 import io.mosip.mimoto.service.impl.DataShareServiceImpl;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
@@ -46,25 +43,23 @@ public class PresentationServiceTest {
         ReflectionTestUtils.setField(presentationService, "maximumResponseHeaderSize", 65536);
         when(objectMapper.writeValueAsString(any())).thenReturn("test-data");
     }
+
     @Test
     public void credentialProofMatchingWithVPRequest() throws Exception {
-
         VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
         PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
-
         when(dataShareService.downloadCredentialFromDataShare(eq(presentationRequestDTO))).thenReturn(vcCredentialResponse);
+        String expectedRedirectUrl = "test_redirect_uri#vp_token=dGVzdC1kYXRh&presentation_submission=test-data";
 
         String actualRedirectUrl = presentationService.authorizePresentation(TestUtilities.getPresentationRequestDTO());
-        String expectedRedirectUrl = "test_redirect_uri#vp_token=dGVzdC1kYXRh&presentation_submission=test-data";
 
         assertEquals(expectedRedirectUrl, actualRedirectUrl);
     }
 
     @Test(expected = VPNotCreatedException.class)
-    public void credentialProofMismatchWithVPRequest() throws ApiNotAccessibleException, IOException {
+    public void credentialProofMismatchWithVPRequest() throws IOException {
         VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("RSASignature2020");
         PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
-
         when(dataShareService.downloadCredentialFromDataShare(eq(presentationRequestDTO))).thenReturn(vcCredentialResponse);
 
         presentationService.authorizePresentation(TestUtilities.getPresentationRequestDTO());

--- a/src/test/java/io/mosip/mimoto/util/TestUtilities.java
+++ b/src/test/java/io/mosip/mimoto/util/TestUtilities.java
@@ -56,7 +56,7 @@ public class TestUtilities {
 
         CredentialDefinitionResponseDto credentialDefinitionResponseDto = new CredentialDefinitionResponseDto();
         credentialDefinitionResponseDto.setType(List.of("VerifiableCredential", credentialSupportedName));
-        credentialDefinitionResponseDto.setCredentialSubject(Map.of("name", credentialDisplayResponseDtoForName,"email", credentialDisplayResponseDtoForEmail));
+        credentialDefinitionResponseDto.setCredentialSubject(Map.of("name", credentialDisplayResponseDtoForName, "email", credentialDisplayResponseDtoForEmail));
         CredentialsSupportedResponse credentialsSupportedResponse = new CredentialsSupportedResponse();
         credentialsSupportedResponse.setFormat("ldp_vc");
         credentialsSupportedResponse.setScope(credentialSupportedName + "_vc_ldp");
@@ -272,6 +272,14 @@ public class TestUtilities {
                 .credential(getVCCredentialPropertiesDTO(type))
                 .format("ldp_vc").build();
     }
+
+    public static DataShareResponseDto getDataShareResponseDTO(String errorCode) {
+        return DataShareResponseDto.builder()
+                .dataShare(new DataShare())
+                .errors(List.of(new ErrorDTO(errorCode == "" ? "Expired!" : errorCode, "Download is failed as credential is expired")))
+                .build();
+    }
+
 
     public static io.mosip.mimoto.dto.idp.TokenResponseDTO getTokenResponseDTO() {
         return io.mosip.mimoto.dto.idp.TokenResponseDTO.builder()


### PR DESCRIPTION
- Remove the deprecation annotations for /issuers/issuer-id config as it will be used by inji web again to get the specific issuer config

- Made changes in CredentialsController error response as the error code is being included in the end exception message twice.

- Written and updated test cases for Credential controller, DataShare service files

- Handled the different edge cases in downloading and generating the PDF with the request credentials based on whether the locale is sent or not in the download request.
**use cases:**

- If the locale is not sent in the request then we will use the properties of the first display object of the credential type
fetched from issuers well-known:

1. If the downloaded / received response also has the credential info in the same lang for the fields then we will show both the field name and field value in the generated pdf.
2. If the downloaded / received response doesn't has info in the same language then we will show field name alone and for the value we show empty string in the generated pdf.

- If the locale is not passed and no display object is available in the issuers well-known then we won't show any field and its value in the generated pdf.