### PR TITLE
MOSIP-39719 - Added a log level for the commons classes

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.1</version>
+			<version>1.3.2-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/testrunner/MosipTestRunner.java
@@ -26,6 +26,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import io.mosip.testrig.apirig.dataprovider.BiometricDataProvider;
 import io.mosip.testrig.apirig.dbaccess.DBManager;
 import io.mosip.testrig.apirig.mimoto.utils.MimotoConfigManager;
+import io.mosip.testrig.apirig.mimoto.utils.MimotoUtil;
 import io.mosip.testrig.apirig.report.EmailableReport;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.ExtractResource;
@@ -36,6 +37,7 @@ import io.mosip.testrig.apirig.utils.AuthTestsUtil;
 import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
+import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
 import io.mosip.testrig.apirig.utils.KeycloakUserManager;
 import io.mosip.testrig.apirig.utils.MispPartnerAndLicenseKeyGeneration;
@@ -65,12 +67,8 @@ public class MosipTestRunner {
 	public static void main(String[] arg) {
 
 		try {
-
-			Map<String, String> envMap = System.getenv();
-			LOGGER.info("** ------------- Get ALL ENV varibales --------------------------------------------- **");
-			for (String envName : envMap.keySet()) {
-				LOGGER.info(String.format("ENV %s = %s%n", envName, envMap.get(envName)));
-			}
+			LOGGER.info("** ------------- API Test Rig Run Started --------------------------------------------- **");
+			
 			BaseTestCase.setRunContext(getRunType(), jarUrl);
 			ExtractResource.removeOldMosipTestTestResource();
 			if (getRunType().equalsIgnoreCase("JAR")) {
@@ -154,6 +152,9 @@ public class MosipTestRunner {
 		MispPartnerAndLicenseKeyGeneration.setLogLevel();
 		JWKKeyUtil.setLogLevel();
 		CertsUtil.setLogLevel();
+		KernelAuthentication.setLogLevel();
+		BaseTestCase.setLogLevel();
+		MimotoUtil.setLogLevel();
 	}
 
 	/**

--- a/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/testrunner/MosipTestRunner.java
@@ -36,6 +36,7 @@ import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthTestsUtil;
 import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.GlobalMethods;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
 import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
@@ -80,6 +81,7 @@ public class MosipTestRunner {
 			MimotoConfigManager.init();
 			suiteSetup(getRunType());
 			SkipTestCaseHandler.loadTestcaseToBeSkippedList("testCaseSkippedList.txt");
+			GlobalMethods.setModuleNameAndReCompilePattern(MimotoConfigManager.getproperty("moduleNamePattern"));
 			setLogLevels();
 
 			// For now we are not doing health check for qa-115.

--- a/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoConfigManager.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoConfigManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import io.mosip.testrig.apirig.mimoto.testrunner.MosipTestRunner;
@@ -13,6 +14,9 @@ public class MimotoConfigManager extends ConfigManager{
 	private static final Logger LOGGER = Logger.getLogger(MimotoConfigManager.class);
 	
 	public static void init() {
+		Logger configManagerLogger = Logger.getLogger(ConfigManager.class);
+		configManagerLogger.setLevel(Level.WARN);
+		
 		Map<String, Object> moduleSpecificPropertiesMap = new HashMap<>();
 		// Load scope specific properties
 		try {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoUtil.java
@@ -6,6 +6,7 @@ import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 import java.util.HashMap;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.json.JSONObject;
@@ -23,6 +24,13 @@ public class MimotoUtil extends AdminTestUtil {
 
 	private static final Logger logger = Logger.getLogger(MimotoUtil.class);
 	private static String otpEnabled = "true";
+	
+	public static void setLogLevel() {
+		if (MimotoConfigManager.IsDebugEnabled())
+			logger.setLevel(Level.ALL);
+		else
+			logger.setLevel(Level.ERROR);
+	}
 
 	public static String isOTPEnabled() {
 		String value = getValueFromMimotoActuator("/mimoto-default.properties", "mosip.otp.download.enable").isBlank()


### PR DESCRIPTION
The setLogLevel method was added to the commons classes to prevent sensitive information, like secrets, from being printed in the console logs.