### PR TITLE
[Injiweb 1436] update the logic of generating the pdf based on the received locale

### DIFF
--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
@@ -180,11 +180,12 @@ public class CredentialServiceImpl implements CredentialService {
     }
 
     @NotNull
-    private static LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> loadDisplayPropertiesFromWellknown(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse, String locale) {
+    private static LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> loadDisplayPropertiesFromWellknown(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse, String userLocale) {
         LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties = new LinkedHashMap<>();
         Map<String, Object> credentialProperties = vcCredentialResponse.getCredential().getCredentialSubject();
         LinkedHashMap<String, CredentialIssuerDisplayResponse> vcPropertiesFromWellKnown = new LinkedHashMap<>();
         Map<String, CredentialDisplayResponseDto> credentialSubject = credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject();
+        String locale = LocaleUtils.resolveLocaleWithFallback(credentialSubject,  userLocale);
         credentialSubject.keySet().forEach(VCProperty -> {
             Optional<CredentialIssuerDisplayResponse> filteredResponse = credentialSubject.get(VCProperty)
                     .getDisplay().stream()

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
@@ -185,18 +185,20 @@ public class CredentialServiceImpl implements CredentialService {
         Map<String, Object> credentialProperties = vcCredentialResponse.getCredential().getCredentialSubject();
         LinkedHashMap<String, CredentialIssuerDisplayResponse> vcPropertiesFromWellKnown = new LinkedHashMap<>();
         Map<String, CredentialDisplayResponseDto> credentialSubject = credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject();
-        String locale = LocaleUtils.resolveLocaleWithFallback(credentialSubject,  userLocale);
-        credentialSubject.keySet().forEach(VCProperty -> {
-            Optional<CredentialIssuerDisplayResponse> filteredResponse = credentialSubject.get(VCProperty)
-                    .getDisplay().stream()
-                    .filter(obj -> "undefined".equals(locale) || LocaleUtils.matchesLocale(obj.getLocale(), locale))// if locale is not undefined use it to fetch the wellknown properties otherwise return the properties of the first display object which has language field
-                    .findFirst();
+        String locale = LocaleUtils.resolveLocaleWithFallback(credentialSubject, userLocale);
+        if (locale != null) {
+            credentialSubject.keySet().forEach(VCProperty -> {
+                Optional<CredentialIssuerDisplayResponse> filteredResponse = credentialSubject.get(VCProperty)
+                        .getDisplay().stream()
+                        .filter(obj -> LocaleUtils.matchesLocale(obj.getLocale(), locale))
+                        .findFirst();
 
-            if (filteredResponse.isPresent()) {
-                CredentialIssuerDisplayResponse filteredValue = filteredResponse.get();
-                vcPropertiesFromWellKnown.put(VCProperty, filteredValue);
-            }
-        });
+                if (filteredResponse.isPresent()) {
+                    CredentialIssuerDisplayResponse filteredValue = filteredResponse.get();
+                    vcPropertiesFromWellKnown.put(VCProperty, filteredValue);
+                }
+            });
+        }
 
         List<String> orderProperty = credentialsSupportedResponse.getOrder();
 

--- a/src/main/java/io/mosip/mimoto/util/LocaleUtils.java
+++ b/src/main/java/io/mosip/mimoto/util/LocaleUtils.java
@@ -24,9 +24,13 @@ public class LocaleUtils {
     public static String resolveLocaleWithFallback(Map<String, CredentialDisplayResponseDto> credentialSubject, String locale) {
         String selectedLocale = null;
 
-        // Iterate through the credentials to check if any display object supports the requested locale
+        // Iterate through the credentials to find a display object that supports the requested locale. If none is found, use the first available display object.
         for (String VCProperty : credentialSubject.keySet()) {
             List<CredentialIssuerDisplayResponse> displayList = credentialSubject.get(VCProperty).getDisplay();
+            // If no matching locale is found for any of the fields, use the locale of the first display object
+            if(selectedLocale == null && displayList!=null && !displayList.isEmpty()){
+                selectedLocale = displayList.get(0).getLocale();
+            }
             // Check if any display object supports the requested locale
             Optional<CredentialIssuerDisplayResponse> filteredResponse = displayList.stream()
                     .filter(obj -> matchesLocale(obj.getLocale(), locale))
@@ -36,18 +40,7 @@ public class LocaleUtils {
                 break; // Break once a matching record is found
             }
         }
-        // If no matching locale is found, use the locale of the first display object
-        if (selectedLocale == null) {
-            // Fall back to the locale of the first display object if no matching locale is found
-            for (String VCProperty : credentialSubject.keySet()) {
-                List<CredentialIssuerDisplayResponse> displayList = credentialSubject.get(VCProperty).getDisplay();
-                if (displayList != null && !displayList.isEmpty()) {
-                    // Get the locale of the first display object in the list
-                    selectedLocale = displayList.get(0).getLocale();
-                    break; // Use the first locale and exit the loop
-                }
-            }
-        }
+
         return selectedLocale;
     }
 

--- a/src/main/java/io/mosip/mimoto/util/LocaleUtils.java
+++ b/src/main/java/io/mosip/mimoto/util/LocaleUtils.java
@@ -1,6 +1,12 @@
 package io.mosip.mimoto.util;
 
+import io.mosip.mimoto.dto.mimoto.CredentialDisplayResponseDto;
+import io.mosip.mimoto.dto.mimoto.CredentialIssuerDisplayResponse;
+
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 
 public class LocaleUtils {
     // Method to convert the input locale strings into 3-letter codes and compare
@@ -14,4 +20,35 @@ public class LocaleUtils {
 
         return locale1Iso3Language.equals(locale2Iso3Language);
     }
+
+    public static String resolveLocaleWithFallback(Map<String, CredentialDisplayResponseDto> credentialSubject, String locale) {
+        String selectedLocale = null;
+
+        // Iterate through the credentials to check if any display object supports the requested locale
+        for (String VCProperty : credentialSubject.keySet()) {
+            List<CredentialIssuerDisplayResponse> displayList = credentialSubject.get(VCProperty).getDisplay();
+            // Check if any display object supports the requested locale
+            Optional<CredentialIssuerDisplayResponse> filteredResponse = displayList.stream()
+                    .filter(obj -> matchesLocale(obj.getLocale(), locale))
+                    .findFirst();
+            if (filteredResponse.isPresent()) {
+                selectedLocale = filteredResponse.get().getLocale();
+                break; // Break once a matching record is found
+            }
+        }
+        // If no matching locale is found, use the locale of the first display object
+        if (selectedLocale == null) {
+            // Fall back to the locale of the first display object if no matching locale is found
+            for (String VCProperty : credentialSubject.keySet()) {
+                List<CredentialIssuerDisplayResponse> displayList = credentialSubject.get(VCProperty).getDisplay();
+                if (displayList != null && !displayList.isEmpty()) {
+                    // Get the locale of the first display object in the list
+                    selectedLocale = displayList.get(0).getLocale();
+                    break; // Use the first locale and exit the loop
+                }
+            }
+        }
+        return selectedLocale;
+    }
+
 }


### PR DESCRIPTION
- Updated the logic of iterating through the downloaded vc credential subject fields and checking if any of the fields has support for received locale(input) otherwise use the first display object locale for displaying all the fields in the PDF.