### PR TITLE
[INJIMOB-3055]: Data Encoding issue Fix for Land Registry

### DIFF
--- a/src/main/java/io/mosip/mimoto/util/ObjectMapperCustomizer.java
+++ b/src/main/java/io/mosip/mimoto/util/ObjectMapperCustomizer.java
@@ -1,0 +1,15 @@
+package io.mosip.mimoto.util;
+
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperCustomizer {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer customizeJackson() {
+        return builder -> builder.featuresToEnable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature());
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -224,10 +224,10 @@ mosip.inji.ovp.redirect.url.pattern=%s#vp_token=%s&presentation_submission=%s
 mosip.inji.ovp.error.redirect.url.pattern=%s?error=%s&error_description=%s
 
 #DataShare Config
-mosip.data.share.url=https://datashare-inji.dev1.mosip.net
+mosip.data.share.url=http://localhost:8097
 mosip.data.share.create.url=${mosip.data.share.url}/v1/datashare/create/static-policyid/static-subscriberid
 mosip.data.share.create.retry.count=3
-mosip.data.share.get.url.pattern=http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*
+mosip.data.share.get.url.pattern=${mosip.data.share.url}/v1/datashare/get/static-policyid/static-subscriberid/*
 
 mosip.security.cors-enable=true
 #comma separated allowed origins


### PR DESCRIPTION
- Enabling Escape Non Ascii feature while encoding the data for Jackson Library's Object Mapper.

[INJIMOB-3055](https://mosip.atlassian.net/browse/INJIMOB-3055)

[INJIMOB-3055]: https://mosip.atlassian.net/browse/INJIMOB-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ