### PR TITLE
 [INJIWEB-1471]: Data Encoding issue Fix for Land Registry 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
         <dependency>
             <groupId>io.mosip</groupId>
             <artifactId>pixelpass-jar</artifactId>
-            <version>0.5.0</version>
+            <version>0.7.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -224,10 +224,10 @@ mosip.inji.ovp.redirect.url.pattern=%s#vp_token=%s&presentation_submission=%s
 mosip.inji.ovp.error.redirect.url.pattern=%s?error=%s&error_description=%s
 
 #DataShare Config
-mosip.data.share.url=https://datashare-inji.dev1.mosip.net
+mosip.data.share.url=http://localhost:8097
 mosip.data.share.create.url=${mosip.data.share.url}/v1/datashare/create/static-policyid/static-subscriberid
 mosip.data.share.create.retry.count=3
-mosip.data.share.get.url.pattern=http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*
+mosip.data.share.get.url.pattern=${mosip.data.share.url}/v1/datashare/get/static-policyid/static-subscriberid/*
 
 mosip.security.cors-enable=true
 #comma separated allowed origins


### PR DESCRIPTION
- Update Pixelpass version to 0.7.0-SNAPSHOT in which BigDecimal case is handled

[INJIWEB-1471](https://mosip.atlassian.net/browse/INJIWEB-1471)

[INJIWEB-1471]: https://mosip.atlassian.net/browse/INJIWEB-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ