### PR TITLE
[INJIWEB-1430]: Remove QRCodeWriter and use kmp pixelpass artifact for generating QR Code 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
         <googlecode.json-simple.version>1.1.1</googlecode.json-simple.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <jwt.version> 3.8.1</jwt.version>
-        <google.zxing.version>3.3.3</google.zxing.version>
         <itextcore.version>8.0.3</itextcore.version>
         <itexthtml2pdf.version>5.0.3</itexthtml2pdf.version>
         <itext.version>5.5.13</itext.version>
@@ -408,11 +407,6 @@
             <groupId>com.itextpdf.tool</groupId>
             <artifactId>xmlworker</artifactId>
             <version>${itext.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.zxing</groupId>
-            <artifactId>javase</artifactId>
-            <version>${google.zxing.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
@@ -11,13 +11,11 @@ import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.*;
 import io.mosip.mimoto.dto.openid.presentation.PresentationDefinitionDTO;
 import io.mosip.mimoto.exception.*;
-import io.mosip.mimoto.model.SigningAlgorithm;
 import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.service.CredentialService;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.*;
 import io.mosip.pixelpass.PixelPass;
-import io.mosip.pixelpass.exception.QrDataOverflowException;
 import io.mosip.pixelpass.types.ECC;
 import io.mosip.vercred.vcverifier.CredentialsVerifier;
 import jakarta.annotation.PostConstruct;
@@ -29,7 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -255,13 +252,7 @@ public class CredentialServiceImpl implements CredentialService {
     }
 
     private String constructQRCodeWithVCData(VCCredentialResponse vcCredentialResponse) throws JsonProcessingException {
-        try {
-            String qrData = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
-            return pixelPass.generateQRCodeWithinLimit(allowedQRDataSizeLimit, qrData, DEFAULT_ECC_LEVEL, "");
-        } catch (QrDataOverflowException e) {
-            log.warn("QR data exceeds the allowed limit", allowedQRDataSizeLimit);
-            return "";
-        }
+        return pixelPass.generateQRCode(objectMapper.writeValueAsString(vcCredentialResponse.getCredential()), DEFAULT_ECC_LEVEL, "");
     }
 
     private String constructQRCodeWithAuthorizeRequest(VCCredentialResponse vcCredentialResponse, String dataShareUrl) throws JsonProcessingException {


### PR DESCRIPTION
[INJIWEB-1430](https://mosip.atlassian.net/browse/INJIWEB-1430) - Adapting KMP pixelpass artifacts in mimoto.

Changes Done:
- Removed QRWriter and zxing dependecnies to construct QR Code Image.
- Using Pixelpass for generating QR code image for both OnlineSharing and EmbeddedVC.

[INJIWEB-1430]: https://mosip.atlassian.net/browse/INJIWEB-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ