### PR TITLE
MOSIP-40924 - Remove faker pom dependency from mimoto release branch.

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -58,11 +58,6 @@
 			<artifactId>apitest-commons</artifactId>
 			<version>1.3.2-SNAPSHOT</version>
 		</dependency>
-		<dependency>
-			<groupId>com.github.javafaker</groupId>
-			<artifactId>javafaker</artifactId>
-			<version>1.0.2</version>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
- Remove faker pom dependency from mimoto release branch as it is moved to commons pom.