### PR TITLE
[Injiweb 1418] fix download issue observed for certain issuer

### DIFF
--- a/src/main/java/io/mosip/mimoto/repository/WalletCredentialsRepository.java
+++ b/src/main/java/io/mosip/mimoto/repository/WalletCredentialsRepository.java
@@ -13,7 +13,6 @@ public interface WalletCredentialsRepository extends JpaRepository<VerifiableCre
     List<VerifiableCredential> findByWalletId(String walletId);
     Optional<VerifiableCredential> findById(String id);
 
-    @Query(value = "SELECT EXISTS (SELECT 1 FROM verifiable_credentials WHERE credential_metadata->>'issuerId' = :issuerId AND credential_metadata->>'credentialType' = :credentialType)", nativeQuery = true)
-    boolean existsByIssuerIdAndCredentialType(@Param("issuerId") String issuerId, @Param("credentialType") String credentialType);
-
+    @Query(value = "SELECT EXISTS (SELECT 1 FROM verifiable_credentials WHERE credential_metadata->>'issuerId' = :issuerId AND credential_metadata->>'credentialType' = :credentialType AND wallet_id = :walletId)", nativeQuery = true)
+    boolean existsByIssuerIdAndCredentialTypeAndWalletId(@Param("issuerId") String issuerId, @Param("credentialType") String credentialType, @Param("walletId") String walletId);
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletCredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletCredentialServiceImpl.java
@@ -88,7 +88,7 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
             String issuerId, String credentialType, TokenResponseDTO response,
             String credentialValidity, String locale, String walletId, String base64EncodedWalletKey) throws Exception {
 
-        shouldInitiateDownloadRequest(issuerId,credentialType);
+        shouldInitiateDownloadRequest(issuerId, credentialType, walletId);
 
         IssuerDTO issuerDTO = issuersService.getIssuerDetails(issuerId);
         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = getIssuerWellKnownResponse(issuerId);
@@ -104,15 +104,15 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
         return WalletCredentialResponseDTOFactory.buildCredentialResponseDTO(issuerDTO, credentialsSupportedResponse, locale, savedCredential.getId());
     }
 
-    private void shouldInitiateDownloadRequest(String issuerId, String credentialType) {
+    private void shouldInitiateDownloadRequest(String issuerId, String credentialType, String walletId) {
         Set<String> issuers = Set.of("Mosip");
-        if (issuers.contains(issuerId) && alreadyDownloaded(issuerId, credentialType)) {
+        if (issuers.contains(issuerId) && alreadyDownloaded(issuerId, credentialType, walletId)) {
             throw new RuntimeException("A credential is already downloaded for the selected Issuer and Credential Type. Only one is allowed, so download will not be initiated");
         }
     }
 
-    private boolean alreadyDownloaded(String issuerId, String credentialType) {
-        return walletCredentialsRepository.existsByIssuerIdAndCredentialType(issuerId, credentialType);
+    private boolean alreadyDownloaded(String issuerId, String credentialType, String walletId) {
+        return walletCredentialsRepository.existsByIssuerIdAndCredentialTypeAndWalletId(issuerId, credentialType, walletId);
     }
 
     @Override

--- a/src/test/java/io/mosip/mimoto/service/WalletCredentialServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/WalletCredentialServiceTest.java
@@ -110,7 +110,7 @@ public class WalletCredentialServiceTest {
 
     @Test
     public void shouldThrowExceptionWhenDuplicateCredentialExists() {
-        when(walletCredentialsRepository.existsByIssuerIdAndCredentialType("Mosip", credentialType)).thenReturn(true);
+        when(walletCredentialsRepository.existsByIssuerIdAndCredentialTypeAndWalletId("Mosip", credentialType, walletId)).thenReturn(true);
 
         RuntimeException exception = assertThrows(RuntimeException.class, () ->
                 walletCredentialService.fetchAndStoreCredential("Mosip", credentialType, tokenResponse, "1", "en", walletId, base64Key)


### PR DESCRIPTION
- We were not allowing the user to download a new credential if a VC is already downloaded for the same issuer and credentialType combination but this doesn't allow the user to download VC in another wallet or by using another account. So fixed this and now we will check whether we should allow or not by using issuer and credential type and walletId combination . Per wallet only one credential can be downloaded for the same issuer and credential Type (only for mosip issuer right now).