### PR TITLE
MOSIP-41420 - Updated the apitest commons version and fixed the build failure

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.2-SNAPSHOT</version>
+			<version>1.3.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
MOSIP-41420 - Updated the apitest commons version and fixed the build failure