### PR TITLE
MOSIP-41593 - Update mimoto testrig to support latest esignet 1.5.1 and above

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoConstants.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoConstants.java
@@ -1,0 +1,9 @@
+package io.mosip.testrig.apirig.mimoto.utils;
+
+public class MimotoConstants {
+	
+	public static final String SUNBIRD_INSURANCE_AUTH_FACTOR_TYPE = "KBI";
+	
+	public static final String SUNBIRD_INSURANCE_AUTH_FACTOR_TYPE_STRING = "sunbirdInsuranceAuthFactorType";
+
+}

--- a/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/utils/MimotoUtil.java
@@ -6,6 +6,7 @@ import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
 import java.util.HashMap;
 
 import javax.ws.rs.core.MediaType;
@@ -159,6 +160,22 @@ public class MimotoUtil extends AdminTestUtil {
 		
 		if (jsonString.contains(GlobalConstants.TIMESTAMP)) {
 			jsonString = replaceKeywordValue(jsonString, GlobalConstants.TIMESTAMP, generateCurrentUTCTimeStamp());
+		}
+		
+		if (jsonString.contains("$UNIQUENONCEVALUEFORESIGNET$")) {
+			jsonString = replaceKeywordValue(jsonString, "$UNIQUENONCEVALUEFORESIGNET$",
+					String.valueOf(Calendar.getInstance().getTimeInMillis()));
+		}
+
+		if (jsonString.contains("$SUNBIRDINSURANCEAUTHFACTORTYPE$")) {
+			String authFactorType = MimotoConfigManager
+					.getproperty(MimotoConstants.SUNBIRD_INSURANCE_AUTH_FACTOR_TYPE_STRING);
+
+			String valueToReplace = (authFactorType != null && !authFactorType.isBlank()) ? authFactorType
+					: MimotoConstants.SUNBIRD_INSURANCE_AUTH_FACTOR_TYPE;
+
+			jsonString = replaceKeywordValue(jsonString, "$SUNBIRDINSURANCEAUTHFACTORTYPE$", valueToReplace);
+
 		}
 		
 		if (jsonString.contains("$POLICYNUMBERFORSUNBIRDRC$")) {

--- a/api-test/src/main/resources/config/mimoto.properties
+++ b/api-test/src/main/resources/config/mimoto.properties
@@ -4,3 +4,7 @@ mimoto-oidc-mosipid-partner-clientid=mimoto.oidc.mosipid.partner.clientid
 mimoto-oidc-sunbird-partner-clientid=mimoto.oidc.insurance.partner.clientid
 mosip-esignet-insurance-host=mosip.esignet.insurance.host
 runPlugin=mosipid
+
+
+# Uncomment the line below if the eSignet version is older than 1.5.1 for compatibility
+#sunbirdInsuranceAuthFactorType=KBA

--- a/api-test/src/main/resources/mimoto/OAuthDetailsRequest/OAuthDetailsRequest.yml
+++ b/api-test/src/main/resources/mimoto/OAuthDetailsRequest/OAuthDetailsRequest.yml
@@ -17,7 +17,7 @@ OAuthDetailsRequest:
       	"display": "popup",
 	    "prompt": "login",
 	    "acrValues": "mosip:idp:acr:generated-code mosip:idp:acr:linked-wallet mosip:idp:acr:biometrics",
-	    "nonce": "973eieljzng",
+	    "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
 	    "state": "eree2311",
 	    "claimsLocales": "en",
 	    "codeChallenge": "$CODECHALLENGE$",

--- a/api-test/src/main/resources/mimoto/SunBirdC/AuthenticateUserSunBirdC/AuthenticateUserSunBirdC.yml
+++ b/api-test/src/main/resources/mimoto/SunBirdC/AuthenticateUserSunBirdC/AuthenticateUserSunBirdC.yml
@@ -14,7 +14,7 @@ AuthenticateUserSunBirdC:
       	"requestTime": "$TIMESTAMP$",
       	"transactionId": "$ID:ESignet_OAuthDetailsRequest_SunBirdC_all_Valid_Smoke_sid_transactionId$",
       	"individualId": "$POLICYNUMBERFORSUNBIRDRC$",
-      	"authFactorType" : "KBA",
+      	"authFactorType" : "$SUNBIRDINSURANCEAUTHFACTORTYPE$",
       	"challenge" : "$CHALLENGEVALUEFORSUNBIRDC$",
       	"format": "base64url-encoded-json"
     }'

--- a/api-test/src/main/resources/mimoto/SunBirdC/OAuthDetailsRequestSunBirdC/OAuthDetailsRequestSunBirdC.yml
+++ b/api-test/src/main/resources/mimoto/SunBirdC/OAuthDetailsRequestSunBirdC/OAuthDetailsRequestSunBirdC.yml
@@ -17,7 +17,7 @@ OAuthDetailsRequestSunBirdC:
       	"display": "popup",
 	    "prompt": "login",
 	    "acrValues": "mosip:idp:acr:knowledge",
-	    "nonce": "973eieljzng",
+	    "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
 	    "state": "eree2311",
 	    "claimsLocales": "en",
 	    "codeChallenge": "$CODECHALLENGE$",


### PR DESCRIPTION
- Added mimotoConstants class.
- Added Sunbird auth factor type as configurable for esignet backward compatibility.
- Generate new random string for oauth details API nonce field.