### PR TITLE
[INJIWEB-1533] update the logic of delete wallet api to reset wallet correctly in different scenarios

### DIFF
--- a/docs/api-documentation-openapi.json
+++ b/docs/api-documentation-openapi.json
@@ -2869,13 +2869,13 @@
                                             "errorMessage": "Locale must be a 2-letter code"
                                         }
                                     },
-                                    "Invalid Wallet Id": {
+                                    "Invalid Wallet ID": {
                                         "value": {
                                             "errorCode": "invalid_request",
                                             "errorMessage": "Invalid Wallet ID. Session and request Wallet ID do not match"
                                         }
                                     },
-                                    "Wallet Id not found in session": {
+                                    "Wallet ID not found in session": {
                                         "value": {
                                             "errorCode": "wallet_locked",
                                             "errorMessage": "Wallet is locked"
@@ -3686,8 +3686,8 @@
                 "tags": [
                     "Wallets"
                 ],
-                "summary": "Delete a wallet",
-                "description": "This endpoint allows you to delete a specific wallet. The API is secured using session-based authentication. The session ID is extracted from the Cookie header to authenticate the user. The user's ID is obtained from the session and used to validate ownership of the wallet before deletion. If the wallet is successfully deleted, a 200 OK response is returned.",
+                "summary": "Delete a Wallet",
+                "description": "This endpoint allows you to delete a specific wallet. The API is secured using session-based authentication. The session ID is extracted from the Cookie header to authenticate the user. The user's ID is obtained from the session and used to validate ownership of the Wallet before deletion. If the Wallet is successfully deleted, a 200 OK response is returned; otherwise, an appropriate error response is returned.",
                 "operationId": "deleteWallet",
                 "security": [
                     {
@@ -3702,7 +3702,7 @@
                         "schema": {
                             "type": "string"
                         },
-                        "description": "Unique identifier of the wallet to be deleted"
+                        "description": "Unique identifier of the Wallet to be deleted"
                     }
                 ],
                 "responses": {
@@ -3710,14 +3710,14 @@
                         "description": "Wallet successfully deleted"
                     },
                     "401": {
-                        "description": "Unauthorized user deleting a wallet",
+                        "description": "Unauthorized user deleting a Wallet",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/Error"
                                 },
                                 "examples": {
-                                    "User ID is not present in session": {
+                                    "User ID not found in session": {
                                         "value": {
                                             "errorCode": "unauthorized",
                                             "errorMessage": "User ID not found in session"
@@ -3741,7 +3741,19 @@
                                             "errorMessage": "User ID cannot be null or empty"
                                         }
                                     },
-                                    "Wallet not found": {
+                                    "Invalid Wallet ID": {
+                                        "value": {
+                                            "errorCode": "invalid_request",
+                                            "errorMessage": "Invalid Wallet ID. Session and request Wallet ID do not match"
+                                        }
+                                    },
+                                    "Wallet ID not found in session": {
+                                        "value": {
+                                            "errorCode": "wallet_locked",
+                                            "errorMessage": "Wallet is locked"
+                                        }
+                                    },
+                                    "Wallet not found in database": {
                                         "value": {
                                             "errorCode": "invalid_request",
                                             "errorMessage": "Wallet not found"

--- a/src/main/java/io/mosip/mimoto/constant/SwaggerLiteralConstants.java
+++ b/src/main/java/io/mosip/mimoto/constant/SwaggerLiteralConstants.java
@@ -84,8 +84,8 @@ public class SwaggerLiteralConstants {
 
     public static final String WALLETS_NAME = "Wallets";
     public static final String WALLETS_DESCRIPTION = "All the Wallet related endpoints";
-    public static final String WALLETS_DELETE_SUMMARY = "Delete a wallet";
-    public static final String WALLETS_DELETE_DESCRIPTION = "This endpoint allows you to delete a specific wallet";
+    public static final String WALLETS_DELETE_SUMMARY = "Delete a Wallet";
+    public static final String WALLETS_DELETE_DESCRIPTION = "This endpoint allows you to delete a specific wallet. The API is secured using session-based authentication. The session ID is extracted from the Cookie header to authenticate the user. The user's ID is obtained from the session and used to validate ownership of the Wallet before deletion. If the Wallet is successfully deleted, a 200 OK response is returned; otherwise, an appropriate error response is returned.";
 
     /* Wallet Credentials Controller */
     public static final String WALLET_CREDENTIALS_NAME = "Wallet Credentials";

--- a/src/main/java/io/mosip/mimoto/controller/WalletCredentialsController.java
+++ b/src/main/java/io/mosip/mimoto/controller/WalletCredentialsController.java
@@ -91,9 +91,9 @@ public class WalletCredentialsController {
     @ApiResponse(responseCode = "200", description = "Verifiable Credential downloaded and stored successfully", content = @Content(mediaType = "application/json", schema = @Schema(implementation = VerifiableCredentialResponseDTO.class)))
     @ApiResponse(responseCode = "400", description = "Bad request - Wallet key is null / blank or Wallet ID is null / blank / mismatch with session Wallet ID or required params are missing / invalid", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorDTO.class), examples = {
             @ExampleObject(name = "Invalid header Accept-Language", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"Locale must be a 2-letter code\"}"),
-            @ExampleObject(name = "Wallet Id is empty or blank", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"Wallet ID cannot be blank\"}"),
+            @ExampleObject(name = "Wallet ID is empty or blank", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"Wallet ID cannot be blank\"}"),
             @ExampleObject(name = "Wallet ID not found in session", value = "{\"errorCode\": \"wallet_locked\", \"errorMessage\": \"Wallet is locked\"}"),
-            @ExampleObject(name = "Invalid Wallet Id", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"Invalid Wallet ID. Session and request Wallet ID do not match\"}"),
+            @ExampleObject(name = "Invalid Wallet ID", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"Invalid Wallet ID. Session and request Wallet ID do not match\"}"),
             @ExampleObject(name = "Wallet key not found in session", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"Wallet key not found in session\"}"),
             @ExampleObject(name = "Invalid issuer", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"issuerId cannot be blank\"}"),
             @ExampleObject(name = "Invalid credentialConfigurationId", value = "{\"errorCode\": \"invalid_request\", \"errorMessage\": \"credentialConfigurationId cannot be blank\"}")}))


### PR DESCRIPTION
Updated the logic of delete wallet api to reset wallet only if the request is sent with correct walletId after unlocking the wallet and updated some messages in swagger annotation to keep it consistent with api json file