### PR TITLE
[Injiweb 1645] fix verification issue observed for the VCs downloaded in login flow

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -23,6 +23,8 @@ fileignoreconfig:
   checksum: 81b14da4f42f335cf6a3094489844962b92fc629c89691487558c71c3d44a915
 - filename: src/main/java/io/mosip/mimoto/controller/CredentialShareController.java
   checksum: 666c22ca63adb8770de901e220f8efeb5ec1d3f63064a58dea33ba49b8e15872
+- filename: src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+  checksum: b04c0ff467788706b21b1576db06f1482c5d1684744fb0e6c4236aa61037c8aa
 - filename: src/main/java/io/mosip/mimoto/controller/IssuersController.java
   checksum: 856d860de2562fa019ac23bd724b84e1d67b834883b332c12415e6714de9bb05
 - filename: helm/mimoto/templates/deployment.yaml

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -147,8 +147,21 @@ public class CredentialPDFGeneratorService {
                             });
 
                 });
-        String qrCodeImage = QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type()) ? constructQRCodeWithAuthorizeRequest(vcCredentialResponse, dataShareUrl) :
-                QRCodeType.EmbeddedVC.equals(issuerDTO.getQr_code_type()) ? constructQRCodeWithVCData(vcCredentialResponse) : "";
+
+        String qrCodeImage;
+        if (QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type())) {
+            // Login flow
+            if (dataShareUrl.isEmpty()) {
+                qrCodeImage = constructQRCodeWithVCData(vcCredentialResponse);
+            } else {
+                qrCodeImage = constructQRCodeWithAuthorizeRequest(vcCredentialResponse, dataShareUrl);
+            }
+        } else if (QRCodeType.EmbeddedVC.equals(issuerDTO.getQr_code_type())) {
+            qrCodeImage = constructQRCodeWithVCData(vcCredentialResponse);
+        } else {
+            qrCodeImage = "";
+        }
+
         data.put("qrCodeImage", qrCodeImage);
         data.put("credentialValidity", credentialValidity);
         data.put("logoUrl", issuerDTO.getDisplay().stream().map(d -> d.getLogo().getUrl()).findFirst().orElse(""));


### PR DESCRIPTION
- For the VCs downloaded in the Login flow we are not storing them into the dataShare so we won't be having dataShareUrl to use it for sharing it to the Verifier for verification so for now for the VCs downloaded in the Login flow we are not going to include OpenId4VP authorization request in the downloaded PDF even if the **qrCodeType** is set to **onlineSharing** for the selected issuer. So as part of this PR made changes to embed the whole VC into the qr code image of the downloaded PDF instead of OpenId4VP authorization request.