### PR TITLE
[Injiweb 1662] fix compatability issue occuring between develop and release branch related to properties stored in the wallet metadata 

### DIFF
--- a/src/main/java/io/mosip/mimoto/model/WalletMetadata.java
+++ b/src/main/java/io/mosip/mimoto/model/WalletMetadata.java
@@ -1,8 +1,10 @@
 package io.mosip.mimoto.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WalletMetadata {
 
     private String encryptionAlgo;


### PR DESCRIPTION
- As part of [Injiweb-1627 ](https://mosip.atlassian.net/browse/INJIWEB-1627) we have added implementation for Wallet passcode retry flow and this adds new properties like **lockStatus** and **passcodeControl** into the wallet_metadata column of wallet table. But this changes are taken into develop branch alone and not into release branch so in release branch when fetching Wallets from the Database which are having these new properties the code is throwing error saying it couldn’t deserialize these unknown properties **lockStatus** and **passcodeControl**. So made changes in WalletMetadata class to ignore the unknown properties.