### PR TITLE
MOSIP-42984: Update api test commons in mimoto api test rig

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.2.1-SNAPSHOT</version>
+			<version>1.3.3</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Updated api test commons version to 1.3.3 in release branch 0.19.x for mimoto test rigs