### PR TITLE
[INJIMOB-3571] add: jwks_uri to VerifierDTO

### DIFF
--- a/docker-compose/config/mimoto-trusted-verifiers.json
+++ b/docker-compose/config/mimoto-trusted-verifiers.json
@@ -8,38 +8,7 @@
       "response_uris": [
         "https://injiverify.collab.mosip.net/v1/verify/vp-submission/vp-direct-post"
       ],
-      "client_metadata": {
-        "client_name": "Requester name",
-        "logo_uri": "<logo_uri>",
-        "authorization_encrypted_response_alg": "ECDH-ES",
-        "authorization_encrypted_response_enc": "A256GCM",
-        "jwks": {
-          "keys": [
-            {
-              "kty": "OKP",
-              "crv": "X25519",
-              "use": "enc",
-              "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-              "alg": "ECDH-ES",
-              "kid": "verifier-key-id"
-            }
-          ]
-        },
-        "vp_formats": {
-          "mso_mdoc": {
-            "alg": [
-              "ES256"
-            ]
-          },
-          "ldp_vp": {
-            "proof_type": [
-              "Ed25519Signature2018",
-              "Ed25519Signature2020",
-              "RsaSignature2018"
-            ]
-          }
-        }
-      }
+      "jwks_uri": "https://injiverify.collab.mosip.net/.well-known/jwks.json"
     }
   ]
 }

--- a/src/main/java/io/mosip/mimoto/dto/openid/VerifierDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/openid/VerifierDTO.java
@@ -9,7 +9,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
 @NoArgsConstructor
@@ -28,9 +29,9 @@ public class VerifierDTO {
     @Schema(description = "Response URIs of the Verifier")
     List<String> responseUris;
 
-    @JsonProperty("client_metadata")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    @Schema(description = "Metadata of the Verifier")
-    Map<String,?> clientMetadata;
+    @JsonProperty("jwks_uri")
+    @Schema(description = "JWKS URI of the Verifier")
+    @JsonInclude(NON_NULL)
+    String jwksUri;
 }
 

--- a/src/main/resources/mimoto-trusted-verifiers.json
+++ b/src/main/resources/mimoto-trusted-verifiers.json
@@ -8,38 +8,7 @@
       "response_uris": [
         "https://injiverify.collab.mosip.net/v1/verify/vp-submission/vp-direct-post"
       ],
-      "client_metadata": {
-        "client_name": "Requester name",
-        "logo_uri": "<logo_uri>",
-        "authorization_encrypted_response_alg": "ECDH-ES",
-        "authorization_encrypted_response_enc": "A256GCM",
-        "jwks": {
-          "keys": [
-            {
-              "kty": "OKP",
-              "crv": "X25519",
-              "use": "enc",
-              "x": "BVNVdqorpxCCnTOkkw8S2NAYXvfEvkC-8RDObhrAUA4",
-              "alg": "ECDH-ES",
-              "kid": "verifier-key-id"
-            }
-          ]
-        },
-        "vp_formats": {
-          "mso_mdoc": {
-            "alg": [
-              "ES256"
-            ]
-          },
-          "ldp_vp": {
-            "proof_type": [
-              "Ed25519Signature2018",
-              "Ed25519Signature2020",
-              "RsaSignature2018"
-            ]
-          }
-        }
-      }
+      "jwks_uri": "https://injiverify.collab.mosip.net/.well-known/jwks.json"
     }
   ]
 }

--- a/src/test/java/io/mosip/mimoto/controller/VerifiersControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/VerifiersControllerTest.java
@@ -83,7 +83,7 @@ public class VerifiersControllerTest {
                 .clientId("test-clientId")
                 .redirectUris(Collections.singletonList("https://test-redirectUri"))
                 .responseUris(Collections.singletonList("https://test-responseUri"))
-                .clientMetadata(metadata)
+                .jwksUri("https://test/.well-known/jwks.json")
                 .build();
 
         VerifiersDTO trustedVerifiers = VerifiersDTO.builder()
@@ -95,7 +95,7 @@ public class VerifiersControllerTest {
         mockMvc.perform(get("/verifiers").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.response.verifiers[0].client_id").value("test-clientId"))
-                .andExpect(jsonPath("$.response.verifiers[0].client_metadata.client_name").value("Test-Verifier"));
+                .andExpect(jsonPath("$.response.verifiers[0].jwks_uri").value("https://test/.well-known/jwks.json"));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class VerifiersControllerTest {
                 .clientId("test-clientId")
                 .redirectUris(Collections.singletonList("https://test-redirectUri"))
                 .responseUris(Collections.singletonList("https://test-responseUri"))
-                .clientMetadata(Collections.emptyMap())
+                .jwksUri("https://test/.well-known/jwks.json")
                 .build();
 
         VerifiersDTO trustedVerifiers = VerifiersDTO.builder()
@@ -115,8 +115,8 @@ public class VerifiersControllerTest {
 
         mockMvc.perform(get("/verifiers").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.response.verifiers[0].client_metadata").isMap())
-                .andExpect(jsonPath("$.response.verifiers[0].client_metadata").isEmpty());
+                .andExpect(jsonPath("$.response.verifiers[0].jwks_uri").isString())
+                .andExpect(jsonPath("$.response.verifiers[0].jwks_uri").value("https://test/.well-known/jwks.json"));
     }
 
 


### PR DESCRIPTION
Changes include

- client_metadata is removed from veriferDTO
- `jwks_uri` is added to Verifier 
     - This jwks_uri will be the Verifier's uri where their JWKs is hosted
     - usecase: This will further be used for verifying the pre-registered Verifiers signed Authorization Request

Sample response of `/verifiers` api

```
{
  "response": {
    "verifiers": [
      {
        "client_id": "mock-client",
        "redirect_uris": [
          "https://example.com/"
        ],
        "response_uris": [
          "https://example.com/verifier/vp-response"
        ],
        "jwks_uri": "https://example.com/.well-known/jwks.json"
      },
      {
        "client_id": "mock-client-1",
        "redirect_uris": [
          "https://example2.com/"
        ],
        "response_uris": [
          "https://example2.com/verifier/vp-response"
        ]
      }
    ]
  },
  "errors": []
}
```