### PR TITLE
[INJIWEB-1712] - Implement presentation submission with verifiable presentation storage

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -110,7 +110,7 @@ fileignoreconfig:
 - filename: src/main/java/io/mosip/mimoto/util/JwtGeneratorUtil.java
   checksum: c8533dd38f79879119ba2895afca75d60e9704d5a0df4a0e79bc3b9292bd0d38
 - filename: src/main/java/io/mosip/mimoto/service/impl/CredentialRequestServiceImpl.java
-  checksum: c2f731cdd77977bee05fade0751e2c7bac67d07b894a0746d984bbcaa82206f6
+  checksum: e149260fd0607baad68daa20d8d14b320951497e932e13e6e148045673cd6257
 - filename: src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
   checksum: c669189f60e8fa5f0cb47d3c7cbb4ab34d87afbb6fb4de65b7eb06c691a41034
 - filename: src/main/java/io/mosip/mimoto/constant/SigningAlgorithm.java
@@ -134,19 +134,21 @@ fileignoreconfig:
 - filename: src/test/java/io/mosip/mimoto/service/VcSdJwtCredentialFormatHandlerTest.java
   checksum: e91aa11aa049453a3a7cd542386dbb813f5c868678f68d6bd71af92149e0d5db
 - filename: db_scripts/inji_mimoto/ddl.sql
-  checksum: 781b2f4be76597455a7768453a71d26ee3fe62e7c3fd5d3e7c490ac9122c8a5f
+  checksum: 51cd2efbe5220b995ae7cff7d70797b2c1bde0ce3325b70d62a31a1f4f41aa47
 - filename: db_scripts/inji_mimoto/ddl/mimoto-trusted-verifiers.sql
   checksum: bbb73e09a9669a8bf78a30b1a72ffdcdffee3f3eb92c5f39ffb5f6ae37e748d2
+- filename: db_scripts/inji_mimoto/ddl/mimoto-verifiable_presentations.sql
+  checksum: 61bba5988812b323c27f3a8fbdd4b802e09efe42772cbd4263a1bff814c74886
 - filename: src/main/java/io/mosip/mimoto/controller/OpenID4VPController.java
   checksum: eef302db396aa1d46d128ef7422d5aeb00c9173af32f61effdf31a0762ddff83
 - filename: src/main/java/io/mosip/mimoto/service/impl/VerifierServiceImpl.java
   checksum: 04d143cb4cb10b7dd4d66344c412681a4888983e232f85e4a0e56237e5248325
 - filename: src/main/java/io/mosip/mimoto/service/impl/SessionManager.java
-  checksum: f06c77aef3e5c6b4edf3c006124ff36cd1638f46b9763c1ef95bd51374422bbc
+  checksum: d88c08d3e5981286ace173e2b50ab6d87a55636b647a92829572a18999663e7c
 - filename: src/test/java/io/mosip/mimoto/controller/WalletPresentationsControllerTest.java
   checksum: 559c0da4613e9eea58833a64bcbf47583eb2040f50771a99407a854a3ef1db52
 - filename: src/main/java/io/mosip/mimoto/controller/WalletPresentationsController.java
-  checksum: 8a1fb8a7bfa27d87633760565a8ab095a83dc94db0a654a89125b2eab32b6b15
+  checksum: 12fc0f8471554ca5025c37b1ee6d7c0045f36b57a8b3c0e528b3859c3de722f9
 - filename: db_upgrade_script/inji_mimoto/sql/0.14.x_to_0.15.x_upgrade.sql
   checksum: 32d62be953744f5307f5807f434c1f98e040f9d85b2760d26605a65adbbd162f
 - filename: src/test/java/io/mosip/mimoto/service/VerifierServiceTest.java
@@ -173,4 +175,12 @@ fileignoreconfig:
   checksum: 217f93d77186a5b9bf06c0f148d8c7f4ef9aaa334517108f573295c9a9e71c20
 - filename: src/main/java/io/mosip/mimoto/constant/OpenID4VPConstants.java
   checksum: 81ca55276277c00a7121ecc70444202bd30a8a7f0c88b40799ab1106f5bbf0e5
+- filename: src/main/java/io/mosip/mimoto/service/KeyPairService.java
+  checksum: e2c4dbcdcf131b3026ba47cf8f7dddbd2cd71259888dad9160afd86b9aa7ea6d
+- filename: src/main/java/io/mosip/mimoto/service/PresentationSubmissionService.java
+  checksum: f4cc9853d567931ae629ccf84568f148469e2853e477ea366e79585b9330a04d
+- filename: src/main/java/io/mosip/mimoto/service/impl/KeyPairServiceImpl.java
+  checksum: c52c3b8f803d8fb0cdc615012b5e675b1c6d83320594e860de741974f3cdb24f
+- filename: src/main/java/io/mosip/mimoto/service/impl/PresentationSubmissionServiceImpl.java
+  checksum: fd412479483d92ae3efbd07aee42564152f8fd9da2a642643290cdab3c375dbe
 version: ""

--- a/.talismanrc
+++ b/.talismanrc
@@ -146,7 +146,7 @@ fileignoreconfig:
 - filename: src/main/java/io/mosip/mimoto/service/impl/SessionManager.java
   checksum: d88c08d3e5981286ace173e2b50ab6d87a55636b647a92829572a18999663e7c
 - filename: src/test/java/io/mosip/mimoto/controller/WalletPresentationsControllerTest.java
-  checksum: 559c0da4613e9eea58833a64bcbf47583eb2040f50771a99407a854a3ef1db52
+  checksum: 3aab4ade6ea8909b550d5dbe04a8af171ec36f249909535ce71dfd21ea37d0fb
 - filename: src/main/java/io/mosip/mimoto/controller/WalletPresentationsController.java
   checksum: 12fc0f8471554ca5025c37b1ee6d7c0045f36b57a8b3c0e528b3859c3de722f9
 - filename: db_upgrade_script/inji_mimoto/sql/0.14.x_to_0.15.x_upgrade.sql
@@ -172,7 +172,7 @@ fileignoreconfig:
 - filename: src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
   checksum: b1323c5b2d2209440ff2d4705d72d67cf93f3a790ef1a4bdeccc5c557686bd85
 - filename: src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
-  checksum: 217f93d77186a5b9bf06c0f148d8c7f4ef9aaa334517108f573295c9a9e71c20
+  checksum: f541358ce3b674a8865592b8c899c2dac484730b8790f9a99b6a79a5b7953c9a
 - filename: src/main/java/io/mosip/mimoto/constant/OpenID4VPConstants.java
   checksum: 81ca55276277c00a7121ecc70444202bd30a8a7f0c88b40799ab1106f5bbf0e5
 - filename: src/main/java/io/mosip/mimoto/service/KeyPairService.java
@@ -183,4 +183,10 @@ fileignoreconfig:
   checksum: c52c3b8f803d8fb0cdc615012b5e675b1c6d83320594e860de741974f3cdb24f
 - filename: src/main/java/io/mosip/mimoto/service/impl/PresentationSubmissionServiceImpl.java
   checksum: fd412479483d92ae3efbd07aee42564152f8fd9da2a642643290cdab3c375dbe
+- filename: src/test/java/io/mosip/mimoto/util/Base64UtilTest.java
+  checksum: 700663d179554cec53962c6ed12957411c5960c32bc0b8d799f79c1b92191c33
+- filename: src/test/java/io/mosip/mimoto/service/PresentationSubmissionServiceTest.java
+  checksum: 99e26a013d61aa37e45bf3b858a511a4f12bfcde09aa18ed067f2926eb77f830
+- filename: src/test/java/io/mosip/mimoto/service/KeyPairServiceTest.java
+  checksum: fbc153d7259000e237268025c0bef540fb1f76259901d2cc633adf81e251a450
 version: ""

--- a/.talismanrc
+++ b/.talismanrc
@@ -76,7 +76,7 @@ fileignoreconfig:
 - filename: src/test/java/io/mosip/mimoto/util/WalletValidatorTest.java
   checksum: 90dce7daa19f0eb9050194a3c77a88d449a83c337d9041bfdeb7bfded3bbd12c
 - filename: src/main/java/io/mosip/mimoto/exception/ErrorConstants.java
-  checksum: 85fd3ab5d0023e31611da20ad3376921180aa8b1e526d452803d9cecade07221
+  checksum: 3766d9f0726f6f527aeca768ac173a6ea56f7df979e16e04a5a20d5ebe98eaf6
 - filename: src/test/java/io/mosip/mimoto/util/TestUtilities.java
   checksum: 90d5310d9499acf98fd3d14230f70e8c378339ed46f384f02d170811a9b05dd5
 - filename: src/main/java/io/mosip/mimoto/controller/WalletCredentialsController.java
@@ -146,9 +146,9 @@ fileignoreconfig:
 - filename: src/main/java/io/mosip/mimoto/service/impl/SessionManager.java
   checksum: d88c08d3e5981286ace173e2b50ab6d87a55636b647a92829572a18999663e7c
 - filename: src/test/java/io/mosip/mimoto/controller/WalletPresentationsControllerTest.java
-  checksum: 3aab4ade6ea8909b550d5dbe04a8af171ec36f249909535ce71dfd21ea37d0fb
+  checksum: 9e8d06af154c14fa40f16193aaee9c905fa5b03c99cb901a8a0b28b0b09121ba
 - filename: src/main/java/io/mosip/mimoto/controller/WalletPresentationsController.java
-  checksum: 12fc0f8471554ca5025c37b1ee6d7c0045f36b57a8b3c0e528b3859c3de722f9
+  checksum: 9e8d06af154c14fa40f16193aaee9c905fa5b03c99cb901a8a0b28b0b09121ba
 - filename: db_upgrade_script/inji_mimoto/sql/0.14.x_to_0.15.x_upgrade.sql
   checksum: 32d62be953744f5307f5807f434c1f98e040f9d85b2760d26605a65adbbd162f
 - filename: src/test/java/io/mosip/mimoto/service/VerifierServiceTest.java
@@ -180,13 +180,17 @@ fileignoreconfig:
 - filename: src/main/java/io/mosip/mimoto/service/PresentationSubmissionService.java
   checksum: f4cc9853d567931ae629ccf84568f148469e2853e477ea366e79585b9330a04d
 - filename: src/main/java/io/mosip/mimoto/service/impl/KeyPairServiceImpl.java
-  checksum: c52c3b8f803d8fb0cdc615012b5e675b1c6d83320594e860de741974f3cdb24f
+  checksum: f55561ba31c6710904b53502fde71564406e0f5102b8234f07e8789d7a313230
 - filename: src/main/java/io/mosip/mimoto/service/impl/PresentationSubmissionServiceImpl.java
-  checksum: fd412479483d92ae3efbd07aee42564152f8fd9da2a642643290cdab3c375dbe
+  checksum: 62fe8f55d40078eb88ca4bbf0f6b453f4be47a37e048796f08d94e9cd0aed1fb
 - filename: src/test/java/io/mosip/mimoto/util/Base64UtilTest.java
   checksum: 700663d179554cec53962c6ed12957411c5960c32bc0b8d799f79c1b92191c33
 - filename: src/test/java/io/mosip/mimoto/service/PresentationSubmissionServiceTest.java
-  checksum: 99e26a013d61aa37e45bf3b858a511a4f12bfcde09aa18ed067f2926eb77f830
+  checksum: 42154b3c9b9b392ad530d6edc5bb58bfa46a8f55ff744e50ab8ab1880a325bee
 - filename: src/test/java/io/mosip/mimoto/service/KeyPairServiceTest.java
   checksum: fbc153d7259000e237268025c0bef540fb1f76259901d2cc633adf81e251a450
+- filename: src/main/java/io/mosip/mimoto/service/impl/PresentationActionServiceImpl.java
+  checksum: 13f3da2b60a6319b1f48d5a98a726f5cad571865762626a06b432061097dafe3
+- filename: src/test/java/io/mosip/mimoto/service/PresentationActionServiceTest.java
+  checksum: f79257d43d522d4076e78fbe802c2e29184e8ff3a3347016578ffca56015a696
 version: ""

--- a/db_scripts/inji_mimoto/ddl.sql
+++ b/db_scripts/inji_mimoto/ddl.sql
@@ -9,3 +9,4 @@
 \ir ddl/mimoto-proof_signing_keys.sql
 \ir ddl/mimoto-verifiable_credentials.sql
 \ir ddl/mimoto-trusted-verifiers.sql
+\ir ddl/mimoto-verifiable_presentations.sql

--- a/db_scripts/inji_mimoto/ddl/mimoto-verifiable_presentations.sql
+++ b/db_scripts/inji_mimoto/ddl/mimoto-verifiable_presentations.sql
@@ -1,0 +1,33 @@
+-- -------------------------------------------------------------------------------------------------
+-- Database Name: inji_mimoto
+-- Table Name : verifiable_presentations
+-- Purpose    : Stores records of verifiable presentations submitted by a wallet to a verifier
+--
+--
+-- Modified Date        Modified By         Comments / Remarks
+-- ------------------------------------------------------------------------------------------
+-- ------------------------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS verifiable_presentations (
+    id character varying(36) PRIMARY KEY,               -- Primary key for the presentation record (use presentationId)
+    wallet_id character varying(36) NOT NULL,           -- Foreign key referring to the wallet table (wallet.id)
+    auth_request JSONB NOT NULL,                        -- Verifier's authorization request payload (as JSON)
+    presentation_data JSONB NOT NULL,                   -- Additional metadata including shared credential ids
+    verifier_id character varying(255),                 -- Verifier identifier (e.g., client_id)
+    status character varying(32) NOT NULL,              -- Submission status: in-progress/success/error
+    requested_at TIMESTAMP,                             -- Verifier request timestamp
+    created_at TIMESTAMP DEFAULT now(),                 -- Submission timestamp (defaults to current time)
+    consent BOOLEAN NOT NULL DEFAULT TRUE,              -- User consent flag
+
+    CONSTRAINT fk_vp_wallet_id FOREIGN KEY (wallet_id) REFERENCES wallet (id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE verifiable_presentations IS 'Verifiable Presentations: Records of presentations shared with verifiers';
+COMMENT ON COLUMN verifiable_presentations.id IS 'Primary Key: Unique identifier for the presentation (presentationId)';
+COMMENT ON COLUMN verifiable_presentations.wallet_id IS 'Wallet ID: Foreign key referring to the wallet table';
+COMMENT ON COLUMN verifiable_presentations.auth_request IS 'Authorization Request: The authorization request payload from the verifier';
+COMMENT ON COLUMN verifiable_presentations.presentation_data IS 'Presentation Data: Additional metadata including shared credential ids';
+COMMENT ON COLUMN verifiable_presentations.verifier_id IS 'Verifier Identifier: The verifier''s client_id or equivalent identifier';
+COMMENT ON COLUMN verifiable_presentations.status IS 'Status: in-progress/success/error';
+COMMENT ON COLUMN verifiable_presentations.requested_at IS 'Requested At: Timestamp when verifier requested the presentation';
+COMMENT ON COLUMN verifiable_presentations.created_at IS 'Created At: Timestamp when the submission record was created';
+COMMENT ON COLUMN verifiable_presentations.consent IS 'Consent: Indicates whether user consented to sharing';

--- a/docs/api-documentation-openapi.json
+++ b/docs/api-documentation-openapi.json
@@ -4251,7 +4251,7 @@
                                     }, "Response when an error occurs while submitting a rejection": {
                                         "value": {
                                             "status": "error",
-                                            "message": "Failed to submit Verifiable Presentation."
+                                            "message": "Failed to submit Verifiable Presentation"
                                         }
                                     }
                                 }

--- a/src/main/java/io/mosip/mimoto/constant/OpenID4VPConstants.java
+++ b/src/main/java/io/mosip/mimoto/constant/OpenID4VPConstants.java
@@ -11,6 +11,7 @@ public class OpenID4VPConstants {
     
     // Authorization request structure keys
     public static final String AUTHORIZATION_REQUEST = "authorizationRequest";
+    public static final String AUTHORIZATION_REQUEST_URL = "authorizationRequestUrl";
     
     // Presentation definition structure keys
     public static final String PRESENTATION_DEFINITION = "presentationDefinition";
@@ -24,4 +25,51 @@ public class OpenID4VPConstants {
     public static final String FILTER = "filter";
     public static final String TYPE = "type";
     public static final String PATTERN = "pattern";
+    
+    // VP Token signing result keys
+    public static final String JWS = "jws";
+    public static final String PROOF_VALUE = "proofValue";
+    public static final String SIGNATURE_ALGORITHM = "signatureAlgorithm";
+    public static final String SIGNATURE = "signature";
+    public static final String MDOC_AUTHENTICATION_ALGORITHM = "mdocAuthenticationAlgorithm";
+    public static final String DOCUMENT_TYPE_SIGNATURES = "documentTypeSignatures";
+    
+    // MSO_MDOC specific keys
+    public static final String DOC_TYPE_TO_DEVICE_AUTHENTICATION_BYTES = "docTypeToDeviceAuthenticationBytes";
+    
+    // Credential format type strings
+    public static final String FORMAT_LDP_VC_UNDERSCORE = "ldp_vc";
+    public static final String FORMAT_LDP_VC_HYPHEN = "ldp-vc";
+    public static final String FORMAT_MSO_MDOC_UNDERSCORE = "mso_mdoc";
+    public static final String FORMAT_MSO_MDOC_HYPHEN = "mso-mdoc";
+    
+    // Algorithm names
+    public static final String ALGORITHM_ES256 = "ES256";
+    public static final String ALGORITHM_EDDSA = "EdDSA";
+    
+    // JWT separators and delimiters
+    public static final String DETACHED_JWT_SEPARATOR = "..";
+    
+    // JWT header critical parameters
+    public static final String JWT_CRITICAL_PARAM_B64 = "b64";
+    
+    // DID (Decentralized Identifier) related constants
+    public static final String DID_JWK_PREFIX = "did:jwk:";
+    public static final String DID_KEY_FRAGMENT = "#0";
+    
+    // Response status constants
+    public static final String STATUS_SUCCESS = "SUCCESS";
+    public static final String STATUS_ERROR = "ERROR";
+    
+    // Database record status constants (lowercase)
+    public static final String DB_STATUS_SUCCESS = "success";
+    public static final String DB_STATUS_ERROR = "error";
+    
+    // Response message constants
+    public static final String MESSAGE_PRESENTATION_SUCCESS = "Presentation successfully submitted and shared with verifier";
+    public static final String MESSAGE_PRESENTATION_SHARE_FAILED = "Presentation submitted but failed to share with verifier";
+    
+    // Credential selection keys
+    public static final String SELECTED_CREDENTIALS = "selectedCredentials";
 }
+

--- a/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
@@ -1,0 +1,47 @@
+package io.mosip.mimoto.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * DTO for submitting a presentation with selected credentials or rejecting a verifier
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request payload for submitting a presentation with selected credentials or rejecting a verifier")
+public class SubmitPresentationRequestDTO {
+
+    @Schema(description = "List of credential IDs that the user has selected to include in the presentation", 
+            example = "[\"cred-123\", \"cred-456\"]")
+    private List<String> selectedCredentials;
+
+    @Schema(description = "Error code for rejecting the verifier (used when user denies the presentation request)", 
+            example = "access_denied")
+    private String errorCode;
+
+    @Schema(description = "Error message for rejecting the verifier (used when user denies the presentation request)", 
+            example = "User denied authorization to share credentials")
+    private String errorMessage;
+
+    /**
+     * Checks if this is a submission request (has selected credentials)
+     */
+    public boolean isSubmissionRequest() {
+        return selectedCredentials != null && !selectedCredentials.isEmpty();
+    }
+
+    /**
+     * Checks if this is a rejection request (has error code and message)
+     */
+    public boolean isRejectionRequest() {
+        return errorCode != null && !errorCode.trim().isEmpty() && 
+               errorMessage != null && !errorMessage.trim().isEmpty();
+    }
+}

--- a/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
@@ -31,17 +31,22 @@ public class SubmitPresentationRequestDTO {
     private String errorMessage;
 
     /**
-     * Checks if this is a submission request (has selected credentials)
+     * Checks if this is a submission request (has selected credentials and NO error fields)
      */
     public boolean isSubmissionRequest() {
-        return selectedCredentials != null && !selectedCredentials.isEmpty();
+        boolean hasCredentials = selectedCredentials != null && !selectedCredentials.isEmpty();
+        boolean hasErrorFields = (errorCode != null && !errorCode.trim().isEmpty()) || 
+                                 (errorMessage != null && !errorMessage.trim().isEmpty());
+        return hasCredentials && !hasErrorFields;
     }
 
     /**
-     * Checks if this is a rejection request (has error code and message)
+     * Checks if this is a rejection request (has error code and message and NO credentials)
      */
     public boolean isRejectionRequest() {
-        return errorCode != null && !errorCode.trim().isEmpty() && 
-               errorMessage != null && !errorMessage.trim().isEmpty();
+        boolean hasErrorFields = errorCode != null && !errorCode.trim().isEmpty() && 
+                                errorMessage != null && !errorMessage.trim().isEmpty();
+        boolean hasCredentials = selectedCredentials != null && !selectedCredentials.isEmpty();
+        return hasErrorFields && !hasCredentials;
     }
 }

--- a/src/main/java/io/mosip/mimoto/dto/SubmitPresentationResponseDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/SubmitPresentationResponseDTO.java
@@ -1,0 +1,30 @@
+package io.mosip.mimoto.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for the response when a presentation is successfully submitted
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Response payload for successful presentation submission")
+public class SubmitPresentationResponseDTO {
+
+    @Schema(description = "Unique identifier of the submitted presentation", 
+            example = "presentation-123")
+    private String presentationId;
+
+    @Schema(description = "Status of the presentation submission", 
+            example = "SUCCESS")
+    private String status;
+
+    @Schema(description = "Message indicating the result of the submission", 
+            example = "Presentation successfully submitted and shared with verifier")
+    private String message;
+}

--- a/src/main/java/io/mosip/mimoto/exception/ErrorConstants.java
+++ b/src/main/java/io/mosip/mimoto/exception/ErrorConstants.java
@@ -49,7 +49,10 @@ public enum ErrorConstants {
     DUPLICATE_VERIFIER("duplicate_verifier", "This verifier is already trusted."),
     ERROR_ADDING_TRUSTED_VERIFIER("error", "Failed to add trusted verifier"),
     REJECT_VERIFIER_EXCEPTION("error", "Failed to submit Verifiable Presentation."),
-    REJECTED_VERIFIER("success", "Presentation request rejected. An OpenID4VP error response has been sent to the verifier."),;
+    REJECTED_VERIFIER("success", "Presentation request rejected. An OpenID4VP error response has been sent to the verifier."),
+    JWT_SIGNING_ERROR("jwt_signing_error", "Failed to sign JWT token during presentation submission"),
+    KEY_GENERATION_ERROR("key_generation_error", "Failed to generate or retrieve cryptographic key"),
+    DECRYPTION_ERROR("decryption_error", "Failed to decrypt data");
 
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/io/mosip/mimoto/model/VerifiablePresentation.java
+++ b/src/main/java/io/mosip/mimoto/model/VerifiablePresentation.java
@@ -1,0 +1,55 @@
+package io.mosip.mimoto.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+/**
+ * Entity class for verifiable_presentations table
+ */
+@Entity
+@Table(name = "verifiable_presentations")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifiablePresentation {
+
+    @Id
+    @Column(name = "id", length = 255)
+    private String id;
+
+    @Column(name = "wallet_id", length = 255, nullable = false)
+    private String walletId;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "auth_request", columnDefinition = "jsonb")
+    private String authRequest;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "presentation_data", columnDefinition = "jsonb")
+    private String presentationData;
+
+    @Column(name = "verifier_id", length = 255)
+    private String verifierId;
+
+    @Column(name = "status", length = 50, nullable = false)
+    private String status;
+
+    @Column(name = "requested_at")
+    private LocalDateTime requestedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "consent", nullable = false)
+    private Boolean consent;
+}

--- a/src/main/java/io/mosip/mimoto/repository/VerifiablePresentationRepository.java
+++ b/src/main/java/io/mosip/mimoto/repository/VerifiablePresentationRepository.java
@@ -1,0 +1,14 @@
+package io.mosip.mimoto.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import io.mosip.mimoto.model.VerifiablePresentation;
+
+/**
+ * Repository interface for VerifiablePresentation entity
+ */
+@Repository
+public interface VerifiablePresentationRepository extends JpaRepository<VerifiablePresentation, String> {
+    
+}

--- a/src/main/java/io/mosip/mimoto/repository/VerifiablePresentationsRepository.java
+++ b/src/main/java/io/mosip/mimoto/repository/VerifiablePresentationsRepository.java
@@ -9,6 +9,6 @@ import io.mosip.mimoto.model.VerifiablePresentation;
  * Repository interface for VerifiablePresentation entity
  */
 @Repository
-public interface VerifiablePresentationRepository extends JpaRepository<VerifiablePresentation, String> {
+public interface VerifiablePresentationsRepository extends JpaRepository<VerifiablePresentation, String> {
     
 }

--- a/src/main/java/io/mosip/mimoto/service/KeyPairService.java
+++ b/src/main/java/io/mosip/mimoto/service/KeyPairService.java
@@ -1,0 +1,25 @@
+package io.mosip.mimoto.service;
+
+import io.mosip.mimoto.constant.SigningAlgorithm;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+
+import java.security.KeyPair;
+
+/**
+ * Service interface for managing key pairs from database
+ */
+public interface KeyPairService {
+
+    /**
+     * Retrieves a key pair from the database for the given wallet ID and signing algorithm
+     *
+     * @param walletId The wallet ID
+     * @param base64EncodedWalletKey The base64 encoded wallet key for decryption
+     * @param signingAlgorithm The signing algorithm
+     * @return The key pair
+     * @throws KeyGenerationException if key generation or retrieval fails
+     * @throws DecryptionException if decryption of private key fails
+     */
+    KeyPair getKeyPairFromDB(String walletId, String base64EncodedWalletKey, SigningAlgorithm signingAlgorithm) throws KeyGenerationException, DecryptionException;
+}

--- a/src/main/java/io/mosip/mimoto/service/PresentationActionService.java
+++ b/src/main/java/io/mosip/mimoto/service/PresentationActionService.java
@@ -1,0 +1,33 @@
+package io.mosip.mimoto.service;
+
+import io.mosip.mimoto.dto.SubmitPresentationRequestDTO;
+import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Service interface for handling presentation actions (submission or rejection)
+ */
+public interface PresentationActionService {
+
+    /**
+     * Handles presentation action - either submission with credentials or rejection with error
+     * <p>
+     * This method handles all business logic and exceptions internally, returning appropriate
+     * HTTP responses. The controller should only catch generic exceptions for unexpected errors.
+     *
+     * @param walletId The wallet ID
+     * @param presentationId The presentation ID
+     * @param request The request containing either selected credentials or error details
+     * @param vpSessionData The session data containing presentation information
+     * @param base64Key The wallet key for decryption (required for submission)
+     * @return ResponseEntity with appropriate response type and HTTP status
+     */
+    ResponseEntity<?> handlePresentationAction(
+            String walletId,
+            String presentationId,
+            SubmitPresentationRequestDTO request,
+            VerifiablePresentationSessionData vpSessionData,
+            String base64Key
+    );
+}
+

--- a/src/main/java/io/mosip/mimoto/service/PresentationSubmissionService.java
+++ b/src/main/java/io/mosip/mimoto/service/PresentationSubmissionService.java
@@ -1,0 +1,40 @@
+package io.mosip.mimoto.service;
+
+import com.nimbusds.jose.JOSEException;
+import io.mosip.mimoto.dto.SubmitPresentationRequestDTO;
+import io.mosip.mimoto.dto.SubmitPresentationResponseDTO;
+import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+
+import java.io.IOException;
+
+/**
+ * Service interface for handling presentation submission operations
+ */
+public interface PresentationSubmissionService {
+
+    /**
+     * Submits a presentation with selected credentials
+     *
+     * @param sessionData The session data containing presentation information
+     * @param walletId The wallet ID
+     * @param presentationId The presentation ID
+     * @param request The submission request with selected credentials
+     * @param base64Key The user's private key for signing
+     * @return The submission response
+     * @throws ApiNotAccessibleException if API is not accessible
+     * @throws IOException if there's an IO error
+     * @throws JOSEException if JWT signing fails
+     * @throws KeyGenerationException if key pair retrieval or generation fails
+     * @throws DecryptionException if decryption of private key fails
+     */
+    SubmitPresentationResponseDTO submitPresentation(
+            VerifiablePresentationSessionData sessionData,
+            String walletId,
+            String presentationId,
+            SubmitPresentationRequestDTO request,
+            String base64Key
+    ) throws ApiNotAccessibleException, IOException, JOSEException, KeyGenerationException, DecryptionException;
+}

--- a/src/main/java/io/mosip/mimoto/service/impl/KeyPairServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/KeyPairServiceImpl.java
@@ -33,61 +33,56 @@ public class KeyPairServiceImpl implements KeyPairService {
     @Override
     public KeyPair getKeyPairFromDB(String walletId, String base64EncodedWalletKey, SigningAlgorithm signingAlgorithm) throws KeyGenerationException, DecryptionException {
         log.debug("Retrieving key pair for walletId: {} with algorithm: {}", walletId, signingAlgorithm);
-        
+
         // Step 1: Retrieve proof signing key from database
         Optional<ProofSigningKey> proofSigningKey = proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, signingAlgorithm.name());
-        
+
         if (proofSigningKey.isEmpty()) {
             log.error("No proof signing key found for walletId: {} with algorithm: {}", walletId, signingAlgorithm);
-            throw new KeyGenerationException("KEY_NOT_FOUND", 
-                "No proof signing key found for walletId: " + walletId + " with algorithm: " + signingAlgorithm);
+            throw new KeyGenerationException("KEY_NOT_FOUND", "No proof signing key found for walletId: " + walletId + " with algorithm: " + signingAlgorithm);
         }
-        
+
         // Step 2: Decode wallet key
         byte[] decodedWalletKey;
         try {
             decodedWalletKey = Base64.getDecoder().decode(base64EncodedWalletKey);
         } catch (IllegalArgumentException e) {
             log.error("Invalid base64 encoded wallet key for walletId: {}", walletId, e);
-            throw new DecryptionException("INVALID_WALLET_KEY", 
-                "Invalid base64 encoded wallet key", e);
+            throw new DecryptionException("INVALID_WALLET_KEY", "Invalid base64 encoded wallet key", e);
         }
-        
+
         SecretKey walletKey = EncryptionDecryptionUtil.bytesToSecretKey(decodedWalletKey);
-        
+
         // Step 3: Decode public key
         byte[] publicKeyBytes;
         try {
             publicKeyBytes = Base64.getDecoder().decode(proofSigningKey.get().getPublicKey());
         } catch (IllegalArgumentException e) {
             log.error("Invalid base64 encoded public key for walletId: {}", walletId, e);
-            throw new KeyGenerationException("INVALID_PUBLIC_KEY", 
-                "Invalid base64 encoded public key", e);
+            throw new KeyGenerationException("INVALID_PUBLIC_KEY", "Invalid base64 encoded public key", e);
         }
-        
+
         // Step 4: Decrypt private key
         byte[] privateKeyInBytes;
         try {
             privateKeyInBytes = encryptionDecryptionUtil.decryptWithAES(walletKey, proofSigningKey.get().getEncryptedSecretKey());
         } catch (Exception e) {
             log.error("Failed to decrypt private key for walletId: {} with algorithm: {}", walletId, signingAlgorithm, e);
-            throw new DecryptionException("DECRYPTION_FAILED", 
-                "Failed to decrypt private key for walletId: " + walletId, e);
+            throw new DecryptionException("DECRYPTION_FAILED", "Failed to decrypt private key for walletId: " + walletId, e);
         }
-        
+
         // Step 5: Generate KeyPair from stored keys
         KeyPair keyPair;
         try {
             keyPair = KeyGenerationUtil.getKeyPairFromDBStoredKeys(signingAlgorithm, publicKeyBytes, privateKeyInBytes);
         } catch (Exception e) {
             log.error("Failed to generate KeyPair for signing algorithm: {} for walletId: {}", signingAlgorithm, walletId, e);
-            throw new KeyGenerationException("KEY_GENERATION_FAILED", 
-                "Failed to generate KeyPair for algorithm: " + signingAlgorithm, e);
+            throw new KeyGenerationException("KEY_GENERATION_FAILED", "Failed to generate KeyPair for algorithm: " + signingAlgorithm, e);
         }
-        
+
         log.debug("Successfully retrieved KeyPair for signing algorithm: {} from database", signingAlgorithm);
-        
+
         return keyPair;
-        
+
     }
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/KeyPairServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/KeyPairServiceImpl.java
@@ -1,0 +1,93 @@
+package io.mosip.mimoto.service.impl;
+
+import io.mosip.mimoto.constant.SigningAlgorithm;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+import io.mosip.mimoto.model.ProofSigningKey;
+import io.mosip.mimoto.repository.ProofSigningKeyRepository;
+import io.mosip.mimoto.service.KeyPairService;
+import io.mosip.mimoto.util.EncryptionDecryptionUtil;
+import io.mosip.mimoto.util.KeyGenerationUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * Service implementation for managing key pairs from database
+ */
+@Slf4j
+@Service
+public class KeyPairServiceImpl implements KeyPairService {
+
+    @Autowired
+    private ProofSigningKeyRepository proofSigningKeyRepository;
+
+    @Autowired
+    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+
+    @Override
+    public KeyPair getKeyPairFromDB(String walletId, String base64EncodedWalletKey, SigningAlgorithm signingAlgorithm) throws KeyGenerationException, DecryptionException {
+        log.debug("Retrieving key pair for walletId: {} with algorithm: {}", walletId, signingAlgorithm);
+        
+        // Step 1: Retrieve proof signing key from database
+        Optional<ProofSigningKey> proofSigningKey = proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, signingAlgorithm.name());
+        
+        if (proofSigningKey.isEmpty()) {
+            log.error("No proof signing key found for walletId: {} with algorithm: {}", walletId, signingAlgorithm);
+            throw new KeyGenerationException("KEY_NOT_FOUND", 
+                "No proof signing key found for walletId: " + walletId + " with algorithm: " + signingAlgorithm);
+        }
+        
+        // Step 2: Decode wallet key
+        byte[] decodedWalletKey;
+        try {
+            decodedWalletKey = Base64.getDecoder().decode(base64EncodedWalletKey);
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid base64 encoded wallet key for walletId: {}", walletId, e);
+            throw new DecryptionException("INVALID_WALLET_KEY", 
+                "Invalid base64 encoded wallet key", e);
+        }
+        
+        SecretKey walletKey = EncryptionDecryptionUtil.bytesToSecretKey(decodedWalletKey);
+        
+        // Step 3: Decode public key
+        byte[] publicKeyBytes;
+        try {
+            publicKeyBytes = Base64.getDecoder().decode(proofSigningKey.get().getPublicKey());
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid base64 encoded public key for walletId: {}", walletId, e);
+            throw new KeyGenerationException("INVALID_PUBLIC_KEY", 
+                "Invalid base64 encoded public key", e);
+        }
+        
+        // Step 4: Decrypt private key
+        byte[] privateKeyInBytes;
+        try {
+            privateKeyInBytes = encryptionDecryptionUtil.decryptWithAES(walletKey, proofSigningKey.get().getEncryptedSecretKey());
+        } catch (Exception e) {
+            log.error("Failed to decrypt private key for walletId: {} with algorithm: {}", walletId, signingAlgorithm, e);
+            throw new DecryptionException("DECRYPTION_FAILED", 
+                "Failed to decrypt private key for walletId: " + walletId, e);
+        }
+        
+        // Step 5: Generate KeyPair from stored keys
+        KeyPair keyPair;
+        try {
+            keyPair = KeyGenerationUtil.getKeyPairFromDBStoredKeys(signingAlgorithm, publicKeyBytes, privateKeyInBytes);
+        } catch (Exception e) {
+            log.error("Failed to generate KeyPair for signing algorithm: {} for walletId: {}", signingAlgorithm, walletId, e);
+            throw new KeyGenerationException("KEY_GENERATION_FAILED", 
+                "Failed to generate KeyPair for algorithm: " + signingAlgorithm, e);
+        }
+        
+        log.debug("Successfully retrieved KeyPair for signing algorithm: {} from database", signingAlgorithm);
+        
+        return keyPair;
+        
+    }
+}

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationActionServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationActionServiceImpl.java
@@ -1,0 +1,126 @@
+package io.mosip.mimoto.service.impl;
+
+import com.nimbusds.jose.JOSEException;
+import io.mosip.mimoto.dto.ErrorDTO;
+import io.mosip.mimoto.dto.RejectedVerifierDTO;
+import io.mosip.mimoto.dto.SubmitPresentationRequestDTO;
+import io.mosip.mimoto.dto.SubmitPresentationResponseDTO;
+import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.InvalidRequestException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+import io.mosip.mimoto.exception.VPErrorNotSentException;
+import io.mosip.mimoto.service.PresentationActionService;
+import io.mosip.mimoto.service.PresentationService;
+import io.mosip.mimoto.service.PresentationSubmissionService;
+import io.mosip.mimoto.util.Utilities;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+import static io.mosip.mimoto.exception.ErrorConstants.*;
+
+/**
+ * Service implementation for handling presentation actions
+ */
+@Slf4j
+@Service
+public class PresentationActionServiceImpl implements PresentationActionService {
+
+    @Autowired
+    private PresentationSubmissionService presentationSubmissionService;
+
+    @Autowired
+    private PresentationService presentationService;
+
+    @Override
+    public ResponseEntity<?> handlePresentationAction(String walletId, String presentationId, SubmitPresentationRequestDTO request, VerifiablePresentationSessionData vpSessionData, String base64Key) {
+
+        log.info("Processing presentation action for walletId: {}, presentationId: {}", walletId, presentationId);
+
+        try {
+            // Determine the action based on request content
+            if (request.isSubmissionRequest()) {
+                log.info("Processing presentation submission for presentationId: {}", presentationId);
+                return handlePresentationSubmission(walletId, presentationId, request, vpSessionData, base64Key);
+
+            } else if (request.isRejectionRequest()) {
+                log.info("Processing verifier rejection for presentationId: {}", presentationId);
+                return handleVerifierRejection(walletId, vpSessionData, request);
+
+            } else {
+                log.warn("Invalid request format - must contain either selectedCredentials or both errorCode and errorMessage");
+                return Utilities.getErrorResponseEntityWithoutWrapper(new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Request must contain either selectedCredentials or both errorCode and errorMessage"), INVALID_REQUEST.getErrorCode(), HttpStatus.BAD_REQUEST, MediaType.APPLICATION_JSON);
+            }
+
+        } catch (JOSEException exception) {
+            log.error("JWT signing error during presentation action for walletId: {}, presentationId: {}", walletId, presentationId, exception);
+            return Utilities.getErrorResponseEntityWithoutWrapper(exception, JWT_SIGNING_ERROR.getErrorCode(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+
+        } catch (KeyGenerationException exception) {
+            log.error("Key generation/retrieval error during presentation action for walletId: {}, presentationId: {}", walletId, presentationId, exception);
+            return Utilities.getErrorResponseEntityWithoutWrapper(exception, KEY_GENERATION_ERROR.getErrorCode(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+
+        } catch (DecryptionException exception) {
+            log.error("Decryption error during presentation action for walletId: {}, presentationId: {}", walletId, presentationId, exception);
+            return Utilities.getErrorResponseEntityWithoutWrapper(exception, DECRYPTION_ERROR.getErrorCode(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+
+        } catch (ApiNotAccessibleException | IOException exception) {
+            log.error("Error during presentation action for walletId: {}, presentationId: {}", walletId, presentationId, exception);
+            return Utilities.getErrorResponseEntityWithoutWrapper(exception, WALLET_CREATE_VP_EXCEPTION.getErrorCode(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+
+        } catch (VPErrorNotSentException exception) {
+            log.error("Error sending rejection to verifier for walletId: {}, presentationId: {}", walletId, presentationId, exception);
+            return Utilities.getErrorResponseEntityWithoutWrapper(exception, REJECT_VERIFIER_EXCEPTION.getErrorCode(), HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+
+        } catch (IllegalArgumentException exception) {
+            log.error("Invalid argument during presentation action for walletId: {}, presentationId: {}", walletId, presentationId, exception);
+            return Utilities.getErrorResponseEntityWithoutWrapper(exception, INVALID_REQUEST.getErrorCode(), HttpStatus.BAD_REQUEST, MediaType.APPLICATION_JSON);
+        }
+    }
+
+    /**
+     * Handles presentation submission with selected credentials
+     */
+    private ResponseEntity<SubmitPresentationResponseDTO> handlePresentationSubmission(String walletId, String presentationId, SubmitPresentationRequestDTO request, VerifiablePresentationSessionData sessionData, String base64Key) throws ApiNotAccessibleException, IOException, JOSEException, KeyGenerationException, DecryptionException {
+
+        log.debug("Submitting presentation for walletId: {}, presentationId: {}", walletId, presentationId);
+
+        if (base64Key == null || base64Key.isBlank()) {
+            log.warn("Wallet key not found for walletId: {}", walletId);
+            throw new IllegalArgumentException("Wallet key is required for presentation submission");
+        }
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        log.info("Presentation submission completed successfully for walletId: {}, presentationId: {}", walletId, presentationId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * Handles verifier rejection with error details
+     */
+    private ResponseEntity<RejectedVerifierDTO> handleVerifierRejection(String walletId, VerifiablePresentationSessionData vpSessionData, SubmitPresentationRequestDTO request) throws VPErrorNotSentException {
+
+        log.debug("Rejecting verifier for walletId: {}", walletId);
+
+        // Create ErrorDTO from the request
+        ErrorDTO errorPayload = new ErrorDTO();
+        errorPayload.setErrorCode(request.getErrorCode());
+        errorPayload.setErrorMessage(request.getErrorMessage());
+
+        // Call the presentation service to reject the verifier
+        RejectedVerifierDTO rejectedVerifierDTO = presentationService.rejectVerifier(walletId, vpSessionData, errorPayload);
+
+        log.info("Verifier rejection completed successfully for walletId: {}", walletId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(rejectedVerifierDTO);
+    }
+}
+

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -24,7 +24,6 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest;
 import io.mosip.openID4VP.authorizationRequest.Verifier;
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.ClientMetadata;
 import io.mosip.mimoto.util.RestApiClient;
-import io.mosip.openID4VP.exceptions.OpenID4VPExceptions;
 import io.mosip.openID4VP.networkManager.NetworkResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationSubmissionServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationSubmissionServiceImpl.java
@@ -1,0 +1,581 @@
+package io.mosip.mimoto.service.impl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.util.Base64URL;
+
+import io.mosip.mimoto.constant.SigningAlgorithm;
+import io.mosip.mimoto.constant.OpenID4VPConstants;
+import io.mosip.mimoto.dto.DecryptedCredentialDTO;
+import io.mosip.mimoto.dto.SubmitPresentationRequestDTO;
+import io.mosip.mimoto.dto.SubmitPresentationResponseDTO;
+import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
+import io.mosip.mimoto.util.JwtGeneratorUtil;
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken;
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult;
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult;
+import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+import io.mosip.mimoto.model.VerifiablePresentation;
+import io.mosip.mimoto.service.PresentationSubmissionService;
+import io.mosip.mimoto.service.KeyPairService;
+import io.mosip.mimoto.service.VerifierService;
+import io.mosip.mimoto.repository.VerifiablePresentationRepository;
+import io.mosip.mimoto.util.UrlParameterUtils;
+import io.mosip.mimoto.util.WalletPresentationUtil;
+import io.mosip.mimoto.util.Base64Util;
+import io.mosip.openID4VP.OpenID4VP;
+import io.mosip.openID4VP.authorizationRequest.Verifier;
+import io.mosip.openID4VP.constants.FormatType;
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Service implementation for handling presentation submission operations
+ */
+@Slf4j
+@Service
+public class PresentationSubmissionServiceImpl implements PresentationSubmissionService {
+
+    private static final String DEFAULT_SIGNATURE_SUITE = "JsonWebSignature2020";
+    private static final String UNKNOWN_VERIFIER = "unknown";
+    private static final String EMPTY_JSON = "{}";
+    
+    @Value("${mimoto.presentation.signing.algorithm:ED25519}")
+    private String defaultSigningAlgorithmName;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private OpenID4VPService openID4VPService;
+
+    @Autowired
+    private VerifierService verifierService;
+
+    @Autowired
+    private KeyPairService keyPairService;
+
+    @Autowired
+    private VerifiablePresentationRepository verifiablePresentationRepository;
+
+    @Override
+    public SubmitPresentationResponseDTO submitPresentation(VerifiablePresentationSessionData sessionData, String walletId, String presentationId, SubmitPresentationRequestDTO request, String base64Key) throws ApiNotAccessibleException, IOException, JOSEException, KeyGenerationException, DecryptionException {
+
+        // Validate all inputs before processing
+        validateInputs(sessionData, walletId, presentationId, request, base64Key);
+        
+        log.info("Starting presentation submission for walletId: {}, presentationId: {}", walletId, presentationId);
+
+        LocalDateTime requestedAt = LocalDateTime.now();
+
+        // Step 1: Fetch full credentials by ID from cache
+        List<DecryptedCredentialDTO> selectedCredentials = fetchSelectedCredentials(sessionData, request.getSelectedCredentials());
+
+        // Step 2: Create OpenID4VP instance and construct unsigned VP token
+        OpenID4VP openID4VP = openID4VPService.create(presentationId);
+        List<Verifier> preRegisteredVerifiers = verifierService.getTrustedVerifiers().getVerifiers().stream()
+                .map(WalletPresentationUtil::mapToVerifier).toList();
+        openID4VP.authenticateVerifier(sessionData.getAuthorizationRequest(), preRegisteredVerifiers, sessionData.isVerifierClientPreregistered());
+
+        // Use configurable signing algorithm
+        SigningAlgorithm signingAlgorithm = SigningAlgorithm.valueOf(defaultSigningAlgorithmName);
+        log.debug("Using signing algorithm: {} for wallet: {}", signingAlgorithm, walletId);
+        KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, signingAlgorithm);
+        JWK jwk = JwtGeneratorUtil.generateJwk(signingAlgorithm, keyPair);
+        Map<FormatType, UnsignedVPToken> unsignedVPToken = constructUnsignedVPToken(openID4VP, selectedCredentials, jwk);
+
+        // Step 3: Sign token using user's private key
+        JWSSigner jwsSigner = JwtGeneratorUtil.createSigner(signingAlgorithm, jwk);
+        Map<FormatType, LdpVPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, jwsSigner, walletId, base64Key);
+
+        // Step 4: Share verifiable presentation with verifier using OpenID4VP JAR
+        boolean shareSuccess = shareVerifiablePresentation(vpTokenSigningResults, sessionData, openID4VP);
+
+        // Step 5: Store presentation record in database
+        storePresentationRecord(walletId, presentationId, request, sessionData, shareSuccess, requestedAt);
+
+        // Step 6: Return success response
+        return SubmitPresentationResponseDTO.builder().presentationId(presentationId)
+                .status(shareSuccess ? OpenID4VPConstants.STATUS_SUCCESS : OpenID4VPConstants.STATUS_ERROR)
+                .message(shareSuccess ? OpenID4VPConstants.MESSAGE_PRESENTATION_SUCCESS
+                        : OpenID4VPConstants.MESSAGE_PRESENTATION_SHARE_FAILED)
+                .build();
+    }
+
+    /**
+     * Signs VP token using JWSSigner for different format types
+     * This method delegates to format-specific signing methods
+     * 
+     * @param unsignedVPTokensMap Map of unsigned VP tokens by format type
+     * @param jwsSigner The JWS signer to use for signing operations (for LDP_VC)
+     * @param walletId The wallet ID for fetching keypairs (for MSO_MDOC)
+     * @param base64Key The base64 encoded wallet key for decryption (for MSO_MDOC)
+     * @return Map of signed VP token results by format type
+     * @throws JOSEException if JWT signing fails
+     * @throws IOException if I/O operations fail
+     * @throws KeyGenerationException if key pair retrieval or generation fails
+     * @throws DecryptionException if decryption of private key fails
+     */
+    private Map<FormatType, LdpVPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, JWSSigner jwsSigner, String walletId, String base64Key) throws JOSEException, IOException, KeyGenerationException, DecryptionException {
+        log.debug("Signing VP token for {} format types", unsignedVPTokensMap.size());
+
+        return unsignedVPTokensMap.entrySet().stream()
+                .map(entry -> {
+                    FormatType formatType = entry.getKey();
+                    UnsignedVPToken unsignedVPToken = entry.getValue();
+
+                    try {
+                        LdpVPTokenSigningResult signingResult = switch (formatType) {
+                            case LDP_VC -> signLdpVcFormat(unsignedVPToken, jwsSigner);
+                            case MSO_MDOC -> signMsoMdocFormat(unsignedVPToken, walletId, base64Key);
+                            default -> {
+                                log.warn("Unsupported format type: {}", formatType);
+                                yield null;
+                            }
+                        };
+
+                        return signingResult != null ? Map.entry(formatType, signingResult) : null;
+                    } catch (JOSEException | IOException | KeyGenerationException | DecryptionException e) {
+                        // Wrap checked exceptions in unchecked for stream processing
+                        throw new RuntimeException("Failed to sign VP token for format: " + formatType, e);
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Signs LDP_VC format verifiable presentation using detached JWT
+     * 
+     * @param unsignedVPToken The unsigned VP token
+     * @param jwsSigner The JWS signer (EdDSA) for signing
+     * @return Signing result with detached JWT proof
+     * @throws JOSEException if JWT signing fails
+     */
+    private LdpVPTokenSigningResult signLdpVcFormat(UnsignedVPToken unsignedVPToken, JWSSigner jwsSigner) throws JOSEException {
+        log.debug("Signing LDP_VC format VP token");
+
+        String dataToSign = ((UnsignedLdpVPToken) unsignedVPToken).getDataToSign();
+
+        // Create JWSHeader with critical parameters for detached JWT
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+                .criticalParams(Set.of(OpenID4VPConstants.JWT_CRITICAL_PARAM_B64))
+                .base64URLEncodePayload(false)
+                .build();
+
+        // Convert dataToSign from base64 to byte array
+        byte[] vpTokenBytes = Base64Util.decodeFlexible(dataToSign);
+
+        // Create header bytes for signing input
+        String headerJson = header.toString();
+        String header64 = Base64Util.encode(headerJson);
+
+        // Create input bytes for detached JWT signing: header + '.' + payload
+        byte[] inputBytes = Base64Util.createDetachedJwtSigningInput(header64, vpTokenBytes);
+
+        // Sign using the provided JWSSigner
+        Base64URL signatureBase64URL = jwsSigner.sign(header, inputBytes);
+        String signature = signatureBase64URL.toString();
+
+        // Create the detached JWT proof: header64 + '..' + signature
+        String proof = header64 + OpenID4VPConstants.DETACHED_JWT_SEPARATOR + signature;
+
+        Map<String, Object> signingResultData = new HashMap<>();
+        signingResultData.put(OpenID4VPConstants.JWS, proof);
+        signingResultData.put(OpenID4VPConstants.PROOF_VALUE, null);
+        signingResultData.put(OpenID4VPConstants.SIGNATURE_ALGORITHM, DEFAULT_SIGNATURE_SUITE);
+
+        return objectMapper.convertValue(signingResultData, LdpVPTokenSigningResult.class);
+    }
+
+    /**
+     * Signs MSO_MDOC format verifiable presentation
+     * Creates ES256 keypair and signs each document type
+     * 
+     * @param unsignedVPToken The unsigned VP token
+     * @param walletId The wallet ID for fetching keypairs
+     * @param base64Key The base64 encoded wallet key for decryption
+     * @return Signing result with document type signatures
+     * @throws JOSEException if JWT signing fails
+     * @throws IOException if I/O operations fail
+     * @throws KeyGenerationException if key pair retrieval or generation fails
+     * @throws DecryptionException if decryption of private key fails
+     */
+    private LdpVPTokenSigningResult signMsoMdocFormat(UnsignedVPToken unsignedVPToken, String walletId, String base64Key) throws JOSEException, IOException, KeyGenerationException, DecryptionException {
+        log.debug("Signing MSO_MDOC format VP token");
+
+        // Convert UnsignedVPToken to Map for MSO_MDOC format
+        @SuppressWarnings("unchecked")
+        Map<String, Object> credentials = objectMapper.convertValue(unsignedVPToken, Map.class);
+        Map<String, Map<String, Object>> documentTypeSignatures = new HashMap<>();
+
+        // For MSO_MDOC format, look for docTypeToDeviceAuthenticationBytes
+        if (!credentials.containsKey(OpenID4VPConstants.DOC_TYPE_TO_DEVICE_AUTHENTICATION_BYTES)) {
+            log.warn("MSO_MDOC format type but no docTypeToDeviceAuthenticationBytes found");
+            return createMsoMdocSigningResult(documentTypeSignatures);
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> docTypeToDeviceAuthenticationBytes =
+                (Map<String, Object>) credentials.get(OpenID4VPConstants.DOC_TYPE_TO_DEVICE_AUTHENTICATION_BYTES);
+
+        if (docTypeToDeviceAuthenticationBytes == null) {
+            return createMsoMdocSigningResult(documentTypeSignatures);
+        }
+
+        // Get MDOC authentication algorithm (defaulting to ES256)
+        String mdocAuthenticationAlgorithm = OpenID4VPConstants.ALGORITHM_ES256;
+        SigningAlgorithm mdocSigningAlgorithm = SigningAlgorithm.ES256;
+
+        // Fetch key pair for MSO_MDOC signing (ES256 algorithm)
+        log.debug("Fetching ES256 keypair for MSO_MDOC signing for walletId: {}", walletId);
+        KeyPair mdocKeyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, mdocSigningAlgorithm);
+        JWK mdocJwk = JwtGeneratorUtil.generateJwk(mdocSigningAlgorithm, mdocKeyPair);
+        JWSSigner mdocSigner = JwtGeneratorUtil.createSigner(mdocSigningAlgorithm, mdocJwk);
+
+        // Process each docType entry using streams
+        Map<String, Map<String, Object>> signedDocTypes = docTypeToDeviceAuthenticationBytes.entrySet().stream()
+                .map(docTypeEntry -> {
+                    String docType = docTypeEntry.getKey();
+                    Object payload = docTypeEntry.getValue();
+
+                    log.debug("Processing MSO_MDOC docType: {} with algorithm: {}", docType, mdocAuthenticationAlgorithm);
+
+                    try {
+                        String signature = signMsoMdocDocType(payload, mdocSigner);
+
+                        // If signature was created successfully
+                        if (signature != null && !signature.isEmpty()) {
+                            Map<String, Object> docTypeResult = new HashMap<>();
+                            docTypeResult.put(OpenID4VPConstants.SIGNATURE, signature);
+                            docTypeResult.put(OpenID4VPConstants.MDOC_AUTHENTICATION_ALGORITHM, mdocAuthenticationAlgorithm);
+
+                            log.debug("Successfully signed MSO_MDOC docType: {} with algorithm: {}",
+                                    docType, mdocAuthenticationAlgorithm);
+
+                            return Map.entry(docType, docTypeResult);
+                        }
+                        return null;
+                    } catch (JOSEException | IOException e) {
+                        log.error("Failed to sign MSO_MDOC docType: {}", docType, e);
+                        throw new RuntimeException("Failed to sign docType: " + docType, e);
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        documentTypeSignatures.putAll(signedDocTypes);
+
+        return createMsoMdocSigningResult(documentTypeSignatures);
+    }
+
+    /**
+     * Signs a single MSO_MDOC document type payload
+     * 
+     * @param payload The payload to sign (string or object)
+     * @param mdocSigner The ES256 signer
+     * @return Base64URL encoded signature
+     * @throws JOSEException if signing operation fails
+     * @throws IOException if payload serialization fails
+     */
+    private String signMsoMdocDocType(Object payload, JWSSigner mdocSigner) throws JOSEException, IOException {
+        // Create JWSHeader for ES256 algorithm
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+
+        // Convert payload to bytes for signing
+        byte[] payloadBytes;
+        if (payload instanceof String) {
+            payloadBytes = ((String) payload).getBytes(StandardCharsets.UTF_8);
+        } else {
+            payloadBytes = objectMapper.writeValueAsBytes(payload);
+        }
+
+        // Sign using the MSO_MDOC specific signer (ES256)
+        Base64URL signatureBase64URL = mdocSigner.sign(header, payloadBytes);
+        return signatureBase64URL.toString();
+    }
+
+    /**
+     * Creates MSO_MDOC signing result from document type signatures
+     * 
+     * @param documentTypeSignatures Map of document type to signature data
+     * @return LdpVPTokenSigningResult
+     */
+    private LdpVPTokenSigningResult createMsoMdocSigningResult(Map<String, Map<String, Object>> documentTypeSignatures) {
+        Map<String, Object> signingResultData = new HashMap<>();
+        signingResultData.put(OpenID4VPConstants.DOCUMENT_TYPE_SIGNATURES, documentTypeSignatures);
+        return objectMapper.convertValue(signingResultData, LdpVPTokenSigningResult.class);
+    }
+
+    /**
+     * Fetches selected credentials from the session cache
+     */
+    private List<DecryptedCredentialDTO> fetchSelectedCredentials(VerifiablePresentationSessionData sessionData, List<String> selectedCredentialIds) {
+
+        log.debug("Fetching {} selected credentials from cache", selectedCredentialIds.size());
+
+        if (sessionData.getMatchingCredentials() == null) {
+            throw new IllegalStateException("No matching credentials found in session cache");
+        }
+
+        return sessionData.getMatchingCredentials().stream()
+                .filter(credential -> selectedCredentialIds.contains(credential.getId()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Constructs unsigned VP token using the OpenID4VP JAR
+     */
+    private Map<FormatType, UnsignedVPToken> constructUnsignedVPToken(OpenID4VP openID4VP, List<DecryptedCredentialDTO> credentials, JWK jwk) throws IOException {
+
+        log.debug("Constructing unsigned VP token for {} credentials", credentials.size());
+
+        try {
+            Map<String, Map<FormatType, List<Object>>> verifiableCredentials = convertCredentialsToJarFormat(credentials);
+            String holderId = resolveHolderId(jwk);
+            return openID4VP.constructUnsignedVPToken(verifiableCredentials, holderId, DEFAULT_SIGNATURE_SUITE);
+        } catch (Exception e) {
+            log.error("Failed to construct unsigned VP token", e);
+            throw new IOException("Failed to construct VP token: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Resolves holderId from the user's public key using JWK format
+     */
+    private String resolveHolderId(JWK jwk) throws IOException {
+        try {
+            // Convert JWK to JSON string
+            String jwkJson = objectMapper.writeValueAsString(jwk.toPublicJWK().toJSONObject());
+
+            // Base64URL encode the JWK JSON
+            String base64UrlEncodedJwk = Base64Util.encode(jwkJson);
+
+            // Construct holderId: did:jwk:{base64url(jwk)}#0
+            return OpenID4VPConstants.DID_JWK_PREFIX + base64UrlEncodedJwk + OpenID4VPConstants.DID_KEY_FRAGMENT;
+
+        } catch (Exception e) {
+            log.error("Failed to resolve holderId from public key", e);
+            throw new IOException("Failed to resolve holderId: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Converts DecryptedCredentialDTO list to the format expected by the OpenID4VP JAR
+     * Extracts the inner credential data from VCCredentialResponse wrapper to remove the "credential" wrapper
+     */
+    private Map<String, Map<FormatType, List<Object>>> convertCredentialsToJarFormat(List<DecryptedCredentialDTO> credentials) {
+
+        return credentials.stream()
+                .collect(Collectors.groupingBy(
+                        DecryptedCredentialDTO::getId,
+                        Collectors.collectingAndThen(
+                                Collectors.toList(),
+                                credList -> credList.stream()
+                                        .collect(Collectors.groupingBy(
+                                                credential -> {
+                                                    // Get format and credential data
+                                                    VCCredentialResponse vcCredentialResponse = credential.getCredential();
+                                                    String credentialFormat = vcCredentialResponse.getFormat();
+                                                    // Convert format string to FormatType enum
+                                                    return mapStringToFormatType(credentialFormat);
+                                                },
+                                                Collectors.mapping(
+                                                        credential -> credential.getCredential().getCredential(),
+                                                        Collectors.toList()
+                                                )
+                                        ))
+                        )
+                ));
+    }
+
+    /**
+     * Maps format string to FormatType enum
+     */
+    private FormatType mapStringToFormatType(String format) {
+        if (format == null) {
+            return FormatType.LDP_VC; // Default fallback
+        }
+
+        return switch (format.toLowerCase()) {
+            case OpenID4VPConstants.FORMAT_LDP_VC_UNDERSCORE, 
+                 OpenID4VPConstants.FORMAT_LDP_VC_HYPHEN -> FormatType.LDP_VC;
+            case OpenID4VPConstants.FORMAT_MSO_MDOC_UNDERSCORE, 
+                 OpenID4VPConstants.FORMAT_MSO_MDOC_HYPHEN -> FormatType.MSO_MDOC;
+            // Add other supported formats as they become available in the OpenID4VP library
+            default -> {
+                log.warn("Unknown credential format: {}, defaulting to LDP_VC", format);
+                yield FormatType.LDP_VC;
+            }
+        };
+    }
+
+    /**
+     * Shares the verifiable presentation with the verifier
+     * First calls OpenID4VP JAR's shareVerifiablePresentation method, then makes HTTP POST
+     */
+    private boolean shareVerifiablePresentation(Map<FormatType, LdpVPTokenSigningResult> vpTokenSigningResults, VerifiablePresentationSessionData sessionData, OpenID4VP openID4VP) {
+        log.debug("Sharing verifiable presentation with verifier");
+
+        try {
+            // Step 1: Call OpenID4VP JAR's shareVerifiablePresentation method
+            log.debug("Calling OpenID4VP JAR's shareVerifiablePresentation method");
+            // Cast to the expected type for the JAR method
+            @SuppressWarnings({"unchecked", "rawtypes"}) Map<FormatType, VPTokenSigningResult> jarMap = (Map) vpTokenSigningResults;
+            String vpToken = openID4VP.shareVerifiablePresentation(jarMap);
+
+            return vpToken.trim().isEmpty();
+
+        } catch (Exception e) {
+            log.error("Failed to share verifiable presentation with verifier", e);
+            return false;
+        }
+    }
+
+    /**
+     * Stores presentation record in the database
+     * Uses @Transactional to ensure atomicity of database operations
+     */
+    @Transactional
+    private void storePresentationRecord(String walletId, String presentationId, SubmitPresentationRequestDTO request, VerifiablePresentationSessionData sessionData, boolean success, LocalDateTime requestedAt) {
+        log.debug("Storing presentation record in database - success: {}", success);
+
+        try {
+            if (sessionData == null) {
+                log.warn("Session data is null for presentationId: {}", presentationId);
+                return;
+            }
+
+            // Extract verifier information from OpenID4VP object
+            String verifierId = extractVerifierId(sessionData);
+            String authRequest = extractVerifierAuthRequest(sessionData);
+            String presentationData = createPresentationData(request, sessionData);
+
+            // Create the presentation record
+            VerifiablePresentation presentation = VerifiablePresentation.builder().id(presentationId).walletId(walletId)
+                    .authRequest(authRequest).presentationData(presentationData).verifierId(verifierId)
+                    .status(success ? OpenID4VPConstants.DB_STATUS_SUCCESS : OpenID4VPConstants.DB_STATUS_ERROR).requestedAt(requestedAt)
+                    .consent(true)
+                    .build();
+
+            // Save to database
+            verifiablePresentationRepository.save(presentation);
+
+            log.info("Presentation record stored successfully - recordId: {}, walletId: {}, presentationId: {}, status: {}", presentationId, walletId, presentationId, success ? OpenID4VPConstants.DB_STATUS_SUCCESS : OpenID4VPConstants.DB_STATUS_ERROR);
+
+        } catch (Exception e) {
+            // Critical failure - log with high severity and include all context
+            log.error("CRITICAL: Failed to store presentation record - walletId: {}, presentationId: {}, verifierId: {}, success: {}", 
+                    walletId, presentationId, 
+                    sessionData != null ? extractVerifierId(sessionData) : "unknown", 
+                    success, e);
+            // Note: Consider adding metrics/alerting here for production monitoring
+            // Example: metrics.incrementCounter("presentation.storage.failures");
+        }
+    }
+
+    /**
+     * Extracts verifier ID from session data
+     */
+    private String extractVerifierId(VerifiablePresentationSessionData sessionData) {
+        try {
+            // Since authorizationRequest is a URL, we need to extract client_id from URL parameters
+            if (sessionData.getAuthorizationRequest() != null) {
+                String authRequestUrl = sessionData.getAuthorizationRequest();
+                return UrlParameterUtils.extractClientIdFromUrl(authRequestUrl);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to extract verifier ID", e);
+        }
+        return UNKNOWN_VERIFIER;
+    }
+
+    /**
+     * Extracts verifier authorization request as JSON
+     */
+    private String extractVerifierAuthRequest(VerifiablePresentationSessionData sessionData) {
+        try {
+            if (sessionData.getAuthorizationRequest() != null) {
+                // Convert the URL string to a JSON object
+                Map<String, Object> authRequestData = new HashMap<>();
+                authRequestData.put(OpenID4VPConstants.AUTHORIZATION_REQUEST_URL, sessionData.getAuthorizationRequest());
+                return objectMapper.writeValueAsString(authRequestData);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to extract verifier auth request", e);
+        }
+        return EMPTY_JSON;
+    }
+
+    /**
+     * Creates presentation data JSON with selected credentials and metadata
+     */
+    private String createPresentationData(SubmitPresentationRequestDTO request, VerifiablePresentationSessionData sessionData) {
+        try {
+            Map<String, Object> presentationData = new HashMap<>();
+            presentationData.put(OpenID4VPConstants.SELECTED_CREDENTIALS, request.getSelectedCredentials());
+
+            return objectMapper.writeValueAsString(presentationData);
+        } catch (Exception e) {
+            log.warn("Failed to create presentation data", e);
+            return EMPTY_JSON;
+        }
+    }
+
+    /**
+     * Validates all input parameters for presentation submission
+     * 
+     * @throws IllegalArgumentException if any input is invalid
+     */
+    private void validateInputs(VerifiablePresentationSessionData sessionData, 
+                                String walletId, 
+                                String presentationId, 
+                                SubmitPresentationRequestDTO request, 
+                                String base64Key) {
+        if (sessionData == null) {
+            log.error("Session data cannot be null");
+            throw new IllegalArgumentException("Session data cannot be null");
+        }
+        
+        if (walletId == null || walletId.isBlank()) {
+            log.error("Wallet ID cannot be null or empty");
+            throw new IllegalArgumentException("Wallet ID cannot be null or empty");
+        }
+        
+        if (presentationId == null || presentationId.isBlank()) {
+            log.error("Presentation ID cannot be null or empty");
+            throw new IllegalArgumentException("Presentation ID cannot be null or empty");
+        }
+        
+        if (request == null) {
+            log.error("Request cannot be null");
+            throw new IllegalArgumentException("Request cannot be null");
+        }
+        
+        if (request.getSelectedCredentials() == null || request.getSelectedCredentials().isEmpty()) {
+            log.error("Selected credentials cannot be null or empty");
+            throw new IllegalArgumentException("Selected credentials cannot be null or empty");
+        }
+        
+        if (base64Key == null || base64Key.isBlank()) {
+            log.error("Base64 key cannot be null or empty");
+            throw new IllegalArgumentException("Base64 key cannot be null or empty");
+        }
+        
+        log.debug("Input validation passed for walletId: {}, presentationId: {}", walletId, presentationId);
+    }
+}

--- a/src/main/java/io/mosip/mimoto/service/impl/SessionManager.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/SessionManager.java
@@ -84,7 +84,7 @@ public class SessionManager {
         // Update the presentations map with the updated session data
         Map<String, VerifiablePresentationSessionData> presentations = (Map<String, VerifiablePresentationSessionData>) httpSession.getAttribute(SessionKeys.PRESENTATIONS + "::" + walletId);
         presentations.put(updatedSessionData.getPresentationId(), updatedSessionData);
-        httpSession.setAttribute(SessionKeys.PRESENTATIONS, presentations);
+        httpSession.setAttribute(SessionKeys.PRESENTATIONS  + "::" + walletId, presentations);
     }
 
     /**

--- a/src/main/java/io/mosip/mimoto/util/Base64Util.java
+++ b/src/main/java/io/mosip/mimoto/util/Base64Util.java
@@ -1,0 +1,189 @@
+package io.mosip.mimoto.util;
+
+import com.nimbusds.jose.util.Base64URL;
+import lombok.experimental.UtilityClass;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Utility class for Base64URL encoding and decoding operations.
+ * Provides centralized Base64URL functionality using both Java standard library
+ * and Nimbus JOSE library for consistency across the application.
+ */
+@UtilityClass
+public class Base64Util {
+
+    /**
+     * Encodes a string to Base64URL format using Nimbus JOSE library
+     * 
+     * @param input the string to encode
+     * @return Base64URL encoded string
+     */
+    public static String encode(String input) {
+        if (input == null) {
+            return null;
+        }
+        return Base64URL.encode(input.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+
+    /**
+     * Encodes a byte array to Base64URL format using Nimbus JOSE library
+     * 
+     * @param bytes the byte array to encode
+     * @return Base64URL encoded string
+     */
+    public static String encode(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        return Base64URL.encode(bytes).toString();
+    }
+
+    /**
+     * Decodes a Base64URL string to byte array using Nimbus JOSE library
+     * 
+     * @param base64UrlString the Base64URL encoded string
+     * @return decoded byte array
+     * @throws IllegalArgumentException if the input is not valid Base64URL
+     */
+    public static byte[] decode(String base64UrlString) {
+        if (base64UrlString == null) {
+            return null;
+        }
+        return Base64URL.from(base64UrlString).decode();
+    }
+
+    /**
+     * Decodes a Base64URL string to a UTF-8 string using Nimbus JOSE library
+     * 
+     * @param base64UrlString the Base64URL encoded string
+     * @return decoded UTF-8 string
+     * @throws IllegalArgumentException if the input is not valid Base64URL
+     */
+    public static String decodeToString(String base64UrlString) {
+        byte[] decoded = decode(base64UrlString);
+        return decoded != null ? new String(decoded, StandardCharsets.UTF_8) : null;
+    }
+
+    /**
+     * Alternative encoding method using Java standard library for compatibility
+     * 
+     * @param input the string to encode
+     * @return Base64URL encoded string using Java standard library
+     */
+    public static String encodeWithJavaStdLib(String input) {
+        if (input == null) {
+            return null;
+        }
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(input.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Alternative encoding method using Java standard library for compatibility
+     * 
+     * @param bytes the byte array to encode
+     * @return Base64URL encoded string using Java standard library
+     */
+    public static String encodeWithJavaStdLib(byte[] bytes) {
+        if (bytes == null) {
+            return null;
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    /**
+     * Alternative decoding method using Java standard library for compatibility
+     * 
+     * @param base64UrlString the Base64URL encoded string
+     * @return decoded byte array using Java standard library
+     * @throws IllegalArgumentException if the input is not valid Base64URL
+     */
+    public static byte[] decodeWithJavaStdLib(String base64UrlString) {
+        if (base64UrlString == null) {
+            return null;
+        }
+        return Base64.getUrlDecoder().decode(base64UrlString);
+    }
+
+    /**
+     * Converts a Base64 or Base64URL string to byte array with automatic format detection.
+     * This method tries Base64URL decoding first (common for JWT/VP tokens), 
+     * then falls back to standard Base64, and finally normalizes and retries if both fail.
+     * 
+     * @param base64String the Base64 or Base64URL encoded string
+     * @return decoded byte array
+     * @throws IllegalArgumentException if the input cannot be decoded in any supported format
+     */
+    public static byte[] decodeFlexible(String base64String) {
+        if (base64String == null) {
+            return null;
+        }
+        
+        try {
+            // First try Base64URL decoding (which is more common for JWT/VP tokens)
+            return Base64.getUrlDecoder().decode(base64String);
+        } catch (IllegalArgumentException e) {
+            try {
+                // Fallback to standard Base64 decoding
+                return Base64.getDecoder().decode(base64String);
+            } catch (IllegalArgumentException e2) {
+                // If both fail, normalize to standard Base64 and try again
+                String normalizedBase64 = normalizeBase64String(base64String);
+                return Base64.getDecoder().decode(normalizedBase64);
+            }
+        }
+    }
+
+    /**
+     * Normalizes a Base64URL string to standard Base64 format with proper padding.
+     * Converts '-' to '+', '_' to '/', and adds padding ('=') if needed.
+     * 
+     * @param base64String the Base64URL string to normalize
+     * @return normalized standard Base64 string with padding
+     */
+    public static String normalizeBase64String(String base64String) {
+        if (base64String == null) {
+            return null;
+        }
+        
+        String standardBase64 = base64String.replace('-', '+').replace('_', '/');
+
+        // Add padding if needed
+        while (standardBase64.length() % 4 != 0) {
+            standardBase64 += "=";
+        }
+
+        return standardBase64;
+    }
+
+    /**
+     * Creates a detached JWT signing input by concatenating header and payload bytes with a period ('.') separator.
+     * This is used for creating the input to sign for detached JWTs where the payload is not included in the final JWT.
+     * Uses ByteBuffer for efficient byte array concatenation.
+     * 
+     * Format: base64url(header) + '.' + payload_bytes
+     * 
+     * @param headerBase64 the Base64URL encoded header string
+     * @param payloadBytes the payload bytes to be signed
+     * @return byte array containing header bytes + '.' + payload bytes
+     */
+    public static byte[] createDetachedJwtSigningInput(String headerBase64, byte[] payloadBytes) {
+        if (headerBase64 == null || payloadBytes == null) {
+            throw new IllegalArgumentException("Header and payload cannot be null");
+        }
+        
+        byte[] headerBytes = headerBase64.getBytes(StandardCharsets.UTF_8);
+        byte periodByte = (byte) '.'; // ASCII 46
+        
+        // Use ByteBuffer for cleaner byte array concatenation
+        ByteBuffer buffer = ByteBuffer.allocate(headerBytes.length + 1 + payloadBytes.length);
+        buffer.put(headerBytes);
+        buffer.put(periodByte);
+        buffer.put(payloadBytes);
+        
+        return buffer.array();
+    }
+}

--- a/src/main/java/io/mosip/mimoto/util/Base64Util.java
+++ b/src/main/java/io/mosip/mimoto/util/Base64Util.java
@@ -17,7 +17,7 @@ public class Base64Util {
 
     /**
      * Encodes a string to Base64URL format using Nimbus JOSE library
-     * 
+     *
      * @param input the string to encode
      * @return Base64URL encoded string
      */
@@ -30,7 +30,7 @@ public class Base64Util {
 
     /**
      * Encodes a byte array to Base64URL format using Nimbus JOSE library
-     * 
+     *
      * @param bytes the byte array to encode
      * @return Base64URL encoded string
      */
@@ -43,7 +43,7 @@ public class Base64Util {
 
     /**
      * Decodes a Base64URL string to byte array using Nimbus JOSE library
-     * 
+     *
      * @param base64UrlString the Base64URL encoded string
      * @return decoded byte array
      * @throws IllegalArgumentException if the input is not valid Base64URL
@@ -57,7 +57,7 @@ public class Base64Util {
 
     /**
      * Decodes a Base64URL string to a UTF-8 string using Nimbus JOSE library
-     * 
+     *
      * @param base64UrlString the Base64URL encoded string
      * @return decoded UTF-8 string
      * @throws IllegalArgumentException if the input is not valid Base64URL
@@ -69,7 +69,7 @@ public class Base64Util {
 
     /**
      * Alternative encoding method using Java standard library for compatibility
-     * 
+     *
      * @param input the string to encode
      * @return Base64URL encoded string using Java standard library
      */
@@ -77,13 +77,12 @@ public class Base64Util {
         if (input == null) {
             return null;
         }
-        return Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(input.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(input.getBytes(StandardCharsets.UTF_8));
     }
 
     /**
      * Alternative encoding method using Java standard library for compatibility
-     * 
+     *
      * @param bytes the byte array to encode
      * @return Base64URL encoded string using Java standard library
      */
@@ -96,7 +95,7 @@ public class Base64Util {
 
     /**
      * Alternative decoding method using Java standard library for compatibility
-     * 
+     *
      * @param base64UrlString the Base64URL encoded string
      * @return decoded byte array using Java standard library
      * @throws IllegalArgumentException if the input is not valid Base64URL
@@ -110,9 +109,9 @@ public class Base64Util {
 
     /**
      * Converts a Base64 or Base64URL string to byte array with automatic format detection.
-     * This method tries Base64URL decoding first (common for JWT/VP tokens), 
+     * This method tries Base64URL decoding first (common for JWT/VP tokens),
      * then falls back to standard Base64, and finally normalizes and retries if both fail.
-     * 
+     *
      * @param base64String the Base64 or Base64URL encoded string
      * @return decoded byte array
      * @throws IllegalArgumentException if the input cannot be decoded in any supported format
@@ -121,7 +120,7 @@ public class Base64Util {
         if (base64String == null) {
             return null;
         }
-        
+
         try {
             // First try Base64URL decoding (which is more common for JWT/VP tokens)
             return Base64.getUrlDecoder().decode(base64String);
@@ -140,7 +139,7 @@ public class Base64Util {
     /**
      * Normalizes a Base64URL string to standard Base64 format with proper padding.
      * Converts '-' to '+', '_' to '/', and adds padding ('=') if needed.
-     * 
+     *
      * @param base64String the Base64URL string to normalize
      * @return normalized standard Base64 string with padding
      */
@@ -148,24 +147,24 @@ public class Base64Util {
         if (base64String == null) {
             return null;
         }
-        
-        String standardBase64 = base64String.replace('-', '+').replace('_', '/');
+
+        StringBuilder standardBase64 = new StringBuilder(base64String.replace('-', '+').replace('_', '/'));
 
         // Add padding if needed
         while (standardBase64.length() % 4 != 0) {
-            standardBase64 += "=";
+            standardBase64.append("=");
         }
 
-        return standardBase64;
+        return standardBase64.toString();
     }
 
     /**
      * Creates a detached JWT signing input by concatenating header and payload bytes with a period ('.') separator.
      * This is used for creating the input to sign for detached JWTs where the payload is not included in the final JWT.
      * Uses ByteBuffer for efficient byte array concatenation.
-     * 
+     * <p>
      * Format: base64url(header) + '.' + payload_bytes
-     * 
+     *
      * @param headerBase64 the Base64URL encoded header string
      * @param payloadBytes the payload bytes to be signed
      * @return byte array containing header bytes + '.' + payload bytes
@@ -174,16 +173,16 @@ public class Base64Util {
         if (headerBase64 == null || payloadBytes == null) {
             throw new IllegalArgumentException("Header and payload cannot be null");
         }
-        
+
         byte[] headerBytes = headerBase64.getBytes(StandardCharsets.UTF_8);
         byte periodByte = (byte) '.'; // ASCII 46
-        
+
         // Use ByteBuffer for cleaner byte array concatenation
         ByteBuffer buffer = ByteBuffer.allocate(headerBytes.length + 1 + payloadBytes.length);
         buffer.put(headerBytes);
         buffer.put(periodByte);
         buffer.put(payloadBytes);
-        
+
         return buffer.array();
     }
 }

--- a/src/main/java/io/mosip/mimoto/util/JwtGeneratorUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/JwtGeneratorUtil.java
@@ -60,7 +60,7 @@ public class JwtGeneratorUtil {
     }
 
 
-    private static JWK generateJwk(SigningAlgorithm algorithm, KeyPair keyPair) {
+    public static JWK generateJwk(SigningAlgorithm algorithm, KeyPair keyPair) {
         PublicKey publicKey = keyPair.getPublic();
         PrivateKey privateKey = keyPair.getPrivate();
 
@@ -99,7 +99,7 @@ public class JwtGeneratorUtil {
         };
     }
 
-    private static JWSSigner createSigner(SigningAlgorithm algorithm, JWK jwk) throws JOSEException {
+    public static JWSSigner createSigner(SigningAlgorithm algorithm, JWK jwk) throws JOSEException {
         return switch (algorithm) {
             case RS256 -> {
                 RSASSASigner signer = new RSASSASigner((RSAKey) jwk);

--- a/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
@@ -44,6 +44,9 @@ public class CredentialRequestServiceTest {
     @MockBean
     private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
 
+    @MockBean
+    private KeyPairService keyPairService;
+
     private final MockedStatic<KeyGenerationUtil> keyGenerationUtilMockedStatic = Mockito.mockStatic(KeyGenerationUtil.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
 
     IssuerDTO issuerDTO;

--- a/src/test/java/io/mosip/mimoto/service/KeyPairServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/KeyPairServiceTest.java
@@ -1,0 +1,489 @@
+package io.mosip.mimoto.service;
+
+import io.mosip.mimoto.constant.SigningAlgorithm;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+import io.mosip.mimoto.model.ProofSigningKey;
+import io.mosip.mimoto.model.Wallet;
+import io.mosip.mimoto.repository.ProofSigningKeyRepository;
+import io.mosip.mimoto.service.impl.KeyPairServiceImpl;
+import io.mosip.mimoto.util.EncryptionDecryptionUtil;
+import io.mosip.mimoto.util.KeyGenerationUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KeyPairServiceTest {
+
+    @InjectMocks
+    private KeyPairServiceImpl keyPairService;
+
+    @Mock
+    private ProofSigningKeyRepository proofSigningKeyRepository;
+
+    @Mock
+    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+
+    private String walletId;
+    private String base64EncodedWalletKey;
+    private ProofSigningKey proofSigningKey;
+    private KeyPair keyPair;
+
+    @Before
+    public void setUp() throws Exception {
+        walletId = "test-wallet-id";
+        
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("Ed25519");
+        keyPair = keyPairGenerator.generateKeyPair();
+        
+        byte[] walletKeyBytes = new byte[32];
+        for (int i = 0; i < 32; i++) {
+            walletKeyBytes[i] = (byte) i;
+        }
+        base64EncodedWalletKey = Base64.getEncoder().encodeToString(walletKeyBytes);
+        
+        Wallet wallet = new Wallet();
+        wallet.setId(walletId);
+        
+        proofSigningKey = new ProofSigningKey();
+        proofSigningKey.setId("key-id");
+        proofSigningKey.setWallet(wallet);
+        proofSigningKey.setPublicKey(Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+        proofSigningKey.setEncryptedSecretKey("encrypted-private-key");
+        proofSigningKey.setCreatedAt(Instant.now());
+        proofSigningKey.setUpdatedAt(Instant.now());
+    }
+
+    @Test
+    public void testGetKeyPairFromDBSuccessWithED25519() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenReturn(keyPair);
+            
+            KeyPair result = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            
+            assertNotNull(result);
+            assertEquals(keyPair, result);
+            verify(proofSigningKeyRepository).findByWalletIdAndAlgorithm(walletId, algorithm.name());
+            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq("encrypted-private-key"));
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBSuccessWithRS256() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.RS256;
+        
+        KeyPairGenerator rsaKeyGen = KeyPairGenerator.getInstance("RSA");
+        rsaKeyGen.initialize(2048);
+        KeyPair rsaKeyPair = rsaKeyGen.generateKeyPair();
+        
+        proofSigningKey.setPublicKey(Base64.getEncoder().encodeToString(rsaKeyPair.getPublic().getEncoded()));
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        byte[] decryptedPrivateKey = rsaKeyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenReturn(rsaKeyPair);
+            
+            KeyPair result = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            
+            assertNotNull(result);
+            assertEquals(rsaKeyPair, result);
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBSuccessWithES256() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ES256;
+        
+        KeyPairGenerator ecKeyGen = KeyPairGenerator.getInstance("EC");
+        ecKeyGen.initialize(256);
+        KeyPair ecKeyPair = ecKeyGen.generateKeyPair();
+        
+        proofSigningKey.setPublicKey(Base64.getEncoder().encodeToString(ecKeyPair.getPublic().getEncoded()));
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        byte[] decryptedPrivateKey = ecKeyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenReturn(ecKeyPair);
+            
+            KeyPair result = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            
+            assertNotNull(result);
+            assertEquals(ecKeyPair, result);
+        }
+    }
+
+    @Test(expected = KeyGenerationException.class)
+    public void testGetKeyPairFromDBThrowsKeyGenerationExceptionWhenKeyNotFound() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.empty());
+        
+        try {
+            keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+        } catch (KeyGenerationException e) {
+            assertEquals("KEY_NOT_FOUND", e.getErrorCode());
+            assertTrue(e.getErrorText().contains("No proof signing key found"));
+            assertTrue(e.getErrorText().contains(walletId));
+            assertTrue(e.getErrorText().contains(algorithm.toString()));
+            throw e;
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBThrowsDecryptionExceptionForInvalidBase64WalletKey() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        String invalidBase64Key = "Invalid!@#$%Base64";
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        try {
+            keyPairService.getKeyPairFromDB(walletId, invalidBase64Key, algorithm);
+            fail("Should have thrown DecryptionException");
+        } catch (DecryptionException e) {
+            assertEquals("INVALID_WALLET_KEY", e.getErrorCode());
+            assertTrue(e.getErrorText().contains("Invalid base64 encoded wallet key"));
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+        }
+    }
+
+    @Test(expected = KeyGenerationException.class)
+    public void testGetKeyPairFromDBThrowsKeyGenerationExceptionForInvalidBase64PublicKey() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        proofSigningKey.setPublicKey("Invalid!@#$%Base64PublicKey");
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class)) {
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            try {
+                keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            } catch (KeyGenerationException e) {
+                assertEquals("INVALID_PUBLIC_KEY", e.getErrorCode());
+                assertTrue(e.getErrorText().contains("Invalid base64 encoded public key"));
+                assertNotNull(e.getCause());
+                assertTrue(e.getCause() instanceof IllegalArgumentException);
+                throw e;
+            }
+        }
+    }
+
+    @Test(expected = DecryptionException.class)
+    public void testGetKeyPairFromDBThrowsDecryptionExceptionWhenDecryptionFails() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenThrow(new RuntimeException("Decryption error"));
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class)) {
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            try {
+                keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            } catch (DecryptionException e) {
+                assertEquals("DECRYPTION_FAILED", e.getErrorCode());
+                assertTrue(e.getErrorText().contains("Failed to decrypt private key"));
+                assertTrue(e.getErrorText().contains(walletId));
+                assertNotNull(e.getCause());
+                throw e;
+            }
+        }
+    }
+
+    @Test(expected = KeyGenerationException.class)
+    public void testGetKeyPairFromDBThrowsKeyGenerationExceptionWhenKeyPairGenerationFails() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenThrow(new RuntimeException("Key generation error"));
+            
+            try {
+                keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            } catch (KeyGenerationException e) {
+                assertEquals("KEY_GENERATION_FAILED", e.getErrorCode());
+                assertTrue(e.getErrorText().contains("Failed to generate KeyPair"));
+                assertTrue(e.getErrorText().contains(algorithm.toString()));
+                assertNotNull(e.getCause());
+                throw e;
+            }
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBWithDifferentWalletIds() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        String wallet1 = "wallet-1";
+        String wallet2 = "wallet-2";
+        
+        ProofSigningKey key1 = new ProofSigningKey();
+        key1.setPublicKey(Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+        key1.setEncryptedSecretKey("encrypted-key-1");
+        
+        ProofSigningKey key2 = new ProofSigningKey();
+        key2.setPublicKey(Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+        key2.setEncryptedSecretKey("encrypted-key-2");
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(wallet1, algorithm.name()))
+                .thenReturn(Optional.of(key1));
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(wallet2, algorithm.name()))
+                .thenReturn(Optional.of(key2));
+        
+        byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), anyString()))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenReturn(keyPair);
+            
+            KeyPair result1 = keyPairService.getKeyPairFromDB(wallet1, base64EncodedWalletKey, algorithm);
+            KeyPair result2 = keyPairService.getKeyPairFromDB(wallet2, base64EncodedWalletKey, algorithm);
+            
+            assertNotNull(result1);
+            assertNotNull(result2);
+            verify(proofSigningKeyRepository).findByWalletIdAndAlgorithm(wallet1, algorithm.name());
+            verify(proofSigningKeyRepository).findByWalletIdAndAlgorithm(wallet2, algorithm.name());
+            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq("encrypted-key-1"));
+            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq("encrypted-key-2"));
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBWithAllSigningAlgorithms() throws Exception {
+        for (SigningAlgorithm algorithm : SigningAlgorithm.values()) {
+            when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                    .thenReturn(Optional.of(proofSigningKey));
+            
+            byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
+            when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                    .thenReturn(decryptedPrivateKey);
+            
+            try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+                 MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+                
+                mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                        .thenReturn(mock(SecretKey.class));
+                
+                mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                        eq(algorithm), any(byte[].class), any(byte[].class)))
+                        .thenReturn(keyPair);
+                
+                KeyPair result = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+                
+                assertNotNull(result);
+            }
+            
+            reset(proofSigningKeyRepository, encryptionDecryptionUtil);
+        }
+    }
+
+    @Test(expected = KeyGenerationException.class)
+    public void testGetKeyPairFromDBWithNullProofSigningKeyRepository() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.empty());
+        
+        keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+    }
+
+    @Test
+    public void testGetKeyPairFromDBVerifiesRepositoryIsCalledWithCorrectParameters() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ES256;
+        String testWalletId = "specific-wallet-id";
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(testWalletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenReturn(keyPair);
+            
+            keyPairService.getKeyPairFromDB(testWalletId, base64EncodedWalletKey, algorithm);
+            
+            verify(proofSigningKeyRepository, times(1)).findByWalletIdAndAlgorithm(testWalletId, algorithm.name());
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBHandlesEmptyEncryptedSecretKey() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        proofSigningKey.setEncryptedSecretKey("");
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("")))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenReturn(keyPair);
+            
+            KeyPair result = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            
+            assertNotNull(result);
+            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq(""));
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBThrowsDecryptionExceptionForCorruptedWalletKey() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenThrow(new RuntimeException("Corrupted key - decryption failed"));
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class)) {
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            try {
+                keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+                fail("Should have thrown DecryptionException");
+            } catch (DecryptionException e) {
+                assertEquals("DECRYPTION_FAILED", e.getErrorCode());
+                assertTrue(e.getErrorText().contains("Failed to decrypt private key"));
+                assertTrue(e.getErrorText().contains(walletId));
+                assertNotNull(e.getCause());
+            }
+        }
+    }
+
+    @Test
+    public void testGetKeyPairFromDBLogsDebugMessages() throws Exception {
+        SigningAlgorithm algorithm = SigningAlgorithm.ED25519;
+        
+        when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
+                .thenReturn(Optional.of(proofSigningKey));
+        
+        byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
+        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+                .thenReturn(decryptedPrivateKey);
+        
+        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+             MockedStatic<KeyGenerationUtil> mockedStaticKeyGen = Mockito.mockStatic(KeyGenerationUtil.class)) {
+            
+            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                    .thenReturn(mock(SecretKey.class));
+            
+            mockedStaticKeyGen.when(() -> KeyGenerationUtil.getKeyPairFromDBStoredKeys(
+                    eq(algorithm), any(byte[].class), any(byte[].class)))
+                    .thenReturn(keyPair);
+            
+            KeyPair result = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
+            
+            assertNotNull(result);
+        }
+    }
+}
+

--- a/src/test/java/io/mosip/mimoto/service/PresentationActionServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationActionServiceTest.java
@@ -1,0 +1,360 @@
+package io.mosip.mimoto.service;
+
+import com.nimbusds.jose.JOSEException;
+import io.mosip.mimoto.dto.ErrorDTO;
+import io.mosip.mimoto.dto.RejectedVerifierDTO;
+import io.mosip.mimoto.dto.SubmitPresentationRequestDTO;
+import io.mosip.mimoto.dto.SubmitPresentationResponseDTO;
+import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+import io.mosip.mimoto.exception.VPErrorNotSentException;
+import io.mosip.mimoto.service.impl.PresentationActionServiceImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PresentationActionServiceTest {
+
+    @InjectMocks
+    private PresentationActionServiceImpl presentationActionService;
+
+    @Mock
+    private PresentationSubmissionService presentationSubmissionService;
+
+    @Mock
+    private PresentationService presentationService;
+
+    private static final String WALLET_ID = "wallet123";
+    private static final String PRESENTATION_ID = "presentation123";
+    private static final String BASE64_KEY = "encodedKey123";
+    private static final String AUTH_REQUEST = "client_id=test&nonce=123";
+
+    private VerifiablePresentationSessionData sessionData;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        sessionData = new VerifiablePresentationSessionData(
+                PRESENTATION_ID,
+                AUTH_REQUEST,
+                Instant.now(),
+                true,
+                null
+        );
+    }
+
+    @Test
+    public void testHandlePresentationAction_SubmissionSuccess() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123", "cred-456"))
+                .build();
+
+        SubmitPresentationResponseDTO expectedResponse = SubmitPresentationResponseDTO.builder()
+                .presentationId(PRESENTATION_ID)
+                .status("SUCCESS")
+                .message("Presentation successfully submitted and shared with verifier")
+                .build();
+
+        when(presentationSubmissionService.submitPresentation(
+                eq(sessionData), eq(WALLET_ID), eq(PRESENTATION_ID), eq(request), eq(BASE64_KEY)))
+                .thenReturn(expectedResponse);
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody() instanceof SubmitPresentationResponseDTO);
+        SubmitPresentationResponseDTO responseBody = (SubmitPresentationResponseDTO) response.getBody();
+        assertEquals(PRESENTATION_ID, responseBody.getPresentationId());
+        assertEquals("SUCCESS", responseBody.getStatus());
+
+        verify(presentationSubmissionService, times(1)).submitPresentation(
+                eq(sessionData), eq(WALLET_ID), eq(PRESENTATION_ID), eq(request), eq(BASE64_KEY));
+        verify(presentationService, never()).rejectVerifier(any(), any(), any());
+    }
+
+    @Test
+    public void testHandlePresentationAction_RejectionSuccess() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .errorCode("access_denied")
+                .errorMessage("User denied authorization to share credentials")
+                .build();
+
+        RejectedVerifierDTO expectedResponse = new RejectedVerifierDTO(
+                "success",
+                null,
+                "Presentation request rejected. An OpenID4VP error response has been sent to the verifier."
+        );
+
+        when(presentationService.rejectVerifier(eq(WALLET_ID), eq(sessionData), any(ErrorDTO.class)))
+                .thenReturn(expectedResponse);
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody() instanceof RejectedVerifierDTO);
+        RejectedVerifierDTO responseBody = (RejectedVerifierDTO) response.getBody();
+        assertEquals("success", responseBody.getStatus());
+
+        verify(presentationService, times(1)).rejectVerifier(eq(WALLET_ID), eq(sessionData), any(ErrorDTO.class));
+        verify(presentationSubmissionService, never()).submitPresentation(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testHandlePresentationAction_InvalidRequest_NoCredentialsOrError() throws Exception {
+        // Given - request with neither credentials nor error
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .build();
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return bad request error
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(presentationSubmissionService, never()).submitPresentation(any(), any(), any(), any(), any());
+        verify(presentationService, never()).rejectVerifier(any(), any(), any());
+    }
+
+    @Test
+    public void testHandlePresentationAction_InvalidRequest_EmptyCredentials() throws Exception {
+        // Given - request with empty credentials list
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Collections.emptyList())
+                .build();
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return bad request error
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        verify(presentationSubmissionService, never()).submitPresentation(any(), any(), any(), any(), any());
+        verify(presentationService, never()).rejectVerifier(any(), any(), any());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Submission_NullWalletKey() {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123"))
+                .build();
+
+        // When - wallet key is null
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, null);
+
+        // Then - should return bad request error
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Submission_EmptyWalletKey() {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123"))
+                .build();
+
+        // When - wallet key is empty
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, "");
+
+        // Then - should return bad request error
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Submission_JOSEException() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123"))
+                .build();
+
+        when(presentationSubmissionService.submitPresentation(
+                any(), any(), any(), any(), any()))
+                .thenThrow(new JOSEException("JWT signing failed"));
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return internal server error
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Submission_KeyGenerationException() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123"))
+                .build();
+
+        when(presentationSubmissionService.submitPresentation(
+                any(), any(), any(), any(), any()))
+                .thenThrow(new KeyGenerationException("Key generation failed", null));
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return internal server error
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Submission_DecryptionException() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123"))
+                .build();
+
+        when(presentationSubmissionService.submitPresentation(
+                any(), any(), any(), any(), any()))
+                .thenThrow(new DecryptionException("Decryption failed", null));
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return internal server error
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Submission_ApiNotAccessibleException() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123"))
+                .build();
+
+        when(presentationSubmissionService.submitPresentation(
+                any(), any(), any(), any(), any()))
+                .thenThrow(new ApiNotAccessibleException("API not accessible"));
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return internal server error
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Submission_IOException() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-123"))
+                .build();
+
+        when(presentationSubmissionService.submitPresentation(
+                any(), any(), any(), any(), any()))
+                .thenThrow(new IOException("IO error"));
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return internal server error
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_Rejection_VPErrorNotSentException() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .errorCode("access_denied")
+                .errorMessage("User denied")
+                .build();
+
+        when(presentationService.rejectVerifier(any(), any(), any()))
+                .thenThrow(new VPErrorNotSentException("Failed to send error to verifier"));
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then - should return internal server error
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    @Test
+    public void testHandlePresentationAction_RejectionWithNullWalletKey() {
+        // Given - rejection doesn't need wallet key
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .errorCode("access_denied")
+                .errorMessage("User denied authorization")
+                .build();
+
+        RejectedVerifierDTO expectedResponse = new RejectedVerifierDTO(
+                "success",
+                null,
+                "Presentation request rejected."
+        );
+
+        when(presentationService.rejectVerifier(eq(WALLET_ID), eq(sessionData), any(ErrorDTO.class)))
+                .thenReturn(expectedResponse);
+
+        // When - wallet key is null but should still work for rejection
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, null);
+
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(presentationService, times(1)).rejectVerifier(any(), any(), any());
+    }
+
+    @Test
+    public void testHandlePresentationAction_SubmissionWithMultipleCredentials() throws Exception {
+        // Given
+        SubmitPresentationRequestDTO request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList("cred-1", "cred-2", "cred-3", "cred-4"))
+                .build();
+
+        SubmitPresentationResponseDTO expectedResponse = SubmitPresentationResponseDTO.builder()
+                .presentationId(PRESENTATION_ID)
+                .status("SUCCESS")
+                .message("Presentation successfully submitted")
+                .build();
+
+        when(presentationSubmissionService.submitPresentation(
+                any(), any(), any(), any(), any()))
+                .thenReturn(expectedResponse);
+
+        // When
+        ResponseEntity<?> response = presentationActionService.handlePresentationAction(
+                WALLET_ID, PRESENTATION_ID, request, sessionData, BASE64_KEY);
+
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(presentationSubmissionService, times(1)).submitPresentation(
+                eq(sessionData), eq(WALLET_ID), eq(PRESENTATION_ID), eq(request), eq(BASE64_KEY));
+    }
+}
+

--- a/src/test/java/io/mosip/mimoto/service/PresentationSubmissionServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationSubmissionServiceTest.java
@@ -1,0 +1,1114 @@
+package io.mosip.mimoto.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.*;
+import io.mosip.mimoto.constant.OpenID4VPConstants;
+import io.mosip.mimoto.constant.SigningAlgorithm;
+import io.mosip.mimoto.dto.DecryptedCredentialDTO;
+import io.mosip.mimoto.dto.SubmitPresentationRequestDTO;
+import io.mosip.mimoto.dto.SubmitPresentationResponseDTO;
+import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
+import io.mosip.mimoto.dto.openid.VerifierDTO;
+import io.mosip.mimoto.dto.openid.VerifiersDTO;
+import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.exception.KeyGenerationException;
+import io.mosip.mimoto.model.CredentialMetadata;
+import io.mosip.mimoto.model.VerifiablePresentation;
+import io.mosip.mimoto.repository.VerifiablePresentationRepository;
+import io.mosip.mimoto.service.impl.OpenID4VPService;
+import io.mosip.mimoto.service.impl.PresentationSubmissionServiceImpl;
+import io.mosip.openID4VP.OpenID4VP;
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken;
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult;
+import io.mosip.openID4VP.constants.FormatType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.Instant;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Comprehensive test suite for PresentationSubmissionServiceImpl
+ * Tests all methods, lines, and branches for complete coverage
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PresentationSubmissionServiceTest {
+
+    @InjectMocks
+    private PresentationSubmissionServiceImpl presentationSubmissionService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private OpenID4VPService openID4VPService;
+
+    @Mock
+    private VerifierService verifierService;
+
+    @Mock
+    private KeyPairService keyPairService;
+
+    @Mock
+    private VerifiablePresentationRepository verifiablePresentationRepository;
+
+    @Mock
+    private OpenID4VP openID4VP;
+
+    @Mock
+    private JWSSigner jwsSigner;
+
+    private VerifiablePresentationSessionData sessionData;
+    private String walletId;
+    private String presentationId;
+    private String base64Key;
+    private SubmitPresentationRequestDTO request;
+    private KeyPair keyPair;
+    private VerifiersDTO verifiersDTO;
+
+    @Before
+    public void setUp() throws Exception {
+        ReflectionTestUtils.setField(presentationSubmissionService, "defaultSigningAlgorithmName", "ED25519");
+
+        walletId = "8a3d2c1b-4e5f-6a7b-8c9d-0e1f2a3b4c5d";
+        presentationId = "vp-presentation-" + System.currentTimeMillis();
+        base64Key = "VGhpc0lzQVNhbXBsZUJhc2U2NEVuY29kZWRXYWxsZXRLZXlGb3JUZXN0aW5nUHVycG9zZXM=";
+        request = SubmitPresentationRequestDTO.builder()
+                .selectedCredentials(Arrays.asList(
+                    "vc-credential-123e4567-e89b-12d3-a456-426614174000",
+                    "vc-credential-987f6543-e21a-98d7-b654-321098765432"
+                ))
+                .build();
+        
+        sessionData = new VerifiablePresentationSessionData();
+        sessionData.setPresentationId(presentationId);
+        sessionData.setAuthorizationRequest(
+            "openid4vp://?client_id=inji-verify-client-001" +
+            "&presentation_definition_uri=https%3A%2F%2Finji-verify.collab.mosip.net%2Fverifier%2Fpresentation_definition_uri" +
+            "&response_type=vp_token" +
+            "&response_mode=direct_post" +
+            "&nonce=NHgLcWlae745DpfJbUyfdg%3D%3D" +
+            "&response_uri=https%3A%2F%2Finji-verify.collab.mosip.net%2Fverifier%2Fvp-response" +
+            "&state=pcmxBfvdPEcjFObgt%2BLekA%3D%3D"
+        );
+        sessionData.setCreatedAt(Instant.now());
+        sessionData.setVerifierClientPreregistered(true);
+        sessionData.setMatchingCredentials(createMockDecryptedCredentials());
+
+        keyPair = generateKeyPairForAlgorithm(SigningAlgorithm.ED25519);
+
+        VerifierDTO verifierDTO = VerifierDTO.builder()
+                .clientId("inji-verify-client-001")
+                .responseUris(Arrays.asList(
+                    "https://inji-verify.collab.mosip.net/verifier/vp-response"
+                ))
+                .build();
+        verifiersDTO = VerifiersDTO.builder()
+                .verifiers(Arrays.asList(verifierDTO))
+                .build();
+    }
+
+
+    @Test
+    public void testSubmitPresentationSuccess() throws Exception {
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(presentationId, response.getPresentationId());
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+        assertEquals(OpenID4VPConstants.MESSAGE_PRESENTATION_SUCCESS, response.getMessage());
+
+        verify(openID4VPService).create(presentationId);
+        verify(verifierService).getTrustedVerifiers();
+        verify(keyPairService).getKeyPairFromDB(eq(walletId), eq(base64Key), any(SigningAlgorithm.class));
+        verify(verifiablePresentationRepository).save(any(VerifiablePresentation.class));
+    }
+
+    @Test
+    public void testSubmitPresentationSuccessWithMultipleCredentials() throws Exception {
+        request.setSelectedCredentials(Arrays.asList(
+            "vc-credential-123e4567-e89b-12d3-a456-426614174000",
+            "vc-credential-987f6543-e21a-98d7-b654-321098765432",
+            "vc-credential-456f7890-a12b-34c5-d678-901234567890"
+        ));
+        sessionData.setMatchingCredentials(createMockDecryptedCredentialsMultiple());
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSubmitPresentationSuccessWithSingleCredential() throws Exception {
+        request.setSelectedCredentials(Arrays.asList("vc-credential-123e4567-e89b-12d3-a456-426614174000"));
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSubmitPresentationSuccessWithVerifierNotPreregistered() throws Exception {
+        sessionData.setVerifierClientPreregistered(false);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+        verify(openID4VP).authenticateVerifier(anyString(), anyList(), eq(false));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSubmitPresentationFailureWithRS256AlgorithmForLdpVc() throws Exception {
+        
+        ReflectionTestUtils.setField(presentationSubmissionService, "defaultSigningAlgorithmName", "RS256");
+        keyPair = generateKeyPairForAlgorithm(SigningAlgorithm.RS256);
+        setupSuccessfulMocks();
+
+        presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+        
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSubmitPresentationFailureWithES256AlgorithmForLdpVc() throws Exception {
+        
+        ReflectionTestUtils.setField(presentationSubmissionService, "defaultSigningAlgorithmName", "ES256");
+        keyPair = generateKeyPairForAlgorithm(SigningAlgorithm.ES256);
+        setupSuccessfulMocks();
+
+        presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+        
+    }
+
+    @Test
+    public void testSubmitPresentationShareFailure() throws Exception {
+        setupMocksForShareFailure();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(presentationId, response.getPresentationId());
+        assertEquals(OpenID4VPConstants.STATUS_ERROR, response.getStatus());
+        assertEquals(OpenID4VPConstants.MESSAGE_PRESENTATION_SHARE_FAILED, response.getMessage());
+
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+        verify(verifiablePresentationRepository).save(captor.capture());
+        assertEquals(OpenID4VPConstants.DB_STATUS_ERROR, captor.getValue().getStatus());
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationNullSessionData() throws Exception {
+        presentationSubmissionService.submitPresentation(null, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationNullWalletId() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, null, presentationId, request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationEmptyWalletId() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, "", presentationId, request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationBlankWalletId() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, "   ", presentationId, request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationNullPresentationId() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, walletId, null, request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationEmptyPresentationId() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, walletId, "", request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationBlankPresentationId() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, walletId, "   ", request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationNullRequest() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, null, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationNullSelectedCredentials() throws Exception {
+        request.setSelectedCredentials(null);
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationEmptySelectedCredentials() throws Exception {
+        request.setSelectedCredentials(Collections.emptyList());
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationNullBase64Key() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationEmptyBase64Key() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, "");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSubmitPresentationBlankBase64Key() throws Exception {
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, "   ");
+    }
+
+
+    @Test(expected = IllegalStateException.class)
+    public void testSubmitPresentationNoMatchingCredentialsInSession() throws Exception {
+        sessionData.setMatchingCredentials(null);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = Exception.class)
+    public void testSubmitPresentationEmptyMatchingCredentialsInSession() throws Exception {
+        sessionData.setMatchingCredentials(Collections.emptyList());
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = ApiNotAccessibleException.class)
+    public void testSubmitPresentationVerifierServiceThrowsException() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenThrow(new ApiNotAccessibleException());
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = KeyGenerationException.class)
+    public void testSubmitPresentationKeyPairServiceThrowsException() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenReturn(verifiersDTO);
+        when(openID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(null);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), any(SigningAlgorithm.class)))
+                .thenThrow(new KeyGenerationException("KEY_GEN_ERROR", "Key generation failed"));
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = DecryptionException.class)
+    public void testSubmitPresentationDecryptionException() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenReturn(verifiersDTO);
+        when(openID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(null);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), any(SigningAlgorithm.class)))
+                .thenThrow(new DecryptionException("DECRYPTION_ERROR", "Decryption failed"));
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = Exception.class)
+    public void testSubmitPresentationIOException() throws Exception {
+        
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test(expected = Exception.class)
+    public void testSubmitPresentationJOSEException() throws Exception {
+        
+        setupMocksUpToSigning();
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), any(SigningAlgorithm.class)))
+                .thenThrow(new RuntimeException("Key retrieval failed"));
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+    }
+
+
+    @Test
+    public void testSubmitPresentationWithLdpVcFormat() throws Exception {
+        List<DecryptedCredentialDTO> ldpCredentials = createMockDecryptedCredentialsWithFormat("ldp_vc");
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(ldpCredentials);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSubmitPresentationWithMsoMdocFormat() throws Exception {
+        List<DecryptedCredentialDTO> msoMdocCredentials = createMockDecryptedCredentialsWithFormat("mso_mdoc");
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(msoMdocCredentials);
+        setupSuccessfulMocksForMsoMdoc();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSubmitPresentationWithMixedFormats() throws Exception {
+        List<DecryptedCredentialDTO> mixedCredentials = createMockDecryptedCredentialsWithMixedFormats();
+        request.setSelectedCredentials(Arrays.asList("vc-credential-mixed-ldp-1", "vc-credential-mixed-mdoc-2"));
+        sessionData.setMatchingCredentials(mixedCredentials);
+        setupSuccessfulMocksForMixedFormats();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+
+    @Test
+    public void testSubmitPresentationStoresPresentationRecordCorrectly() throws Exception {
+        setupSuccessfulMocks();
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        VerifiablePresentation saved = captor.getValue();
+        assertEquals(presentationId, saved.getId());
+        assertEquals(walletId, saved.getWalletId());
+        assertEquals(OpenID4VPConstants.DB_STATUS_SUCCESS, saved.getStatus());
+        assertTrue(saved.getConsent());
+        assertNotNull(saved.getAuthRequest());
+        assertNotNull(saved.getPresentationData());
+        assertNotNull(saved.getVerifierId());
+        assertNotNull(saved.getRequestedAt());
+    }
+
+    @Test
+    public void testSubmitPresentationStoresCorrectVerifierId() throws Exception {
+        setupSuccessfulMocks();
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        VerifiablePresentation saved = captor.getValue();
+        assertEquals("inji-verify-client-001", saved.getVerifierId()); // From mock data in setUp()
+    }
+
+    @Test
+    public void testSubmitPresentationHandlesDatabaseException() throws Exception {
+        setupSuccessfulMocks();
+        doThrow(new RuntimeException("Database error"))
+                .when(verifiablePresentationRepository).save(any(VerifiablePresentation.class));
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSubmitPresentationStoresErrorStatusOnShareFailure() throws Exception {
+        setupMocksForShareFailure();
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        VerifiablePresentation saved = captor.getValue();
+        assertEquals(OpenID4VPConstants.DB_STATUS_ERROR, saved.getStatus());
+    }
+
+
+    @Test
+    public void testSubmitPresentationExtractsVerifierIdFromUrl() throws Exception {
+        sessionData.setAuthorizationRequest("https://verifier.com/authorize?client_id=extracted-client-id&other=param");
+        setupSuccessfulMocks();
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        assertNotNull(captor.getValue().getVerifierId());
+    }
+
+    @Test
+    public void testSubmitPresentationHandlesNullAuthorizationRequest() throws Exception {
+        sessionData.setAuthorizationRequest(null);
+        setupSuccessfulMocks();
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        assertNotNull(captor.getValue().getVerifierId());
+    }
+
+
+    @Test
+    public void testSignMsoMdocFormatWithMultipleDocTypes() throws Exception {
+        setupSuccessfulMocksForMsoMdocWithMultipleDocTypes();
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsForMsoMdocMultipleDocTypes();
+        request.setSelectedCredentials(Arrays.asList("vc-credential-mdoc-multi-1", "vc-credential-mdoc-multi-2"));
+        sessionData.setMatchingCredentials(credentials);
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSignMsoMdocFormatWithEmptyDocTypes() throws Exception {
+        setupSuccessfulMocksForMsoMdocWithEmptyDocTypes();
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsForMsoMdocEmpty();
+        request.setSelectedCredentials(Arrays.asList("vc-credential-mdoc-empty-1"));
+        sessionData.setMatchingCredentials(credentials);
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSignMsoMdocFormatWithNullDocTypeToDeviceAuthenticationBytes() throws Exception {
+        setupSuccessfulMocksForMsoMdocWithNullDocTypes();
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsForMsoMdocNullDocTypes();
+        request.setSelectedCredentials(Arrays.asList("vc-credential-mdoc-null-1"));
+        sessionData.setMatchingCredentials(credentials);
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testSignMsoMdocFormatWithMissingDocTypeToDeviceAuthenticationBytes() throws Exception {
+        setupSuccessfulMocksForMsoMdocWithMissingDocTypeKey();
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsForMsoMdocEmpty();
+        request.setSelectedCredentials(Arrays.asList("vc-credential-mdoc-missing-key-1"));
+        sessionData.setMatchingCredentials(credentials);
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testSignMsoMdocFormatThrowsExceptionOnSigningFailure() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenReturn(verifiersDTO);
+        when(openID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(null);
+        
+        KeyPair es256KeyPair = generateKeyPairForAlgorithm(SigningAlgorithm.ES256);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), eq(SigningAlgorithm.ED25519)))
+                .thenReturn(keyPair);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), eq(SigningAlgorithm.ES256)))
+                .thenReturn(es256KeyPair);
+
+        Map<FormatType, UnsignedVPToken> unsignedVPTokenMap = new HashMap<>();
+        UnsignedVPToken msoMdocToken = mock(UnsignedVPToken.class);
+        unsignedVPTokenMap.put(FormatType.MSO_MDOC, msoMdocToken);
+
+        when(openID4VP.constructUnsignedVPToken(anyMap(), anyString(), anyString()))
+                .thenReturn(unsignedVPTokenMap);
+
+        Map<String, Object> complexPayload = new HashMap<>();
+        complexPayload.put("circularRef", complexPayload);
+        Map<String, Object> docTypeMap = new HashMap<>();
+        docTypeMap.put("docTypeToDeviceAuthenticationBytes", new HashMap<String, Object>() {{
+            put("org.iso.18013.5.1.mDL", complexPayload);
+        }});
+        when(objectMapper.convertValue(any(UnsignedVPToken.class), eq(Map.class)))
+                .thenReturn(docTypeMap);
+        when(objectMapper.writeValueAsBytes(any())).thenThrow(new RuntimeException("Serialization failed"));
+
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsForMsoMdocMultipleDocTypes();
+        request.setSelectedCredentials(Arrays.asList("vc-credential-mdoc-fail-1"));
+        sessionData.setMatchingCredentials(credentials);
+
+        presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+    }
+
+    @Test
+    public void testResolveHolderIdCreatesCorrectDidJwk() throws Exception {
+        setupSuccessfulMocks();
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(openID4VP).constructUnsignedVPToken(anyMap(), argThat(holderId -> 
+            holderId != null && holderId.startsWith("did:jwk:")), anyString());
+    }
+
+
+    @Test
+    public void testMapStringToFormatTypeLdpVcUnderscore() throws Exception {
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsWithFormat("ldp_vc");
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(credentials);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testMapStringToFormatTypeLdpVcHyphen() throws Exception {
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsWithFormat("ldp-vc");
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(credentials);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testMapStringToFormatTypeMsoMdocUnderscore() throws Exception {
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsWithFormat("mso_mdoc");
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(credentials);
+        setupSuccessfulMocksForMsoMdoc();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testMapStringToFormatTypeMsoMdocHyphen() throws Exception {
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsWithFormat("mso-mdoc");
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(credentials);
+        setupSuccessfulMocksForMsoMdoc();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testMapStringToFormatTypeUnknownDefaultsToLdpVc() throws Exception {
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsWithFormat("unknown_format");
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(credentials);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void testMapStringToFormatTypeNullDefaultsToLdpVc() throws Exception {
+        List<DecryptedCredentialDTO> credentials = createMockDecryptedCredentialsWithFormat(null);
+        request.setSelectedCredentials(Arrays.asList("vc-credential-format-test-1", "vc-credential-format-test-2"));
+        sessionData.setMatchingCredentials(credentials);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+
+    @Test
+    public void testShareVerifiablePresentationReturnsTrue() throws Exception {
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+        verify(openID4VP).shareVerifiablePresentation(anyMap());
+    }
+
+    @Test
+    public void testShareVerifiablePresentationReturnsFalse() throws Exception {
+        setupMocksForShareFailure();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertEquals(OpenID4VPConstants.STATUS_ERROR, response.getStatus());
+        assertEquals(OpenID4VPConstants.MESSAGE_PRESENTATION_SHARE_FAILED, response.getMessage());
+    }
+
+    @Test
+    public void testShareVerifiablePresentationHandlesException() throws Exception {
+        setupMocksForShareException();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertEquals(OpenID4VPConstants.STATUS_ERROR, response.getStatus());
+    }
+
+
+    @Test
+    public void testCreatePresentationDataIncludesSelectedCredentials() throws Exception {
+        setupSuccessfulMocks();
+        when(objectMapper.writeValueAsString(any())).thenAnswer(invocation -> {
+            Object arg = invocation.getArgument(0);
+            if (arg instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) arg;
+                if (map.containsKey(OpenID4VPConstants.SELECTED_CREDENTIALS)) {
+                    return "{\"selectedCredentials\":[\"cred-1\",\"cred-2\"]}";
+                }
+            }
+            return "{}";
+        });
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        String presentationData = captor.getValue().getPresentationData();
+        assertNotNull(presentationData);
+        assertTrue(presentationData.contains("selectedCredentials"));
+    }
+
+    @Test
+    public void testCreatePresentationDataHandlesJsonProcessingException() throws Exception {
+        
+        setupSuccessfulMocks();
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        String presentationData = captor.getValue().getPresentationData();
+        assertNotNull(presentationData);
+        assertTrue(presentationData.length() > 0);
+    }
+
+
+    @Test
+    public void testExtractVerifierAuthRequestCreatesJsonObject() throws Exception {
+        setupSuccessfulMocks();
+        when(objectMapper.writeValueAsString(any())).thenAnswer(invocation -> {
+            Object arg = invocation.getArgument(0);
+            if (arg instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) arg;
+                if (map.containsKey(OpenID4VPConstants.AUTHORIZATION_REQUEST_URL)) {
+                    return "{\"authorizationRequestUrl\":\"" + sessionData.getAuthorizationRequest() + "\"}";
+                }
+            }
+            return "{}";
+        });
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        String authRequest = captor.getValue().getAuthRequest();
+        assertNotNull(authRequest);
+        assertTrue(authRequest.contains("authorizationRequestUrl"));
+    }
+
+    @Test
+    public void testExtractVerifierAuthRequestHandlesException() throws Exception {
+        
+        setupSuccessfulMocks();
+        ArgumentCaptor<VerifiablePresentation> captor = ArgumentCaptor.forClass(VerifiablePresentation.class);
+
+        presentationSubmissionService.submitPresentation(sessionData, walletId, presentationId, request, base64Key);
+
+        verify(verifiablePresentationRepository).save(captor.capture());
+        String authRequest = captor.getValue().getAuthRequest();
+        assertNotNull(authRequest);
+        assertTrue(authRequest.length() > 0);
+    }
+
+
+    @Test
+    public void testSubmitPresentationWithVeryLongPresentationId() throws Exception {
+        String longPresentationId = "a".repeat(255);
+        sessionData.setPresentationId(longPresentationId);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, longPresentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(longPresentationId, response.getPresentationId());
+    }
+
+    @Test
+    public void testSubmitPresentationWithSpecialCharactersInWalletId() throws Exception {
+        String specialWalletId = "wallet-123_@#$%";
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, specialWalletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        verify(keyPairService).getKeyPairFromDB(eq(specialWalletId), anyString(), any(SigningAlgorithm.class));
+    }
+
+    @Test
+    public void testSubmitPresentationWithLargeNumberOfCredentials() throws Exception {
+        List<String> manyCredentials = new ArrayList<>();
+        List<DecryptedCredentialDTO> manyDecryptedCredentials = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            String credId = "cred-" + i;
+            manyCredentials.add(credId);
+            manyDecryptedCredentials.add(createMockDecryptedCredential(credId, "ldp_vc"));
+        }
+        request.setSelectedCredentials(manyCredentials);
+        sessionData.setMatchingCredentials(manyDecryptedCredentials);
+        setupSuccessfulMocks();
+
+        SubmitPresentationResponseDTO response = presentationSubmissionService.submitPresentation(
+                sessionData, walletId, presentationId, request, base64Key);
+
+        assertNotNull(response);
+        assertEquals(OpenID4VPConstants.STATUS_SUCCESS, response.getStatus());
+    }
+
+
+    private void setupSuccessfulMocks() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenReturn(verifiersDTO);
+        when(openID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(null);
+        
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), any(SigningAlgorithm.class)))
+                .thenReturn(keyPair);
+
+        Map<FormatType, UnsignedVPToken> unsignedVPTokenMap = new HashMap<>();
+        UnsignedLdpVPToken unsignedLdpVPToken = mock(UnsignedLdpVPToken.class);
+        when(unsignedLdpVPToken.getDataToSign()).thenReturn("dGVzdC1kYXRhLXRvLXNpZ24=");
+        unsignedVPTokenMap.put(FormatType.LDP_VC, unsignedLdpVPToken);
+
+        when(openID4VP.constructUnsignedVPToken(anyMap(), anyString(), anyString()))
+                .thenReturn(unsignedVPTokenMap);
+
+
+        when(openID4VP.shareVerifiablePresentation(anyMap())).thenReturn("");
+
+        when(objectMapper.convertValue(any(), eq(LdpVPTokenSigningResult.class)))
+                .thenReturn(mock(LdpVPTokenSigningResult.class));
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        when(verifiablePresentationRepository.save(any(VerifiablePresentation.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private void setupMocksUpToSigning() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenReturn(verifiersDTO);
+        when(openID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(null);
+
+
+    }
+
+    private void setupMocksForShareFailure() throws Exception {
+        setupSuccessfulMocks();
+        when(openID4VP.shareVerifiablePresentation(anyMap())).thenReturn("error-response");
+    }
+
+    private void setupMocksForShareException() throws Exception {
+        setupSuccessfulMocks();
+        when(openID4VP.shareVerifiablePresentation(anyMap())).thenThrow(new RuntimeException("Share failed"));
+    }
+
+    private void setupSuccessfulMocksForMsoMdoc() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenReturn(verifiersDTO);
+        when(openID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(null);
+        
+        KeyPair es256KeyPair = generateKeyPairForAlgorithm(SigningAlgorithm.ES256);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), eq(SigningAlgorithm.ED25519)))
+                .thenReturn(keyPair);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), eq(SigningAlgorithm.ES256)))
+                .thenReturn(es256KeyPair);
+
+        Map<FormatType, UnsignedVPToken> unsignedVPTokenMap = new HashMap<>();
+        UnsignedVPToken msoMdocToken = mock(UnsignedVPToken.class);
+        unsignedVPTokenMap.put(FormatType.MSO_MDOC, msoMdocToken);
+
+        when(openID4VP.constructUnsignedVPToken(anyMap(), anyString(), anyString()))
+                .thenReturn(unsignedVPTokenMap);
+
+        Map<String, Object> docTypeMap = new HashMap<>();
+        docTypeMap.put("docTypeToDeviceAuthenticationBytes", new HashMap<String, Object>() {{
+            put("org.iso.18013.5.1.mDL", "test-payload");
+        }});
+        when(objectMapper.convertValue(any(UnsignedVPToken.class), eq(Map.class)))
+                .thenReturn(docTypeMap);
+        when(objectMapper.convertValue(any(Map.class), eq(LdpVPTokenSigningResult.class)))
+                .thenReturn(mock(LdpVPTokenSigningResult.class));
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        when(openID4VP.shareVerifiablePresentation(anyMap())).thenReturn("");
+
+        when(verifiablePresentationRepository.save(any(VerifiablePresentation.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private void setupSuccessfulMocksForMixedFormats() throws Exception {
+        when(openID4VPService.create(anyString())).thenReturn(openID4VP);
+        when(verifierService.getTrustedVerifiers()).thenReturn(verifiersDTO);
+        when(openID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(null);
+        
+        KeyPair es256KeyPair = generateKeyPairForAlgorithm(SigningAlgorithm.ES256);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), eq(SigningAlgorithm.ED25519)))
+                .thenReturn(keyPair);
+        when(keyPairService.getKeyPairFromDB(anyString(), anyString(), eq(SigningAlgorithm.ES256)))
+                .thenReturn(es256KeyPair);
+
+        Map<FormatType, UnsignedVPToken> unsignedVPTokenMap = new HashMap<>();
+        UnsignedLdpVPToken ldpToken = mock(UnsignedLdpVPToken.class);
+        when(ldpToken.getDataToSign()).thenReturn("dGVzdC1kYXRhLXRvLXNpZ24=");
+        UnsignedVPToken msoToken = mock(UnsignedVPToken.class);
+        unsignedVPTokenMap.put(FormatType.LDP_VC, ldpToken);
+        unsignedVPTokenMap.put(FormatType.MSO_MDOC, msoToken);
+
+        when(openID4VP.constructUnsignedVPToken(anyMap(), anyString(), anyString()))
+                .thenReturn(unsignedVPTokenMap);
+
+        Map<String, Object> docTypeMap = new HashMap<>();
+        docTypeMap.put("docTypeToDeviceAuthenticationBytes", new HashMap<String, Object>() {{
+            put("org.iso.18013.5.1.mDL", "test-payload");
+        }});
+        when(objectMapper.convertValue(any(UnsignedVPToken.class), eq(Map.class)))
+                .thenReturn(docTypeMap);
+        when(objectMapper.convertValue(any(Map.class), eq(LdpVPTokenSigningResult.class)))
+                .thenReturn(mock(LdpVPTokenSigningResult.class));
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        when(openID4VP.shareVerifiablePresentation(anyMap())).thenReturn("");
+
+        when(verifiablePresentationRepository.save(any(VerifiablePresentation.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private void setupSuccessfulMocksForMsoMdocWithMultipleDocTypes() throws Exception {
+        setupSuccessfulMocksForMsoMdoc();
+        Map<String, Object> docTypeMap = new HashMap<>();
+        docTypeMap.put("docTypeToDeviceAuthenticationBytes", new HashMap<String, Object>() {{
+            put("org.iso.18013.5.1.mDL", "test-payload-1");
+            put("org.iso.18013.5.1.Passport", "test-payload-2");
+            put("org.iso.18013.5.1.HealthCard", "test-payload-3");
+        }});
+        when(objectMapper.convertValue(any(UnsignedVPToken.class), eq(Map.class)))
+                .thenReturn(docTypeMap);
+    }
+
+    private void setupSuccessfulMocksForMsoMdocWithEmptyDocTypes() throws Exception {
+        setupSuccessfulMocksForMsoMdoc();
+        Map<String, Object> docTypeMap = new HashMap<>();
+        docTypeMap.put("docTypeToDeviceAuthenticationBytes", new HashMap<>());
+        when(objectMapper.convertValue(any(UnsignedVPToken.class), eq(Map.class)))
+                .thenReturn(docTypeMap);
+    }
+
+    private void setupSuccessfulMocksForMsoMdocWithNullDocTypes() throws Exception {
+        setupSuccessfulMocksForMsoMdoc();
+        Map<String, Object> docTypeMap = new HashMap<>();
+        docTypeMap.put("docTypeToDeviceAuthenticationBytes", null);
+        when(objectMapper.convertValue(any(UnsignedVPToken.class), eq(Map.class)))
+                .thenReturn(docTypeMap);
+    }
+
+    private void setupSuccessfulMocksForMsoMdocWithMissingDocTypeKey() throws Exception {
+        setupSuccessfulMocksForMsoMdoc();
+        Map<String, Object> docTypeMap = new HashMap<>();
+        when(objectMapper.convertValue(any(UnsignedVPToken.class), eq(Map.class)))
+                .thenReturn(docTypeMap);
+    }
+
+    private List<DecryptedCredentialDTO> createMockDecryptedCredentials() {
+        return Arrays.asList(
+                createMockDecryptedCredential("vc-credential-123e4567-e89b-12d3-a456-426614174000", "ldp_vc"),
+                createMockDecryptedCredential("vc-credential-987f6543-e21a-98d7-b654-321098765432", "ldp_vc")
+        );
+    }
+
+    private List<DecryptedCredentialDTO> createMockDecryptedCredentialsMultiple() {
+        return Arrays.asList(
+                createMockDecryptedCredential("vc-credential-123e4567-e89b-12d3-a456-426614174000", "ldp_vc"),
+                createMockDecryptedCredential("vc-credential-987f6543-e21a-98d7-b654-321098765432", "ldp_vc"),
+                createMockDecryptedCredential("vc-credential-456f7890-a12b-34c5-d678-901234567890", "ldp_vc")
+        );
+    }
+
+    private List<DecryptedCredentialDTO> createMockDecryptedCredentialsWithFormat(String format) {
+        return Arrays.asList(
+                createMockDecryptedCredential("vc-credential-format-test-1", format),
+                createMockDecryptedCredential("vc-credential-format-test-2", format)
+        );
+    }
+
+    private List<DecryptedCredentialDTO> createMockDecryptedCredentialsWithMixedFormats() {
+        return Arrays.asList(
+                createMockDecryptedCredential("vc-credential-mixed-ldp-1", "ldp_vc"),
+                createMockDecryptedCredential("vc-credential-mixed-mdoc-2", "mso_mdoc")
+        );
+    }
+
+    private List<DecryptedCredentialDTO> createMockDecryptedCredentialsForMsoMdocMultipleDocTypes() {
+        return Arrays.asList(
+                createMockDecryptedCredential("vc-credential-mdoc-multi-1", "mso_mdoc"),
+                createMockDecryptedCredential("vc-credential-mdoc-multi-2", "mso_mdoc")
+        );
+    }
+
+    private List<DecryptedCredentialDTO> createMockDecryptedCredentialsForMsoMdocEmpty() {
+        return Arrays.asList(
+                createMockDecryptedCredential("vc-credential-mdoc-empty-1", "mso_mdoc")
+        );
+    }
+
+    private List<DecryptedCredentialDTO> createMockDecryptedCredentialsForMsoMdocNullDocTypes() {
+        return Arrays.asList(
+                createMockDecryptedCredential("vc-credential-mdoc-null-1", "mso_mdoc")
+        );
+    }
+
+    private DecryptedCredentialDTO createMockDecryptedCredential(String id, String format) {
+        DecryptedCredentialDTO credential = new DecryptedCredentialDTO();
+        credential.setId(id);
+        credential.setWalletId(walletId);
+        credential.setCreatedAt(Instant.now().minusSeconds(86400)); // Created 1 day ago
+        credential.setUpdatedAt(Instant.now());
+
+        CredentialMetadata metadata = new CredentialMetadata();
+        metadata.setIssuerId("https://esignet.collab.mosip.net/v1/esignet");
+        metadata.setCredentialType("MOSIPVerifiableCredential");
+        credential.setCredentialMetadata(metadata);
+
+        Map<String, Object> credentialData = new HashMap<>();
+        credentialData.put("@context", Arrays.asList(
+            "https://www.w3.org/2018/credentials/v1",
+            "https://www.w3.org/2018/credentials/examples/v1"
+        ));
+        credentialData.put("type", Arrays.asList("VerifiableCredential", "MOSIPVerifiableCredential"));
+        credentialData.put("issuer", "https://esignet.collab.mosip.net/v1/esignet");
+        credentialData.put("issuanceDate", Instant.now().minusSeconds(86400).toString());
+        credentialData.put("expirationDate", Instant.now().plusSeconds(31536000).toString()); // 1 year
+        
+        credentialData.put("credentialSubject", new HashMap<String, Object>() {{
+            put("id", "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2In0");
+            put("fullName", "John Doe");
+            put("email", "john.doe@example.com");
+            put("dateOfBirth", "1990-01-15");
+            put("gender", "Male");
+            put("phone", "+91-9876543210");
+            put("address", new HashMap<String, Object>() {{
+                put("street", "123 Main Street");
+                put("city", "Bangalore");
+                put("state", "Karnataka");
+                put("postalCode", "560001");
+                put("country", "India");
+            }});
+            put("UIN", "1234567890123456");
+        }});
+
+        if (format != null && (format.equals("ldp_vc") || format.equals("ldp-vc"))) {
+            credentialData.put("proof", new HashMap<String, Object>() {{
+                put("type", "Ed25519Signature2020");
+                put("created", Instant.now().minusSeconds(86400).toString());
+                put("verificationMethod", "https://esignet.collab.mosip.net/v1/esignet#key-1");
+                put("proofPurpose", "assertionMethod");
+                put("proofValue", "z3FXQjecWufY46yg5abdVZsXqLhxhueuSoZgsgwJTmN7bd8gZJVYRDEHbhGEfW6aeRgvNhZqr9h7LhzJBKqvqm8Qe");
+            }});
+        }
+
+        VCCredentialResponse vcResponse = VCCredentialResponse.builder()
+                .format(format != null ? format : "ldp_vc")
+                .credential(credentialData)
+                .build();
+
+        credential.setCredential(vcResponse);
+        return credential;
+    }
+
+    /**
+     * Helper method to generate KeyPair for different signing algorithms
+     * This ensures we use the correct key type for each algorithm
+     */
+    private KeyPair generateKeyPairForAlgorithm(SigningAlgorithm algorithm) throws Exception {
+        KeyPairGenerator keyPairGenerator;
+        
+        switch (algorithm) {
+            case RS256:
+                keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+                keyPairGenerator.initialize(2048);
+                break;
+                
+            case ES256:
+            case ES256K:
+                keyPairGenerator = KeyPairGenerator.getInstance("EC");
+                keyPairGenerator.initialize(256);
+                break;
+                
+            case ED25519:
+            default:
+                keyPairGenerator = KeyPairGenerator.getInstance("Ed25519");
+                break;
+        }
+        
+        return keyPairGenerator.generateKeyPair();
+    }
+
+}

--- a/src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
+++ b/src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
@@ -208,7 +208,7 @@ public class SessionManagerTest {
         // Assert
         @SuppressWarnings("unchecked")
         Map<String, VerifiablePresentationSessionData> updatedPresentations = 
-                (Map<String, VerifiablePresentationSessionData>) session.getAttribute(SessionKeys.PRESENTATIONS);
+                (Map<String, VerifiablePresentationSessionData>) session.getAttribute(SessionKeys.PRESENTATIONS + "::" + walletId);
         
         assertNotNull(updatedPresentations);
         assertTrue(updatedPresentations.containsKey(presentationId));
@@ -328,7 +328,7 @@ public class SessionManagerTest {
         // Assert
         @SuppressWarnings("unchecked")
         Map<String, VerifiablePresentationSessionData> updatedPresentations = 
-                (Map<String, VerifiablePresentationSessionData>) session.getAttribute(SessionKeys.PRESENTATIONS);
+                (Map<String, VerifiablePresentationSessionData>) session.getAttribute(SessionKeys.PRESENTATIONS + "::" + walletId);
         
         assertNotNull(updatedPresentations);
         VerifiablePresentationSessionData updatedSessionData = updatedPresentations.get(presentationId);
@@ -357,7 +357,7 @@ public class SessionManagerTest {
         // Assert
         @SuppressWarnings("unchecked")
         Map<String, VerifiablePresentationSessionData> updatedPresentations = 
-                (Map<String, VerifiablePresentationSessionData>) session.getAttribute(SessionKeys.PRESENTATIONS);
+                (Map<String, VerifiablePresentationSessionData>) session.getAttribute(SessionKeys.PRESENTATIONS + "::" + walletId);
         
         assertNotNull(updatedPresentations);
         VerifiablePresentationSessionData updatedSessionData = updatedPresentations.get(presentationId);

--- a/src/test/java/io/mosip/mimoto/util/Base64UtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/Base64UtilTest.java
@@ -1,0 +1,611 @@
+package io.mosip.mimoto.util;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.Assert.*;
+
+public class Base64UtilTest {
+
+    @Test
+    public void testEncodeStringSuccess() {
+        String input = "Hello World";
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("="));
+        assertFalse(result.contains("+"));
+        assertFalse(result.contains("/"));
+    }
+
+    @Test
+    public void testEncodeStringWithNullInput() {
+        String result = Base64Util.encode((String) null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testEncodeStringWithEmptyInput() {
+        String input = "";
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testEncodeStringWithSpecialCharacters() {
+        String input = "Hello@#$%^&*()_+-=[]{}|;:',.<>?/~`";
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("="));
+    }
+
+    @Test
+    public void testEncodeStringWithUnicodeCharacters() {
+        String input = "Hello 世界 🌍";
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("="));
+    }
+
+    @Test
+    public void testEncodeStringWithMultilineText() {
+        String input = "Line 1\nLine 2\nLine 3";
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("\n"));
+    }
+
+    @Test
+    public void testEncodeBytesSuccess() {
+        byte[] input = "Hello World".getBytes(StandardCharsets.UTF_8);
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("="));
+    }
+
+    @Test
+    public void testEncodeBytesWithNullInput() {
+        String result = Base64Util.encode((byte[]) null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testEncodeBytesWithEmptyArray() {
+        byte[] input = new byte[0];
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testEncodeBytesWithBinaryData() {
+        byte[] input = new byte[]{0x00, 0x01, 0x02, (byte) 0xFF, (byte) 0xFE};
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("="));
+    }
+
+    @Test
+    public void testDecodeSuccess() {
+        String input = "SGVsbG8gV29ybGQ";
+        byte[] result = Base64Util.decode(input);
+        
+        assertNotNull(result);
+        assertEquals("Hello World", new String(result, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testDecodeWithNullInput() {
+        byte[] result = Base64Util.decode(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testDecodeWithEmptyString() {
+        String input = "";
+        byte[] result = Base64Util.decode(input);
+        
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    public void testDecodeWithBase64UrlCharacters() {
+        String input = "SGVsbG8tV29ybGRf";
+        byte[] result = Base64Util.decode(input);
+        
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+
+    @Test
+    public void testDecodeWithInvalidBase64String() {
+        String input = "Invalid!@#$Base64";
+        try {
+            byte[] result = Base64Util.decode(input);
+            assertNotNull(result);
+        } catch (Exception e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void testDecodeToStringSuccess() {
+        String input = "SGVsbG8gV29ybGQ";
+        String result = Base64Util.decodeToString(input);
+        
+        assertNotNull(result);
+        assertEquals("Hello World", result);
+    }
+
+    @Test
+    public void testDecodeToStringWithNullInput() {
+        String result = Base64Util.decodeToString(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testDecodeToStringWithUnicodeContent() {
+        String original = "Hello 世界 🌍";
+        String encoded = Base64Util.encode(original);
+        String decoded = Base64Util.decodeToString(encoded);
+        
+        assertEquals(original, decoded);
+    }
+
+    @Test
+    public void testEncodeWithJavaStdLibStringSuccess() {
+        String input = "Hello World";
+        String result = Base64Util.encodeWithJavaStdLib(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("="));
+        assertFalse(result.contains("+"));
+        assertFalse(result.contains("/"));
+    }
+
+    @Test
+    public void testEncodeWithJavaStdLibStringWithNullInput() {
+        String result = Base64Util.encodeWithJavaStdLib((String) null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testEncodeWithJavaStdLibStringWithEmptyInput() {
+        String input = "";
+        String result = Base64Util.encodeWithJavaStdLib(input);
+        
+        assertNotNull(result);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testEncodeWithJavaStdLibBytesSuccess() {
+        byte[] input = "Hello World".getBytes(StandardCharsets.UTF_8);
+        String result = Base64Util.encodeWithJavaStdLib(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("="));
+    }
+
+    @Test
+    public void testEncodeWithJavaStdLibBytesWithNullInput() {
+        String result = Base64Util.encodeWithJavaStdLib((byte[]) null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testEncodeWithJavaStdLibBytesWithEmptyArray() {
+        byte[] input = new byte[0];
+        String result = Base64Util.encodeWithJavaStdLib(input);
+        
+        assertNotNull(result);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testDecodeWithJavaStdLibSuccess() {
+        String input = "SGVsbG8gV29ybGQ";
+        byte[] result = Base64Util.decodeWithJavaStdLib(input);
+        
+        assertNotNull(result);
+        assertEquals("Hello World", new String(result, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testDecodeWithJavaStdLibWithNullInput() {
+        byte[] result = Base64Util.decodeWithJavaStdLib(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testDecodeWithJavaStdLibWithEmptyString() {
+        String input = "";
+        byte[] result = Base64Util.decodeWithJavaStdLib(input);
+        
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDecodeWithJavaStdLibWithInvalidBase64String() {
+        String input = "Invalid!@#$Base64";
+        Base64Util.decodeWithJavaStdLib(input);
+    }
+
+    @Test
+    public void testDecodeFlexibleWithBase64UrlString() {
+        String input = "SGVsbG8tV29ybGRf";
+        byte[] result = Base64Util.decodeFlexible(input);
+        
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+
+    @Test
+    public void testDecodeFlexibleWithStandardBase64String() {
+        String input = Base64.getEncoder().encodeToString("Hello World".getBytes(StandardCharsets.UTF_8));
+        byte[] result = Base64Util.decodeFlexible(input);
+        
+        assertNotNull(result);
+        assertEquals("Hello World", new String(result, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testDecodeFlexibleWithNullInput() {
+        byte[] result = Base64Util.decodeFlexible(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testDecodeFlexibleWithBase64UrlNoPadding() {
+        String original = "Hello";
+        String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(original.getBytes(StandardCharsets.UTF_8));
+        byte[] result = Base64Util.decodeFlexible(encoded);
+        
+        assertNotNull(result);
+        assertEquals(original, new String(result, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testDecodeFlexibleFallsBackToStandardBase64() {
+        String original = "Test Data";
+        String encoded = Base64.getEncoder().encodeToString(original.getBytes(StandardCharsets.UTF_8));
+        byte[] result = Base64Util.decodeFlexible(encoded);
+        
+        assertNotNull(result);
+        assertEquals(original, new String(result, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testDecodeFlexibleWithBase64UrlCharactersAndNormalization() {
+        String base64UrlString = "SGVsbG8tV29ybGQ";
+        byte[] result = Base64Util.decodeFlexible(base64UrlString);
+        
+        assertNotNull(result);
+        assertTrue(result.length > 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDecodeFlexibleWithCompletelyInvalidString() {
+        String input = "!!!Invalid@@@";
+        Base64Util.decodeFlexible(input);
+    }
+
+    @Test
+    public void testNormalizeBase64StringWithBase64UrlCharacters() {
+        String input = "SGVsbG8tV29ybGRf";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("-"));
+        assertFalse(result.contains("_"));
+        assertTrue(result.contains("+") || !input.contains("-"));
+        assertTrue(result.contains("/") || !input.contains("_"));
+    }
+
+    @Test
+    public void testNormalizeBase64StringWithNullInput() {
+        String result = Base64Util.normalizeBase64String(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testNormalizeBase64StringAddsProperPadding() {
+        String input = "SGVsbG8";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertTrue(result.length() % 4 == 0);
+        assertTrue(result.endsWith("="));
+    }
+
+    @Test
+    public void testNormalizeBase64StringWithAlreadyPaddedString() {
+        String input = "SGVsbG8gV29ybGQ=";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertTrue(result.length() % 4 == 0);
+    }
+
+    @Test
+    public void testNormalizeBase64StringWithNoCharactersToReplace() {
+        String input = "SGVsbG8";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertTrue(result.length() % 4 == 0);
+    }
+
+    @Test
+    public void testNormalizeBase64StringWithEmptyString() {
+        String input = "";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testNormalizeBase64StringConvertsHyphenToPlus() {
+        String input = "SGVs-G8";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertTrue(result.contains("+"));
+        assertFalse(result.contains("-"));
+    }
+
+    @Test
+    public void testNormalizeBase64StringConvertsUnderscoreToSlash() {
+        String input = "SGVs_G8";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertTrue(result.contains("/"));
+        assertFalse(result.contains("_"));
+    }
+
+    @Test
+    public void testNormalizeBase64StringWithMultiplePaddingNeeded() {
+        String input = "SGVs";
+        String result = Base64Util.normalizeBase64String(input);
+        
+        assertNotNull(result);
+        assertTrue(result.length() % 4 == 0);
+        int paddingCount = result.length() - result.replace("=", "").length();
+        assertTrue(paddingCount >= 0);
+    }
+
+    @Test
+    public void testCreateDetachedJwtSigningInputSuccess() {
+        String header = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9";
+        byte[] payload = "test payload".getBytes(StandardCharsets.UTF_8);
+        
+        byte[] result = Base64Util.createDetachedJwtSigningInput(header, payload);
+        
+        assertNotNull(result);
+        String resultString = new String(result, StandardCharsets.UTF_8);
+        assertTrue(resultString.startsWith(header));
+        assertTrue(resultString.contains("."));
+        assertTrue(resultString.endsWith("test payload"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateDetachedJwtSigningInputWithNullHeader() {
+        byte[] payload = "test payload".getBytes(StandardCharsets.UTF_8);
+        Base64Util.createDetachedJwtSigningInput(null, payload);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateDetachedJwtSigningInputWithNullPayload() {
+        String header = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9";
+        Base64Util.createDetachedJwtSigningInput(header, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateDetachedJwtSigningInputWithBothNull() {
+        Base64Util.createDetachedJwtSigningInput(null, null);
+    }
+
+    @Test
+    public void testCreateDetachedJwtSigningInputWithEmptyHeader() {
+        String header = "";
+        byte[] payload = "test payload".getBytes(StandardCharsets.UTF_8);
+        
+        byte[] result = Base64Util.createDetachedJwtSigningInput(header, payload);
+        
+        assertNotNull(result);
+        String resultString = new String(result, StandardCharsets.UTF_8);
+        assertEquals(".test payload", resultString);
+    }
+
+    @Test
+    public void testCreateDetachedJwtSigningInputWithEmptyPayload() {
+        String header = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9";
+        byte[] payload = new byte[0];
+        
+        byte[] result = Base64Util.createDetachedJwtSigningInput(header, payload);
+        
+        assertNotNull(result);
+        String resultString = new String(result, StandardCharsets.UTF_8);
+        assertEquals(header + ".", resultString);
+    }
+
+    @Test
+    public void testCreateDetachedJwtSigningInputCorrectByteOrder() {
+        String header = "ABC";
+        byte[] payload = new byte[]{0x01, 0x02, 0x03};
+        
+        byte[] result = Base64Util.createDetachedJwtSigningInput(header, payload);
+        
+        assertNotNull(result);
+        assertEquals('A', (char) result[0]);
+        assertEquals('B', (char) result[1]);
+        assertEquals('C', (char) result[2]);
+        assertEquals('.', (char) result[3]);
+        assertEquals(0x01, result[4]);
+        assertEquals(0x02, result[5]);
+        assertEquals(0x03, result[6]);
+    }
+
+    @Test
+    public void testCreateDetachedJwtSigningInputCorrectLength() {
+        String header = "header123";
+        byte[] payload = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+        
+        byte[] result = Base64Util.createDetachedJwtSigningInput(header, payload);
+        
+        assertNotNull(result);
+        assertEquals(header.length() + 1 + payload.length, result.length);
+    }
+
+    @Test
+    public void testCreateDetachedJwtSigningInputWithLargePayload() {
+        String header = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9";
+        byte[] payload = new byte[10000];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i % 256);
+        }
+        
+        byte[] result = Base64Util.createDetachedJwtSigningInput(header, payload);
+        
+        assertNotNull(result);
+        assertEquals(header.length() + 1 + payload.length, result.length);
+    }
+
+    @Test
+    public void testEncodeAndDecodeRoundTrip() {
+        String original = "Test Data 123!@#";
+        String encoded = Base64Util.encode(original);
+        String decoded = Base64Util.decodeToString(encoded);
+        
+        assertEquals(original, decoded);
+    }
+
+    @Test
+    public void testEncodeWithJavaStdLibAndDecodeWithJavaStdLibRoundTrip() {
+        String original = "Test Data with Java StdLib";
+        String encoded = Base64Util.encodeWithJavaStdLib(original);
+        byte[] decoded = Base64Util.decodeWithJavaStdLib(encoded);
+        
+        assertEquals(original, new String(decoded, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testEncodeBytesAndDecodeRoundTrip() {
+        byte[] original = new byte[]{0x00, 0x01, 0x7F, (byte) 0x80, (byte) 0xFF};
+        String encoded = Base64Util.encode(original);
+        byte[] decoded = Base64Util.decode(encoded);
+        
+        assertArrayEquals(original, decoded);
+    }
+
+    @Test
+    public void testDecodeFlexibleWithNormalizedStringRoundTrip() {
+        String original = "Test Data for Flexible Decode";
+        String encoded = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(original.getBytes(StandardCharsets.UTF_8));
+        byte[] decoded = Base64Util.decodeFlexible(encoded);
+        
+        assertEquals(original, new String(decoded, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testConsistencyBetweenEncodeMethodsForString() {
+        String input = "Consistency Test";
+        String result1 = Base64Util.encode(input);
+        String result2 = Base64Util.encodeWithJavaStdLib(input);
+        
+        assertEquals(result1, result2);
+    }
+
+    @Test
+    public void testConsistencyBetweenEncodeMethodsForBytes() {
+        byte[] input = "Consistency Test".getBytes(StandardCharsets.UTF_8);
+        String result1 = Base64Util.encode(input);
+        String result2 = Base64Util.encodeWithJavaStdLib(input);
+        
+        assertEquals(result1, result2);
+    }
+
+    @Test
+    public void testDecodeFlexibleHandlesBase64UrlWithoutPadding() {
+        String original = "No padding test";
+        String encoded = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(original.getBytes(StandardCharsets.UTF_8));
+        byte[] decoded = Base64Util.decodeFlexible(encoded);
+        
+        assertNotNull(decoded);
+        assertEquals(original, new String(decoded, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testNormalizeBase64StringHandlesEdgeCaseLengths() {
+        String input1 = "A";
+        String result1 = Base64Util.normalizeBase64String(input1);
+        assertTrue(result1.length() % 4 == 0);
+        
+        String input2 = "AB";
+        String result2 = Base64Util.normalizeBase64String(input2);
+        assertTrue(result2.length() % 4 == 0);
+        
+        String input3 = "ABC";
+        String result3 = Base64Util.normalizeBase64String(input3);
+        assertTrue(result3.length() % 4 == 0);
+        
+        String input4 = "ABCD";
+        String result4 = Base64Util.normalizeBase64String(input4);
+        assertTrue(result4.length() % 4 == 0);
+    }
+
+    @Test
+    public void testCreateDetachedJwtSigningInputWithRealJwtHeader() {
+        String header = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImtleS0xMjMifQ";
+        byte[] payload = "{\"sub\":\"1234567890\",\"name\":\"John Doe\"}".getBytes(StandardCharsets.UTF_8);
+        
+        byte[] result = Base64Util.createDetachedJwtSigningInput(header, payload);
+        
+        assertNotNull(result);
+        assertTrue(result.length > header.length() + payload.length);
+        
+        String resultString = new String(result, StandardCharsets.UTF_8);
+        assertTrue(resultString.contains("."));
+        String[] parts = resultString.split("\\.", 2);
+        assertEquals(header, parts[0]);
+    }
+
+    @Test
+    public void testEncodeStringProducesUrlSafeOutput() {
+        String input = "Test string that might produce + or / characters when encoded";
+        String result = Base64Util.encode(input);
+        
+        assertNotNull(result);
+        assertFalse(result.contains("+"));
+        assertFalse(result.contains("/"));
+        assertFalse(result.contains("="));
+    }
+
+    @Test
+    public void testDecodeFlexibleWithMixedBase64AndBase64Url() {
+        String original = "Mixed encoding test";
+        String standardBase64 = Base64.getEncoder().encodeToString(original.getBytes(StandardCharsets.UTF_8));
+        
+        byte[] decoded = Base64Util.decodeFlexible(standardBase64);
+        
+        assertNotNull(decoded);
+        assertEquals(original, new String(decoded, StandardCharsets.UTF_8));
+    }
+}
+


### PR DESCRIPTION
- Add PresentationSubmissionService and implementation for handling VP submission
- Create SubmitPresentationRequestDTO and SubmitPresentationResponseDTO
- Add VerifiablePresentation entity and repository for VP persistence
- Create new database table for storing verifiable presentations
- Implement KeyPairService for generating and managing key pairs
- Add Base64Util for encoding/decoding operations
- Enhance WalletPresentationsController with submit presentation endpoint
- Add OpenID4VPConstants for centralized OpenID4VP-related constants
- Update SessionManager and other services to support VP submission flow