### PR TITLE
MOSIP-42816 fix error code for delete wallet - empty walletid scenario

### DIFF
--- a/api-test/src/main/resources/mimoto/LoginFlow/Wallet/DeleteWallet/DeleteWallet.yml
+++ b/api-test/src/main/resources/mimoto/LoginFlow/Wallet/DeleteWallet/DeleteWallet.yml
@@ -65,7 +65,7 @@ UnlockWallet:
       	"walletId": ""
 }'
       output: '{
-      "errorCode": "internal_server_error"
+      "errorCode": "invalid_request"
 }'
 
    Mimoto_DeleteWallet_Space_WalletId_Neg:


### PR DESCRIPTION
Change errorCode from internal_server_error to invalid_request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error responses for wallet deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->