### PR TITLE
[INJIWEB-1746] - Fix direct_post response mode: use form-encoded data and update redirect URI handling

### DIFF
--- a/src/main/java/io/mosip/mimoto/dto/openid/presentation/PresentationDefinitionDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/openid/presentation/PresentationDefinitionDTO.java
@@ -15,6 +15,6 @@ import java.util.List;
 public class PresentationDefinitionDTO {
 
     String id;
-    @JsonProperty("inputDescriptors")
+    @JsonProperty("input_descriptors")
     List<InputDescriptorDTO> inputDescriptors;
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -230,16 +230,20 @@ public class PresentationServiceImpl implements PresentationService {
             );
             log.info("Response from verifier after POST: {}", postResponse);
 
-            if(postResponse==null || !postResponse.containsKey("redirect_uri")) {
-                return redirectUri;
-            }
-            // Check for redirect_uri in response
-            else {
+            // Check for redirect_uri in response first
+            if (postResponse != null && postResponse.containsKey("redirect_uri")) {
                 String responseRedirectUri = (String) postResponse.get("redirect_uri");
                 if (responseRedirectUri != null && !responseRedirectUri.isEmpty()) {
                     return responseRedirectUri;
                 }
             }
+
+            // Use request's redirectUri if it's non-blank
+            if (redirectUri != null && !redirectUri.isBlank()) {
+                log.info("Using redirectUri from request: {}", redirectUri);
+                return redirectUri;
+            }
+
             // Fallback behavior if redirect_uri is not provided
             log.warn("No redirect_uri received from verifier in POST response. Falling back to response_uri.");
             return responseUri + "?status=vp_sent";

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -29,6 +29,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -168,6 +170,7 @@ public class PresentationServiceImpl implements PresentationService {
 
         // Create VP Token
         String vpToken = createVpToken(vpDTO);
+
         // Create PresentationSubmission
         String presentationSubmission = constructPresentationSubmission(format, vpDTO, presentationDefinitionDTO, inputDescriptorDTO);
 
@@ -175,6 +178,7 @@ public class PresentationServiceImpl implements PresentationService {
         if (presentationRequestDTO.getResponseMode() != null && "direct_post".equals(presentationRequestDTO.getResponseMode())) {
             return postVpToResponseUri(
                     presentationRequestDTO.getResponseUri(),
+                    presentationRequestDTO.getRedirectUri(),
                     vpToken,
                     presentationSubmission,
                     presentationRequestDTO.getState(),
@@ -207,32 +211,34 @@ public class PresentationServiceImpl implements PresentationService {
                 URLEncoder.encode(presentationSubmission, StandardCharsets.UTF_8));
     }
 
-    private String postVpToResponseUri(String responseUri, String vpToken, String presentationSubmission, String state, String nonce) throws JsonProcessingException {
-        Map<String, Object> postRequest = new HashMap<>();
-        postRequest.put("vp_token", vpToken);
-        postRequest.put("presentation_submission", objectMapper.readTree(presentationSubmission));
+    private String postVpToResponseUri(String responseUri, String redirectUri, String vpToken, String presentationSubmission, String state, String nonce) throws JsonProcessingException {
+        MultiValueMap<String, String> postRequest = new LinkedMultiValueMap<>();
+        postRequest.add("vp_token", Base64.getUrlEncoder().encodeToString(vpToken.getBytes(StandardCharsets.UTF_8)));
+        postRequest.add("presentation_submission", presentationSubmission);
 
         if (state != null) {
-            postRequest.put("state", state);
-        }
-
-        if (nonce != null) {
-            postRequest.put("nonce", nonce);
+            postRequest.add("state", state);
         }
 
         log.info("Posting VP to response_uri: {}", responseUri);
         try {
             Map<String, Object> postResponse = restApiClient.postApi(
                     responseUri,
-                    MediaType.APPLICATION_JSON,
+                    MediaType.APPLICATION_FORM_URLENCODED,
                     postRequest,
                     Map.class
             );
             log.info("Response from verifier after POST: {}", postResponse);
-            // Check for redirect_uri in response
-            String redirectUri = (String) postResponse.get("redirect_uri");
-            if (redirectUri != null && !redirectUri.isEmpty()) {
+
+            if(postResponse==null || !postResponse.containsKey("redirect_uri")) {
                 return redirectUri;
+            }
+            // Check for redirect_uri in response
+            else {
+                String responseRedirectUri = (String) postResponse.get("redirect_uri");
+                if (responseRedirectUri != null && !responseRedirectUri.isEmpty()) {
+                    return responseRedirectUri;
+                }
             }
             // Fallback behavior if redirect_uri is not provided
             log.warn("No redirect_uri received from verifier in POST response. Falling back to response_uri.");

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -639,7 +639,7 @@ public class PresentationServiceTest {
     @Test
     public void testDirectPostResponseModeWithEmptyRedirectUri() throws Exception {
         VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
-        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
+        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTOWithEmptyRedirectURI();
         presentationRequestDTO.setResponseMode("direct_post");
         presentationRequestDTO.setResponseUri("https://verifier.example.com/response");
         presentationRequestDTO.setState("test-state");

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -482,7 +482,7 @@ public class PresentationServiceTest {
 
         String result = presentationService.authorizePresentation(presentationRequestDTO);
 
-        assertEquals("https://verifier.example.com/response?status=vp_sent", result);
+        assertEquals("test_redirect_uri", result);
         verify(restApiClient).postApi(eq("https://verifier.example.com/response"), any(), any(), eq(Map.class));
     }
 

--- a/src/test/java/io/mosip/mimoto/util/TestUtilities.java
+++ b/src/test/java/io/mosip/mimoto/util/TestUtilities.java
@@ -293,6 +293,15 @@ public class TestUtilities {
                 .redirectUri("test_redirect_uri").build();
     }
 
+    public static PresentationRequestDTO getPresentationRequestDTOWithEmptyRedirectURI() {
+        return PresentationRequestDTO.builder()
+                .presentationDefinition(getPresentationDefinitionDTO())
+                .clientId("test_client_id")
+                .resource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test")
+                .responseType("test_response_type")
+                .redirectUri("").build();
+    }
+
     public static VCCredentialProperties getVCCredentialPropertiesDTO(String type) {
 
         ArrayList<String> contextList = new ArrayList<>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VP token is now URL-safe encoded and sent as form data; presentation submission sent as form-encoded payload.
  * Redirect handling improved: prefer response-provided redirect, fall back to request-provided redirect when needed, otherwise use status-based fallback.
  * JSON naming aligned for presentation definitions (snake_case for input descriptors).

* **Tests**
  * Updated tests and added helper to cover empty redirect URI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->