### PR TITLE
INJIWEB-1747 OpenID4VP Flow - Verifier request URL format change

### DIFF
--- a/src/main/java/io/mosip/mimoto/constant/OpenID4VPConstants.java
+++ b/src/main/java/io/mosip/mimoto/constant/OpenID4VPConstants.java
@@ -12,6 +12,7 @@ public class OpenID4VPConstants {
     // Authorization request structure keys
     public static final String AUTHORIZATION_REQUEST = "authorizationRequest";
     public static final String AUTHORIZATION_REQUEST_URL = "authorizationRequestUrl";
+    public static final String AUTHORIZATION_REQUEST_PREFIX = "openid4vp://authorize";
     
     // Presentation definition structure keys
     public static final String PRESENTATION_DEFINITION = "presentationDefinition";

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -40,6 +40,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static io.mosip.mimoto.constant.OpenID4VPConstants.AUTHORIZATION_REQUEST_PREFIX;
 import static io.mosip.mimoto.exception.ErrorConstants.REJECTED_VERIFIER;
 import static io.mosip.mimoto.util.JwtUtils.extractJwtPayloadFromSdJwt;
 import static io.mosip.mimoto.util.JwtUtils.parseJwtHeader;
@@ -78,7 +79,10 @@ public class PresentationServiceImpl implements PresentationService {
 
         List<Verifier> preRegisteredVerifiers = getPreRegisteredVerifiers();
         boolean shouldValidateClient = verifierService.isVerifierClientPreregistered(preRegisteredVerifiers, urlEncodedVPAuthorizationRequest);
-        AuthorizationRequest authorizationRequest = openID4VP.authenticateVerifier(urlEncodedVPAuthorizationRequest, preRegisteredVerifiers, shouldValidateClient);
+
+        String formattedRequest = AUTHORIZATION_REQUEST_PREFIX + urlEncodedVPAuthorizationRequest;
+
+        AuthorizationRequest authorizationRequest = openID4VP.authenticateVerifier(formattedRequest, preRegisteredVerifiers, shouldValidateClient);
         VerifiablePresentationVerifierDTO verifiablePresentationVerifierDTO = createVPResponseVerifierDTO(preRegisteredVerifiers, authorizationRequest, walletId);
 
         return new VerifiablePresentationResponseDTO(presentationId, verifiablePresentationVerifierDTO);


### PR DESCRIPTION
 Added openid4vp://authorize before sending the params to OpenID4VP method for parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenID4VP authorization request handling to include standard protocol prefix formatting for improved verification compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->