### PR TITLE
[INJIWEB-1757] Remove dependencies from pom.xml to fix license issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,16 @@
             <groupId>io.mosip.kernel</groupId>
             <artifactId>kernel-core</artifactId>
             <version>1.3.0-beta.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -223,10 +233,6 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
             <version>${starter.redis.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </dependency>
 
         <!-- MOSIP -->
         <dependency>
@@ -284,26 +290,11 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.2.9</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,9 @@
         <session.redis.version>3.4.0</session.redis.version>
         <starter.redis.version>3.4.1</starter.redis.version>
 
-        <!-- data -->
-        <h2.version>2.1.210</h2.version>
-
         <!-- test -->
         <junit.version>4.13.1</junit.version>
         <mockito.version>5.15.2</mockito.version>
-        <!-- logger -->
-        <logback.version>1.2.3</logback.version>
 
         <!-- json -->
         <jackson.version>2.13.2</jackson.version>


### PR DESCRIPTION
- Excluded transitive junit dependencies coming in from kernel-core
- Removed direct dependency of junit-vintage, logback and h2database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cleaned up project dependencies: added exclusions to avoid obsolete test artifacts, removed the legacy JUnit vintage engine, removed the embedded H2 database, and removed legacy Logback logging libraries to streamline builds and reduce potential conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->