### PR TITLE
[INJIWEB-1756] Add URL wildcard check for datashare resource URL as per security team feedback

### DIFF
--- a/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
@@ -134,10 +134,9 @@ public class DataShareServiceImpl {
     private static void validateResourceURL(String credentialsResourceUri) {
         try {
             URI parsedUri = new URI(credentialsResourceUri);
-            String path = parsedUri.getPath();
-            String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+            String decodedURI = parsedUri.getPath();
 
-            String wildcardPart = getWildcardPart(decodedPath);
+            String wildcardPart = getWildcardPart(decodedURI);
 
             if (!SAFE_URL_SEGMENT_PATTERN.matcher(wildcardPart).matches()) {
                 throw new InvalidCredentialResourceException(
@@ -169,7 +168,7 @@ public class DataShareServiceImpl {
             wildcardPart = segments[segments.length - 1];
         }
 
-        if (wildcardPart.isEmpty() || wildcardPart.contains(" ")) {
+        if (wildcardPart.isEmpty()) {
             throw new InvalidCredentialResourceException(
                     ErrorConstants.RESOURCE_INVALID.getErrorCode(),
                     "Invalid resource identifier in URL");

--- a/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
@@ -25,8 +25,6 @@ import org.springframework.util.PathMatcher;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
 @Slf4j

--- a/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
@@ -140,4 +140,65 @@ public class DataShareServiceTest {
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
     }
+
+    @Test
+    public void throwResourceInvalidRequestExceptionWhenCredentialURLHasIllegalDirectoryCharacter() {
+        String expectedExceptionMsg = "invalid_resource --> Invalid path structure in resource URL";
+        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/te..st")).thenReturn(true);
+
+        presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/te..st");
+
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
+    }
+
+    @Test
+    public void throwResourceInvalidRequestExceptionWhenCredentialURLHasIllegalForwardSlashCharacter() {
+        String expectedExceptionMsg = "invalid_resource --> Invalid path structure in resource URL";
+        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid//test")).thenReturn(true);
+
+        presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid//test");
+
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
+    }
+
+    @Test
+    public void throwResourceInvalidRequestExceptionWhenCredentialURLIsMisconfiguredAndHasNoWildcard() {
+        String expectedExceptionMsg = "invalid_resource --> Invalid resource identifier in URL";
+        ReflectionTestUtils.setField(dataShareService, "dataShareGetUrlPattern", "http://datashare.datashare/*");
+        Mockito.when(pathMatcher.match("http://datashare.datashare/*", "http://datashare.datashare/")).thenReturn(true);
+
+        presentationRequestDTO.setResource("http://datashare.datashare/");
+
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
+    }
+
+    @Test
+    public void throwResourceInvalidRequestExceptionWhenCredentialURLHasIllegalCharacters() {
+        String expectedExceptionMsg = "invalid_resource --> Invalid characters in wildcard segment";
+        presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test$");
+
+        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test$")).thenReturn(true);
+
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
+    }
+
+    @Test
+    public void throwResourceInvalidRequestExceptionWhenCredentialURLIsMalformed() {
+        String expectedExceptionMsg = "invalid_resource --> Malformed resource URL";
+        presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%%illegal");
+
+        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%%illegal")).thenReturn(true);
+
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
+    }
 }

--- a/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
@@ -201,4 +201,18 @@ public class DataShareServiceTest {
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
     }
+
+    @Test
+    public void throwResourceInvalidRequestExceptionWhenCredentialURLHasDoubleEncodedPathTraversal() {
+        String expectedExceptionMsg = "invalid_resource --> Invalid characters in wildcard segment";
+        presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%252e%252e");
+
+        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*",
+                "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%252e%252e")).thenReturn(true);
+
+        InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class,
+                () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
+
+        assertEquals(expectedExceptionMsg, actualException.getMessage());
+    }
 }


### PR DESCRIPTION
Added validation for the datashare URL received as a input to download endpoint. The aim is to ensure that there is no script or illegal characters added to the URL before mimoto service tries fetch the resource from the datashare service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened credential resource URL validation to reject malformed or unsafe URLs (illegal characters, invalid or empty path segments, double-encoded traversal, missing wildcard) prior to making data-share requests, improving robustness and security.

* **Tests**
  * Added comprehensive unit tests covering multiple invalid credential URL scenarios to ensure errors are raised and handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->