### PR TITLE
[INJIWEB-1780] Change redirect url fetching logic in datashare direct-post response mode to handle redirect_uri coming in from /vp-submission response

### DIFF
--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -229,6 +229,13 @@ public class PresentationServiceImpl implements PresentationService {
                     postRequest,
                     Map.class
             );
+
+            // Use request's redirectUri if it's non-blank
+            if (redirectUri != null && !redirectUri.isBlank()) {
+                log.info("Using redirectUri from request: {}", redirectUri);
+                return redirectUri;
+            }
+
             log.info("Response from verifier after POST: {}", postResponse);
 
             // Check for redirect_uri in response first
@@ -237,12 +244,6 @@ public class PresentationServiceImpl implements PresentationService {
                 if (responseRedirectUri != null && !responseRedirectUri.isEmpty()) {
                     return responseRedirectUri;
                 }
-            }
-
-            // Use request's redirectUri if it's non-blank
-            if (redirectUri != null && !redirectUri.isBlank()) {
-                log.info("Using redirectUri from request: {}", redirectUri);
-                return redirectUri;
             }
 
             // Fallback behavior if redirect_uri is not provided

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -428,6 +428,29 @@ public class PresentationServiceTest {
 
         String result = presentationService.authorizePresentation(presentationRequestDTO);
 
+        assertEquals("test_redirect_uri", result);
+        verify(restApiClient).postApi(eq("https://verifier.example.com/response"), any(), any(), eq(Map.class));
+    }
+
+    @Test
+    public void testDirectPostResponseModeWithNoRedirectURIParam() throws Exception {
+        VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
+        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
+        presentationRequestDTO.setResponseMode("direct_post");
+        presentationRequestDTO.setResponseUri("https://verifier.example.com/response");
+        presentationRequestDTO.setState("test-state");
+        presentationRequestDTO.setNonce("test-nonce");
+        presentationRequestDTO.setRedirectUri("");
+
+        Map<String, Object> mockResponse = Map.of("redirect_uri", "https://verifier.example.com/success");
+
+        when(dataShareService.downloadCredentialFromDataShare(eq(presentationRequestDTO))).thenReturn(vcCredentialResponse);
+        when(objectMapper.convertValue(eq(vcCredentialResponse.getCredential()), eq(VCCredentialProperties.class)))
+                .thenReturn((VCCredentialProperties) vcCredentialResponse.getCredential());
+        when(restApiClient.postApi(anyString(), any(), any(), eq(Map.class))).thenReturn(mockResponse);
+
+        String result = presentationService.authorizePresentation(presentationRequestDTO);
+
         assertEquals("https://verifier.example.com/success", result);
         verify(restApiClient).postApi(eq("https://verifier.example.com/response"), any(), any(), eq(Map.class));
     }


### PR DESCRIPTION
New behavior in data-share direct-post response mode : 
- First check if redirect_uri param exists, if it does redirect to the URL in it
- If it's missing or empty, check for redirect_uri in body of responseUri endpoint response.