### PR TITLE
INJIWEB-1750 Spike implementation of using injivc-renderer's SVG to PDF converter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,26 @@
             <artifactId>pixelpass-jar</artifactId>
             <version>0.7.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.mosip</groupId>
+            <artifactId>injivcrenderer-jar</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-transcoder</artifactId>
+            <version>1.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>fop</artifactId>
+            <version>2.11</version>
+        </dependency>
         <dependency>
             <groupId>io.mosip.kernel</groupId>
             <artifactId>kernel-biometrics-api</artifactId>
@@ -458,7 +477,6 @@
             <artifactId>caffeine</artifactId>
             <version>3.1.8</version>
         </dependency>
-
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>

--- a/src/main/java/io/mosip/mimoto/config/AppConfig.java
+++ b/src/main/java/io/mosip/mimoto/config/AppConfig.java
@@ -1,6 +1,7 @@
 package io.mosip.mimoto.config;
 
 
+import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.pixelpass.PixelPass;
 import io.mosip.vercred.vcverifier.CredentialsVerifier;
 import org.springframework.context.annotation.Bean;
@@ -16,5 +17,10 @@ public class AppConfig {
     @Bean
     public PixelPass pixelPass() {
         return new PixelPass();
+    }
+
+    @Bean
+    public InjiVcRenderer injiVcRenderer() {
+        return new InjiVcRenderer("inji-web");
     }
 }

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -13,6 +13,7 @@ import com.itextpdf.html2pdf.ConverterProperties;
 import com.itextpdf.html2pdf.HtmlConverter;
 import com.itextpdf.html2pdf.resolver.font.DefaultFontProvider;
 import com.itextpdf.kernel.pdf.PdfWriter;
+import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerDisplayResponse;
@@ -22,12 +23,13 @@ import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
 import io.mosip.mimoto.dto.openid.presentation.PresentationDefinitionDTO;
 import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
+import io.mosip.mimoto.util.Base64Util;
 import io.mosip.mimoto.util.LocaleUtils;
+import io.mosip.mimoto.util.SvgFixerUtil;
 import io.mosip.mimoto.util.Utilities;
 import io.mosip.pixelpass.PixelPass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.Velocity;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +45,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import java.util.Map;
-import java.util.Properties;
 
 @Slf4j
 @Service
@@ -68,6 +67,12 @@ public class CredentialPDFGeneratorService {
     @Autowired
     private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
 
+    @Autowired
+    private InjiVcRenderer injiVcRenderer;
+
+    @Autowired
+    private SvgFixerUtil svgFixerUtil;
+
     @Value("${mosip.inji.ovp.qrdata.pattern}")
     private String ovpQRDataPattern;
 
@@ -87,20 +92,27 @@ public class CredentialPDFGeneratorService {
     private boolean maskDisclosures;
 
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        // Get the appropriate processor based on format
-        CredentialFormatHandler processor = credentialFormatHandlerFactory.getHandler(vcCredentialResponse.getFormat());
+        // Check if this is a v2 data model credential
+        if (isV2DataModel(vcCredentialResponse)) {
+            log.info("Detected v2 data model for credential, using InjiVcRenderer");
+            return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse);
+        } else {
+            log.info("Using v1 data model flow for credential");
+            // Get the appropriate processor based on format
+            CredentialFormatHandler processor = credentialFormatHandlerFactory.getHandler(vcCredentialResponse.getFormat());
 
-        // Extract credential properties using the specific processor
-        Map<String, Object> credentialProperties = processor.extractCredentialClaims(vcCredentialResponse);
+            // Extract credential properties using the specific processor
+            Map<String, Object> credentialProperties = processor.extractCredentialClaims(vcCredentialResponse);
 
-        // Load display properties using the specific processor
-        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties =
-                processor.loadDisplayPropertiesFromWellknown(credentialProperties, credentialsSupportedResponse, locale);
+            // Load display properties using the specific processor
+            LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties =
+                    processor.loadDisplayPropertiesFromWellknown(credentialProperties, credentialsSupportedResponse, locale);
 
-        Map<String, Object> data = getPdfResourceFromVcProperties(displayProperties, credentialsSupportedResponse,
-                vcCredentialResponse, issuerDTO, dataShareUrl, credentialValidity);
+            Map<String, Object> data = getPdfResourceFromVcProperties(displayProperties, credentialsSupportedResponse,
+                    vcCredentialResponse, issuerDTO, dataShareUrl, credentialValidity);
 
-        return renderVCInCredentialTemplate(data, issuerDTO.getIssuer_id(), credentialConfigurationId);
+            return renderVCInCredentialTemplate(data, issuerDTO.getIssuer_id(), credentialConfigurationId);
+        }
     }
 
     private Map<String, Object> getPdfResourceFromVcProperties(
@@ -151,7 +163,7 @@ public class CredentialPDFGeneratorService {
                 if (disclosures.contains(key)) {
                     disclosuresProps.put(key, displayName);
                     if (maskDisclosures) {
-                        strVal = utilities.maskValue(strVal);
+                        strVal = Utilities.maskValue(strVal);
                     }
                 }
                 if (!isFaceKey && displayName != null) {
@@ -211,7 +223,9 @@ public class CredentialPDFGeneratorService {
             List<?> list = (List<?>) val;
             if (list.isEmpty()) return "";
             if (list.getFirst() instanceof String) {
-                return String.join(", ", (List<String>) list);
+                @SuppressWarnings("unchecked")
+                List<String> stringList = (List<String>) list;
+                return String.join(", ", stringList);
             } else if (list.getFirst() instanceof Map<?, ?>) {
                 return list.stream()
                         .filter(Objects::nonNull)
@@ -275,5 +289,54 @@ public class CredentialPDFGeneratorService {
         BufferedImage qrImage = MatrixToImageWriter.toBufferedImage(bitMatrix);
         return Utilities.encodeToString(qrImage, "png");
     }
-}
 
+    private boolean isV2DataModel(VCCredentialResponse vcCredentialResponse) {
+        // Extract credential data based on format
+        Object credentialPayload = vcCredentialResponse.getCredential();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> credentialPayloadMap = (Map<String, Object>) credentialPayload;
+        Object contextField = credentialPayloadMap.get("@context");
+
+        if (contextField instanceof List<?> contextEntries) {
+            return contextEntries.stream().anyMatch(entry -> entry.toString().contains("v2"));
+        } else if (contextField instanceof String) {
+            String contextFieldString = contextField.toString();
+            return contextFieldString.contains("v2");
+        }
+        return false;
+    }
+
+    private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse) throws Exception {
+        try {
+            // Convert credential to JSON string for InjiVcRenderer
+            String credentialJsonString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
+
+            // LDP VC format — wellKnown is in "credential_definition.credential_subject" of CredentialsSupportedResponse
+            String wellKnownJson = null;
+            if (credentialsSupportedResponse.getCredentialDefinition() != null &&
+                    credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject() != null) {
+                wellKnownJson = objectMapper.writeValueAsString(
+                        credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject());
+            }
+
+            // Generate credential display content using InjiVcRenderer
+            List<Object> generatedSvgObjects = injiVcRenderer.generateCredentialDisplayContent(
+                    io.mosip.injivcrenderer.constants.CredentialFormat.LDP_VC, wellKnownJson, credentialJsonString);
+
+            List<String> svgStrings = generatedSvgObjects.stream()
+                    .map(Object::toString)
+                    .map(svgFixerUtil::addMissingOffsetToStopElements)
+                    .toList();
+
+            log.debug("Fixed {} SVG elements for PDF conversion", svgStrings.size());
+
+            String base64PdfContent = injiVcRenderer.convertSvgToPdf(svgStrings);
+            byte[] decodedPdfBytes = Base64Util.decode(base64PdfContent);
+            return new ByteArrayInputStream(decodedPdfBytes);
+        } catch (Exception e) {
+            log.error("Error generating PDF for v2 credential using InjiVcRenderer: {}", e.getMessage(), e);
+            throw new Exception("Failed to generate PDF for v2 credential: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -92,8 +92,8 @@ public class CredentialPDFGeneratorService {
     private boolean maskDisclosures;
 
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        // Check if this is a v2 data model credential
-        if (isV2DataModel(vcCredentialResponse)) {
+        // Check if this is a v2 data model credential with template in the renderMethod
+        if (hasV2ContextWithSvgTemplate(vcCredentialResponse)) {
             log.info("Detected v2 data model for credential, using InjiVcRenderer");
             return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse);
         } else {
@@ -290,20 +290,44 @@ public class CredentialPDFGeneratorService {
         return Utilities.encodeToString(qrImage, "png");
     }
 
-    private boolean isV2DataModel(VCCredentialResponse vcCredentialResponse) {
+    private boolean hasV2ContextWithSvgTemplate(VCCredentialResponse vcCredentialResponse) {
         // Extract credential data based on format
         Object credentialPayload = vcCredentialResponse.getCredential();
 
+        // For SD-JWT credentialPayload is String
+        if (!(credentialPayload instanceof Map<?, ?>)) return false;
+
         @SuppressWarnings("unchecked")
         Map<String, Object> credentialPayloadMap = (Map<String, Object>) credentialPayload;
-        Object contextField = credentialPayloadMap.get("@context");
 
-        if (contextField instanceof List<?> contextEntries) {
-            return contextEntries.stream().anyMatch(entry -> entry.toString().contains("v2"));
-        } else if (contextField instanceof String) {
-            String contextFieldString = contextField.toString();
-            return contextFieldString.contains("v2");
+        return containsV2Context(credentialPayloadMap)
+                && containsSvgTemplate(credentialPayloadMap);
+    }
+
+    private boolean containsV2Context(Map<String, Object> credentialPayloadMap) {
+        Object contextField = credentialPayloadMap.get("@context");
+        if (contextField instanceof List<?> contextFieldList) {
+            return contextFieldList.stream()
+                    .anyMatch(entry -> entry.toString().contains("v2"));
         }
+        if (contextField instanceof String contextFieldString) return contextFieldString.contains("v2");
+
+        return false;
+    }
+
+    private boolean containsSvgTemplate(Map<String, Object> payload) {
+        Object renderMethod = payload.get("renderMethod");
+        if (renderMethod instanceof List<?> renderMethodList) {
+            return renderMethodList.stream().allMatch(entry -> {
+                if (!(entry instanceof Map<?, ?> renderMethodProperties)) return false;
+
+                return renderMethodProperties.containsKey("template");
+            });
+        }
+        if (renderMethod instanceof Map<?, ?> renderMethodMap) {
+            return renderMethodMap.containsKey("template");
+        }
+
         return false;
     }
 
@@ -311,14 +335,7 @@ public class CredentialPDFGeneratorService {
         try {
             // Convert credential to JSON string for InjiVcRenderer
             String credentialJsonString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
-
-            // LDP VC format — wellKnown is in "credential_definition.credential_subject" of CredentialsSupportedResponse
-            String wellKnownJson = null;
-            if (credentialsSupportedResponse.getCredentialDefinition() != null &&
-                    credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject() != null) {
-                wellKnownJson = objectMapper.writeValueAsString(
-                        credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject());
-            }
+            String wellKnownJson = objectMapper.writeValueAsString(credentialsSupportedResponse);
 
             // Generate credential display content using InjiVcRenderer
             List<Object> generatedSvgObjects = injiVcRenderer.generateCredentialDisplayContent(

--- a/src/main/java/io/mosip/mimoto/util/SvgFixerUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/SvgFixerUtil.java
@@ -1,0 +1,18 @@
+package io.mosip.mimoto.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SvgFixerUtil {
+
+    // Adds missing offset attribute to <stop/> elements in SVG content
+    public String addMissingOffsetToStopElements(String svgContent) {
+        if (svgContent == null) return null;
+
+        // Add offset="0" if missing in <stop> elements
+        return svgContent.replaceAll(
+                "<stop(?![^>]*offset=)",
+                "<stop offset=\"0\" "
+        );
+    }
+}


### PR DESCRIPTION
Added the sample implementation of InjivcRenderer's SvgToPdf converter.

Confluence page : https://mosip.atlassian.net/wiki/x/GQBogw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for v2-format credentials when generating PDFs.
  * Introduced a new rendering path to produce display-ready SVGs before PDF conversion.

* **Bug Fixes**
  * Fixed SVG rendering issues by ensuring gradient/stop offsets are present to prevent visual glitches.

* **Improvements**
  * Improved SVG-to-PDF conversion for more accurate credential appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->