### PR TITLE
Injiweb 1580 : Use of injivcrenderer for svg to pdf conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
         <dependency>
             <groupId>io.mosip</groupId>
             <artifactId>injivcrenderer-jar</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -428,7 +428,26 @@
             <artifactId>pixelpass-jar</artifactId>
             <version>0.7.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>io.mosip</groupId>
+            <artifactId>injivcrenderer-jar</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-transcoder</artifactId>
+            <version>1.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>fop</artifactId>
+            <version>2.11</version>
+        </dependency>
         <dependency>
             <groupId>io.mosip.kernel</groupId>
             <artifactId>kernel-biometrics-api</artifactId>
@@ -463,7 +482,6 @@
             <artifactId>caffeine</artifactId>
             <version>3.1.8</version>
         </dependency>
-
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>

--- a/src/main/java/io/mosip/mimoto/config/AppConfig.java
+++ b/src/main/java/io/mosip/mimoto/config/AppConfig.java
@@ -1,6 +1,7 @@
 package io.mosip.mimoto.config;
 
 
+import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.pixelpass.PixelPass;
 import io.mosip.vercred.vcverifier.CredentialsVerifier;
 import org.springframework.context.annotation.Bean;
@@ -16,5 +17,10 @@ public class AppConfig {
     @Bean
     public PixelPass pixelPass() {
         return new PixelPass();
+    }
+
+    @Bean
+    public InjiVcRenderer injiVcRenderer() {
+        return new InjiVcRenderer("inji-web");
     }
 }

--- a/src/main/java/io/mosip/mimoto/constant/LdpVcV2Constants.java
+++ b/src/main/java/io/mosip/mimoto/constant/LdpVcV2Constants.java
@@ -1,0 +1,17 @@
+package io.mosip.mimoto.constant;
+
+/**
+ * Constants for LDP VC credentials with V2 context
+ */
+public class LdpVcV2Constants {
+
+    // Credential context and URL
+    public static final String CONTEXT = "@context";
+    public static final String V2_CONTEXT_URL = "https://www.w3.org/ns/credentials/v2";
+
+    // Render method and its properties
+    public static final String RENDER_METHOD = "renderMethod";
+    public static final String TEMPLATE = "template";
+    public static final String RENDER_SUITE = "renderSuite";
+    public static final String SVG_MUSTACHE_RENDER_SUITE = "svg-mustache";
+}

--- a/src/main/java/io/mosip/mimoto/dto/mimoto/VCCredentialProperties.java
+++ b/src/main/java/io/mosip/mimoto/dto/mimoto/VCCredentialProperties.java
@@ -49,4 +49,6 @@ public class VCCredentialProperties implements Serializable {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Map<String, Object> credentialStatus;
+
+    private Object renderMethod;
 }

--- a/src/main/java/io/mosip/mimoto/dto/mimoto/VCCredentialProperties.java
+++ b/src/main/java/io/mosip/mimoto/dto/mimoto/VCCredentialProperties.java
@@ -50,5 +50,6 @@ public class VCCredentialProperties implements Serializable {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Map<String, Object> credentialStatus;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Object renderMethod;
 }

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -13,6 +13,7 @@ import com.itextpdf.html2pdf.ConverterProperties;
 import com.itextpdf.html2pdf.HtmlConverter;
 import com.itextpdf.html2pdf.resolver.font.DefaultFontProvider;
 import com.itextpdf.kernel.pdf.PdfWriter;
+import com.nimbusds.jose.util.Base64URL;
 import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.dto.IssuerDTO;
@@ -368,7 +369,7 @@ public class CredentialPDFGeneratorService {
             log.debug("Fixed {} SVG elements for PDF conversion", svgStrings.size());
 
             String base64PdfContent = injiVcRenderer.convertSvgToPdf(svgStrings);
-            byte[] decodedPdfBytes = Base64.getUrlDecoder().decode(base64PdfContent);
+            byte[] decodedPdfBytes = Base64URL.from(base64PdfContent).decode();
             return new ByteArrayInputStream(decodedPdfBytes);
         } catch (Exception e) {
             log.error("Error generating PDF for v2 credential using InjiVcRenderer: {}", e.getMessage(), e);

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -13,6 +13,7 @@ import com.itextpdf.html2pdf.ConverterProperties;
 import com.itextpdf.html2pdf.HtmlConverter;
 import com.itextpdf.html2pdf.resolver.font.DefaultFontProvider;
 import com.itextpdf.kernel.pdf.PdfWriter;
+import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerDisplayResponse;
@@ -22,12 +23,13 @@ import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
 import io.mosip.mimoto.dto.openid.presentation.PresentationDefinitionDTO;
 import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
+import io.mosip.mimoto.util.Base64Util;
 import io.mosip.mimoto.util.LocaleUtils;
+import io.mosip.mimoto.util.SvgFixerUtil;
 import io.mosip.mimoto.util.Utilities;
 import io.mosip.pixelpass.PixelPass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.Velocity;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +45,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import java.util.Map;
-import java.util.Properties;
 
 @Slf4j
 @Service
@@ -68,6 +67,12 @@ public class CredentialPDFGeneratorService {
     @Autowired
     private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
 
+    @Autowired
+    private InjiVcRenderer injiVcRenderer;
+
+    @Autowired
+    private SvgFixerUtil svgFixerUtil;
+
     @Value("${mosip.inji.ovp.qrdata.pattern}")
     private String ovpQRDataPattern;
 
@@ -87,20 +92,27 @@ public class CredentialPDFGeneratorService {
     private boolean maskDisclosures;
 
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        // Get the appropriate processor based on format
-        CredentialFormatHandler processor = credentialFormatHandlerFactory.getHandler(vcCredentialResponse.getFormat());
+        // Check if this is a v2 data model credential
+        if (isV2DataModel(vcCredentialResponse)) {
+            log.info("Detected v2 data model for credential, using InjiVcRenderer");
+            return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse);
+        } else {
+            log.info("Using v1 data model flow for credential");
+            // Get the appropriate processor based on format
+            CredentialFormatHandler processor = credentialFormatHandlerFactory.getHandler(vcCredentialResponse.getFormat());
 
-        // Extract credential properties using the specific processor
-        Map<String, Object> credentialProperties = processor.extractCredentialClaims(vcCredentialResponse);
+            // Extract credential properties using the specific processor
+            Map<String, Object> credentialProperties = processor.extractCredentialClaims(vcCredentialResponse);
 
-        // Load display properties using the specific processor
-        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties =
-                processor.loadDisplayPropertiesFromWellknown(credentialProperties, credentialsSupportedResponse, locale);
+            // Load display properties using the specific processor
+            LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties =
+                    processor.loadDisplayPropertiesFromWellknown(credentialProperties, credentialsSupportedResponse, locale);
 
-        Map<String, Object> data = getPdfResourceFromVcProperties(displayProperties, credentialsSupportedResponse,
-                vcCredentialResponse, issuerDTO, dataShareUrl, credentialValidity);
+            Map<String, Object> data = getPdfResourceFromVcProperties(displayProperties, credentialsSupportedResponse,
+                    vcCredentialResponse, issuerDTO, dataShareUrl, credentialValidity);
 
-        return renderVCInCredentialTemplate(data, issuerDTO.getIssuer_id(), credentialConfigurationId);
+            return renderVCInCredentialTemplate(data, issuerDTO.getIssuer_id(), credentialConfigurationId);
+        }
     }
 
     private Map<String, Object> getPdfResourceFromVcProperties(
@@ -151,7 +163,7 @@ public class CredentialPDFGeneratorService {
                 if (disclosures.contains(key)) {
                     disclosuresProps.put(key, displayName);
                     if (maskDisclosures) {
-                        strVal = utilities.maskValue(strVal);
+                        strVal = Utilities.maskValue(strVal);
                     }
                 }
                 if (!isFaceKey && displayName != null) {
@@ -211,7 +223,9 @@ public class CredentialPDFGeneratorService {
             List<?> list = (List<?>) val;
             if (list.isEmpty()) return "";
             if (list.getFirst() instanceof String) {
-                return String.join(", ", (List<String>) list);
+                @SuppressWarnings("unchecked")
+                List<String> stringList = (List<String>) list;
+                return String.join(", ", stringList);
             } else if (list.getFirst() instanceof Map<?, ?>) {
                 return list.stream()
                         .filter(Objects::nonNull)
@@ -275,5 +289,54 @@ public class CredentialPDFGeneratorService {
         BufferedImage qrImage = MatrixToImageWriter.toBufferedImage(bitMatrix);
         return Utilities.encodeToString(qrImage, "png");
     }
-}
 
+    private boolean isV2DataModel(VCCredentialResponse vcCredentialResponse) {
+        // Extract credential data based on format
+        Object credentialPayload = vcCredentialResponse.getCredential();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> credentialPayloadMap = (Map<String, Object>) credentialPayload;
+        Object contextField = credentialPayloadMap.get("@context");
+
+        if (contextField instanceof List<?> contextEntries) {
+            return contextEntries.stream().anyMatch(entry -> entry.toString().contains("v2"));
+        } else if (contextField instanceof String) {
+            String contextFieldString = contextField.toString();
+            return contextFieldString.contains("v2");
+        }
+        return false;
+    }
+
+    private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse) throws Exception {
+        try {
+            // Convert credential to JSON string for InjiVcRenderer
+            String credentialJsonString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
+
+            // LDP VC format — wellKnown is in "credential_definition.credential_subject" of CredentialsSupportedResponse
+            String wellKnownJson = null;
+            if (credentialsSupportedResponse.getCredentialDefinition() != null &&
+                    credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject() != null) {
+                wellKnownJson = objectMapper.writeValueAsString(
+                        credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject());
+            }
+
+            // Generate credential display content using InjiVcRenderer
+            List<Object> generatedSvgObjects = injiVcRenderer.generateCredentialDisplayContent(
+                    io.mosip.injivcrenderer.constants.CredentialFormat.LDP_VC, wellKnownJson, credentialJsonString);
+
+            List<String> svgStrings = generatedSvgObjects.stream()
+                    .map(Object::toString)
+                    .map(svgFixerUtil::addMissingOffsetToStopElements)
+                    .toList();
+
+            log.debug("Fixed {} SVG elements for PDF conversion", svgStrings.size());
+
+            String base64PdfContent = injiVcRenderer.convertSvgToPdf(svgStrings);
+            byte[] decodedPdfBytes = Base64Util.decode(base64PdfContent);
+            return new ByteArrayInputStream(decodedPdfBytes);
+        } catch (Exception e) {
+            log.error("Error generating PDF for v2 credential using InjiVcRenderer: {}", e.getMessage(), e);
+            throw new Exception("Failed to generate PDF for v2 credential: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -94,9 +94,9 @@ public class CredentialPDFGeneratorService {
     private boolean maskDisclosures;
 
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        // Check if credential is a v2 data model credential with template in the renderMethod
+        // Check if the credential is a LDP VC credential with v2 data model and has template in the renderMethod
         if (hasV2ContextWithSvgTemplate(vcCredentialResponse)) {
-            log.info("Detected v2 data model with render method and template for credential, using InjiVcRenderer");
+            log.info("Detected LDP VC v2 credential with svg template, using InjiVcRenderer for PDF generation");
             return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse, issuerDTO, dataShareUrl);
         } else {
             log.info("Using v1 data model flow for credential");
@@ -318,8 +318,8 @@ public class CredentialPDFGeneratorService {
         return false;
     }
 
-    private boolean containsSvgTemplate(Map<String, Object> payload) {
-        Object renderMethod = payload.get("renderMethod");
+    private boolean containsSvgTemplate(Map<String, Object> credentialPayloadMap) {
+        Object renderMethod = credentialPayloadMap.get("renderMethod");
         if (renderMethod instanceof List<?> renderMethodList) {
             return renderMethodList.stream().allMatch(entry -> {
                 if (!(entry instanceof Map<?, ?> renderMethodProperties)) return false;
@@ -336,26 +336,24 @@ public class CredentialPDFGeneratorService {
 
     private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse, IssuerDTO issuerDTO, String dataShareUrl) throws Exception {
         try {
-            // Get the ldp_vc credential as a Map
+            // Get the ldp_vc credential and convert to string
             @SuppressWarnings("unchecked")
-            Map<String, Object> credentialMap = (Map<String, Object>) vcCredentialResponse.getCredential();
+            Map<String, Object> credentialPayloadMap = (Map<String, Object>) vcCredentialResponse.getCredential();
+            String credentialJsonString = objectMapper.writeValueAsString(credentialPayloadMap);
 
-            // Adding the QR code image to the credential map
-            String qrCodeImage = "";
+            // Generate the QR code data to embed into the svg for Online Sharing
+            String qrCodeData = "";
             if (QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type())) {
-                qrCodeImage = constructQRCodeWithAuthorizeRequest(vcCredentialResponse, dataShareUrl);
-            } else if (QRCodeType.EmbeddedVC.equals(issuerDTO.getQr_code_type())) {
-                qrCodeImage = constructQRCodeWithVCData(vcCredentialResponse);
+                PresentationDefinitionDTO presentationDefinitionDTO = presentationService.constructPresentationDefinition(vcCredentialResponse);
+                String presentationString = objectMapper.writeValueAsString(presentationDefinitionDTO);
+                qrCodeData = String.format(ovpQRDataPattern, URLEncoder.encode(dataShareUrl, StandardCharsets.UTF_8), URLEncoder.encode(presentationString, StandardCharsets.UTF_8));
             }
-            credentialMap.put("qrCodeImage", qrCodeImage);
 
-            // Convert credential to JSON string for InjiVcRenderer
-            String credentialJsonString = objectMapper.writeValueAsString(credentialMap);
             String wellKnownJson = objectMapper.writeValueAsString(credentialsSupportedResponse);
 
-            // Generate credential display content using InjiVcRenderer
+            // Generate list of rendered svg strings using InjiVcRenderer
             List<Object> generatedSvgObjects = injiVcRenderer.generateCredentialDisplayContent(
-                    io.mosip.injivcrenderer.constants.CredentialFormat.LDP_VC, wellKnownJson, credentialJsonString);
+                    io.mosip.injivcrenderer.constants.CredentialFormat.LDP_VC, wellKnownJson, credentialJsonString, qrCodeData);
 
             if (generatedSvgObjects.isEmpty()) {
                  throw new Exception("No SVG content generated for v2 credential");

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -23,7 +23,6 @@ import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
 import io.mosip.mimoto.dto.openid.presentation.PresentationDefinitionDTO;
 import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
-import io.mosip.mimoto.util.Base64Util;
 import io.mosip.mimoto.util.LocaleUtils;
 import io.mosip.mimoto.util.SvgFixerUtil;
 import io.mosip.mimoto.util.Utilities;
@@ -49,6 +48,8 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 public class CredentialPDFGeneratorService {
+
+    private static final String V2_CONTEXT_URL = "https://www.w3.org/ns/credentials/v2";
 
     private record SelectedFace(String key, String face) {}
 
@@ -90,8 +91,6 @@ public class CredentialPDFGeneratorService {
 
     @Value("${mosip.injiweb.mask.disclosures:true}")
     private boolean maskDisclosures;
-
-    private static final String V2_CONTEXT_URL = "https://www.w3.org/ns/credentials/v2";
 
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
         // Check if credential is a v2 data model credential with template in the renderMethod
@@ -369,7 +368,7 @@ public class CredentialPDFGeneratorService {
             log.debug("Fixed {} SVG elements for PDF conversion", svgStrings.size());
 
             String base64PdfContent = injiVcRenderer.convertSvgToPdf(svgStrings);
-            byte[] decodedPdfBytes = Base64Util.decode(base64PdfContent);
+            byte[] decodedPdfBytes = Base64.getUrlDecoder().decode(base64PdfContent);
             return new ByteArrayInputStream(decodedPdfBytes);
         } catch (Exception e) {
             log.error("Error generating PDF for v2 credential using InjiVcRenderer: {}", e.getMessage(), e);

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -91,11 +91,13 @@ public class CredentialPDFGeneratorService {
     @Value("${mosip.injiweb.mask.disclosures:true}")
     private boolean maskDisclosures;
 
+    private static final String V2_CONTEXT_URL = "https://www.w3.org/ns/credentials/v2";
+
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        // Check if this is a v2 data model credential with template in the renderMethod
+        // Check if credential is a v2 data model credential with template in the renderMethod
         if (hasV2ContextWithSvgTemplate(vcCredentialResponse)) {
-            log.info("Detected v2 data model for credential, using InjiVcRenderer");
-            return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse);
+            log.info("Detected v2 data model with render method and template for credential, using InjiVcRenderer");
+            return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse, issuerDTO, dataShareUrl);
         } else {
             log.info("Using v1 data model flow for credential");
             // Get the appropriate processor based on format
@@ -291,10 +293,11 @@ public class CredentialPDFGeneratorService {
     }
 
     private boolean hasV2ContextWithSvgTemplate(VCCredentialResponse vcCredentialResponse) {
-        // Extract credential data based on format
-        Object credentialPayload = vcCredentialResponse.getCredential();
+        if (!CredentialFormat.LDP_VC.getFormat().equals(vcCredentialResponse.getFormat())) {
+            return false;
+        }
 
-        // For SD-JWT credentialPayload is String
+        Object credentialPayload = vcCredentialResponse.getCredential();
         if (!(credentialPayload instanceof Map<?, ?>)) return false;
 
         @SuppressWarnings("unchecked")
@@ -306,11 +309,11 @@ public class CredentialPDFGeneratorService {
 
     private boolean containsV2Context(Map<String, Object> credentialPayloadMap) {
         Object contextField = credentialPayloadMap.get("@context");
-        if (contextField instanceof List<?> contextFieldList) {
-            return contextFieldList.stream()
-                    .anyMatch(entry -> entry.toString().contains("v2"));
-        }
-        if (contextField instanceof String contextFieldString) return contextFieldString.contains("v2");
+
+        if (contextField instanceof List<?> contextList)
+            return contextList.stream().anyMatch(entry -> V2_CONTEXT_URL.equals(entry.toString()));
+        if (contextField instanceof String contextString)
+            return V2_CONTEXT_URL.equals(contextString);
 
         return false;
     }
@@ -331,15 +334,32 @@ public class CredentialPDFGeneratorService {
         return false;
     }
 
-    private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse) throws Exception {
+    private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse, IssuerDTO issuerDTO, String dataShareUrl) throws Exception {
         try {
+            // Get the ldp_vc credential as a Map
+            @SuppressWarnings("unchecked")
+            Map<String, Object> credentialMap = (Map<String, Object>) vcCredentialResponse.getCredential();
+
+            // Adding the QR code image to the credential map
+            String qrCodeImage = "";
+            if (QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type())) {
+                qrCodeImage = constructQRCodeWithAuthorizeRequest(vcCredentialResponse, dataShareUrl);
+            } else if (QRCodeType.EmbeddedVC.equals(issuerDTO.getQr_code_type())) {
+                qrCodeImage = constructQRCodeWithVCData(vcCredentialResponse);
+            }
+            credentialMap.put("qrCodeImage", qrCodeImage);
+
             // Convert credential to JSON string for InjiVcRenderer
-            String credentialJsonString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
+            String credentialJsonString = objectMapper.writeValueAsString(credentialMap);
             String wellKnownJson = objectMapper.writeValueAsString(credentialsSupportedResponse);
 
             // Generate credential display content using InjiVcRenderer
             List<Object> generatedSvgObjects = injiVcRenderer.generateCredentialDisplayContent(
                     io.mosip.injivcrenderer.constants.CredentialFormat.LDP_VC, wellKnownJson, credentialJsonString);
+
+            if (generatedSvgObjects.isEmpty()) {
+                 throw new Exception("No SVG content generated for v2 credential");
+            }
 
             List<String> svgStrings = generatedSvgObjects.stream()
                     .map(Object::toString)

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -96,7 +96,7 @@ public class CredentialPDFGeneratorService {
         // Check if the credential can support SVG based rendering
         if (isSvgBasedRenderingSupported(vcCredentialResponse)) {
             log.info("Detected LDP VC v2 credential with svg template, using InjiVcRenderer for PDF generation");
-            return generatePdfForV2Credential(vcCredentialResponse, issuerDTO, dataShareUrl);
+            return generatePdfUsingSvgTemplate(vcCredentialResponse, issuerDTO, dataShareUrl);
         } else {
             log.info("Using v1 data model flow for credential");
             // Get the appropriate processor based on format
@@ -224,9 +224,7 @@ public class CredentialPDFGeneratorService {
             List<?> list = (List<?>) val;
             if (list.isEmpty()) return "";
             if (list.getFirst() instanceof String) {
-                @SuppressWarnings("unchecked")
-                List<String> stringList = (List<String>) list;
-                return String.join(", ", stringList);
+                return String.join(", ", (List<String>) list);
             } else if (list.getFirst() instanceof Map<?, ?>) {
                 return list.stream()
                         .filter(Objects::nonNull)
@@ -335,12 +333,10 @@ public class CredentialPDFGeneratorService {
         return false;
     }
 
-    private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, String dataShareUrl) throws Exception {
+    private ByteArrayInputStream generatePdfUsingSvgTemplate(VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, String dataShareUrl) throws Exception {
         try {
             // Get the ldp_vc credential and convert to string
-            @SuppressWarnings("unchecked")
-            Map<String, Object> credentialPayloadMap = (Map<String, Object>) vcCredentialResponse.getCredential();
-            String credentialJsonString = objectMapper.writeValueAsString(credentialPayloadMap);
+            String credentialJsonString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
 
             // Generate the QR code data to embed into the svg for Online Sharing
             String qrCodeData = null;

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -16,6 +16,7 @@ import com.itextpdf.kernel.pdf.PdfWriter;
 import com.nimbusds.jose.util.Base64URL;
 import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.CredentialFormat;
+import io.mosip.mimoto.constant.LdpVcV2Constants;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerDisplayResponse;
 import io.mosip.mimoto.dto.mimoto.CredentialSupportedDisplayResponse;
@@ -49,8 +50,6 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 public class CredentialPDFGeneratorService {
-
-    private static final String V2_CONTEXT_URL = "https://www.w3.org/ns/credentials/v2";
 
     private record SelectedFace(String key, String face) {}
 
@@ -94,10 +93,10 @@ public class CredentialPDFGeneratorService {
     private boolean maskDisclosures;
 
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        // Check if the credential is a LDP VC credential with v2 data model and has template in the renderMethod
-        if (hasV2ContextWithSvgTemplate(vcCredentialResponse)) {
+        // Check if the credential can support SVG based rendering
+        if (isSvgBasedRenderingSupported(vcCredentialResponse)) {
             log.info("Detected LDP VC v2 credential with svg template, using InjiVcRenderer for PDF generation");
-            return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse, issuerDTO, dataShareUrl);
+            return generatePdfForV2Credential(vcCredentialResponse, issuerDTO, dataShareUrl);
         } else {
             log.info("Using v1 data model flow for credential");
             // Get the appropriate processor based on format
@@ -292,7 +291,7 @@ public class CredentialPDFGeneratorService {
         return Utilities.encodeToString(qrImage, "png");
     }
 
-    private boolean hasV2ContextWithSvgTemplate(VCCredentialResponse vcCredentialResponse) {
+    private boolean isSvgBasedRenderingSupported(VCCredentialResponse vcCredentialResponse) {
         if (!CredentialFormat.LDP_VC.getFormat().equals(vcCredentialResponse.getFormat())) {
             return false;
         }
@@ -308,33 +307,35 @@ public class CredentialPDFGeneratorService {
     }
 
     private boolean containsV2Context(Map<String, Object> credentialPayloadMap) {
-        Object contextField = credentialPayloadMap.get("@context");
+        Object contextField = credentialPayloadMap.get(LdpVcV2Constants.CONTEXT);
 
         if (contextField instanceof List<?> contextList)
-            return contextList.stream().anyMatch(entry -> V2_CONTEXT_URL.equals(entry.toString()));
+            return contextList.stream().anyMatch(entry -> LdpVcV2Constants.V2_CONTEXT_URL.equals(entry.toString()));
         if (contextField instanceof String contextString)
-            return V2_CONTEXT_URL.equals(contextString);
+            return LdpVcV2Constants.V2_CONTEXT_URL.equals(contextString);
 
         return false;
     }
 
     private boolean containsSvgTemplate(Map<String, Object> credentialPayloadMap) {
-        Object renderMethod = credentialPayloadMap.get("renderMethod");
+        Object renderMethod = credentialPayloadMap.get(LdpVcV2Constants.RENDER_METHOD);
         if (renderMethod instanceof List<?> renderMethodList) {
             return renderMethodList.stream().allMatch(entry -> {
                 if (!(entry instanceof Map<?, ?> renderMethodProperties)) return false;
 
-                return renderMethodProperties.containsKey("template");
+                String renderSuite = (String) renderMethodProperties.get(LdpVcV2Constants.RENDER_SUITE);
+                return renderMethodProperties.containsKey(LdpVcV2Constants.TEMPLATE) && LdpVcV2Constants.SVG_MUSTACHE_RENDER_SUITE.equals(renderSuite);
             });
         }
         if (renderMethod instanceof Map<?, ?> renderMethodMap) {
-            return renderMethodMap.containsKey("template");
+            String renderSuite = (String) renderMethodMap.get(LdpVcV2Constants.RENDER_SUITE);
+            return renderMethodMap.containsKey(LdpVcV2Constants.TEMPLATE) && LdpVcV2Constants.SVG_MUSTACHE_RENDER_SUITE.equals(renderSuite);
         }
 
         return false;
     }
 
-    private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, CredentialsSupportedResponse credentialsSupportedResponse, IssuerDTO issuerDTO, String dataShareUrl) throws Exception {
+    private ByteArrayInputStream generatePdfForV2Credential(VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, String dataShareUrl) throws Exception {
         try {
             // Get the ldp_vc credential and convert to string
             @SuppressWarnings("unchecked")
@@ -342,18 +343,16 @@ public class CredentialPDFGeneratorService {
             String credentialJsonString = objectMapper.writeValueAsString(credentialPayloadMap);
 
             // Generate the QR code data to embed into the svg for Online Sharing
-            String qrCodeData = "";
+            String qrCodeData = null;
             if (QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type())) {
                 PresentationDefinitionDTO presentationDefinitionDTO = presentationService.constructPresentationDefinition(vcCredentialResponse);
                 String presentationString = objectMapper.writeValueAsString(presentationDefinitionDTO);
                 qrCodeData = String.format(ovpQRDataPattern, URLEncoder.encode(dataShareUrl, StandardCharsets.UTF_8), URLEncoder.encode(presentationString, StandardCharsets.UTF_8));
             }
 
-            String wellKnownJson = objectMapper.writeValueAsString(credentialsSupportedResponse);
-
             // Generate list of rendered svg strings using InjiVcRenderer
             List<Object> generatedSvgObjects = injiVcRenderer.generateCredentialDisplayContent(
-                    io.mosip.injivcrenderer.constants.CredentialFormat.LDP_VC, wellKnownJson, credentialJsonString, qrCodeData);
+                    io.mosip.injivcrenderer.constants.CredentialFormat.LDP_VC, null, credentialJsonString, qrCodeData);
 
             if (generatedSvgObjects.isEmpty()) {
                  throw new Exception("No SVG content generated for v2 credential");

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -92,8 +92,8 @@ public class CredentialPDFGeneratorService {
     private boolean maskDisclosures;
 
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
-        // Check if this is a v2 data model credential
-        if (isV2DataModel(vcCredentialResponse)) {
+        // Check if this is a v2 data model credential with template in the renderMethod
+        if (hasV2ContextWithSvgTemplate(vcCredentialResponse)) {
             log.info("Detected v2 data model for credential, using InjiVcRenderer");
             return generatePdfForV2Credential(vcCredentialResponse, credentialsSupportedResponse);
         } else {
@@ -290,20 +290,44 @@ public class CredentialPDFGeneratorService {
         return Utilities.encodeToString(qrImage, "png");
     }
 
-    private boolean isV2DataModel(VCCredentialResponse vcCredentialResponse) {
+    private boolean hasV2ContextWithSvgTemplate(VCCredentialResponse vcCredentialResponse) {
         // Extract credential data based on format
         Object credentialPayload = vcCredentialResponse.getCredential();
 
+        // For SD-JWT credentialPayload is String
+        if (!(credentialPayload instanceof Map<?, ?>)) return false;
+
         @SuppressWarnings("unchecked")
         Map<String, Object> credentialPayloadMap = (Map<String, Object>) credentialPayload;
-        Object contextField = credentialPayloadMap.get("@context");
 
-        if (contextField instanceof List<?> contextEntries) {
-            return contextEntries.stream().anyMatch(entry -> entry.toString().contains("v2"));
-        } else if (contextField instanceof String) {
-            String contextFieldString = contextField.toString();
-            return contextFieldString.contains("v2");
+        return containsV2Context(credentialPayloadMap)
+                && containsSvgTemplate(credentialPayloadMap);
+    }
+
+    private boolean containsV2Context(Map<String, Object> credentialPayloadMap) {
+        Object contextField = credentialPayloadMap.get("@context");
+        if (contextField instanceof List<?> contextFieldList) {
+            return contextFieldList.stream()
+                    .anyMatch(entry -> entry.toString().contains("v2"));
         }
+        if (contextField instanceof String contextFieldString) return contextFieldString.contains("v2");
+
+        return false;
+    }
+
+    private boolean containsSvgTemplate(Map<String, Object> payload) {
+        Object renderMethod = payload.get("renderMethod");
+        if (renderMethod instanceof List<?> renderMethodList) {
+            return renderMethodList.stream().allMatch(entry -> {
+                if (!(entry instanceof Map<?, ?> renderMethodProperties)) return false;
+
+                return renderMethodProperties.containsKey("template");
+            });
+        }
+        if (renderMethod instanceof Map<?, ?> renderMethodMap) {
+            return renderMethodMap.containsKey("template");
+        }
+
         return false;
     }
 
@@ -311,14 +335,7 @@ public class CredentialPDFGeneratorService {
         try {
             // Convert credential to JSON string for InjiVcRenderer
             String credentialJsonString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
-
-            // LDP VC format — wellKnown is in "credential_definition.credential_subject" of CredentialsSupportedResponse
-            String wellKnownJson = null;
-            if (credentialsSupportedResponse.getCredentialDefinition() != null &&
-                    credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject() != null) {
-                wellKnownJson = objectMapper.writeValueAsString(
-                        credentialsSupportedResponse.getCredentialDefinition().getCredentialSubject());
-            }
+            String wellKnownJson = objectMapper.writeValueAsString(credentialsSupportedResponse);
 
             // Generate credential display content using InjiVcRenderer
             List<Object> generatedSvgObjects = injiVcRenderer.generateCredentialDisplayContent(

--- a/src/main/java/io/mosip/mimoto/util/SvgFixerUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/SvgFixerUtil.java
@@ -1,0 +1,18 @@
+package io.mosip.mimoto.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SvgFixerUtil {
+
+    // Adds missing offset attribute to <stop/> elements in SVG content
+    public String addMissingOffsetToStopElements(String svgContent) {
+        if (svgContent == null) return null;
+
+        // Add offset="0" if missing in <stop> elements
+        return svgContent.replaceAll(
+                "<stop(?![^>]*offset=)",
+                "<stop offset=\"0\" "
+        );
+    }
+}

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -890,9 +890,9 @@ class CredentialPDFGeneratorServiceTest {
     }
 
     @Test
-    void testInjiVcRendererInvokedForLdpVcWithTemplate() throws Exception {
+    void testInjiVcRendererInvokedForLdpVcWithContextStringAndTemplate() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
+        credentialMap.put("@context", "https://www.w3.org/ns/credentials/v2");
         credentialMap.put("renderMethod", List.of(Map.of("template", "<svg></svg>")));
         VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
             .format("ldp_vc")
@@ -917,7 +917,105 @@ class CredentialPDFGeneratorServiceTest {
     }
 
     @Test
-    void testInjiVcRendererNotInvokedForNonLdpVcOrMissingTemplate() throws Exception {
+    void testInjiVcRendererInvokedForLdpVcWithContextListAndTemplate() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2", "https://w3id.org/security/v1"));
+        credentialMap.put("renderMethod", List.of(Map.of("template", "<svg></svg>")));
+
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(credentialMap)
+                .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString(), anyString()))
+                .thenReturn(List.of("<svg></svg>"));
+        when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
+        when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn("AQID");
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testInjiVcRendererInvokedForLdpVcWhenRenderMethodListWithTemplates() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
+        credentialMap.put("renderMethod", List.of(
+            Map.of(
+                "type", "TemplateRenderMethod",
+                "renderSuite", "svg-mustache",
+                "template", Map.of("id", "https://certify/rendering-template/5b9c")
+            ),
+            Map.of(
+                "type", "TemplateRenderMethod",
+                "renderSuite", "svg-mustache",
+                "template", Map.of("id", "https://certify/rendering-template/6b9c")
+            ),
+            Map.of(
+                "type", "TemplateRenderMethod",
+                "renderSuite", "svg-mustache",
+                "template", Map.of("id", "https://certify/rendering-template/7b9c")
+            )
+        ));
+
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+            .format("ldp_vc")
+            .credential(credentialMap)
+            .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString(), anyString()))
+                .thenReturn(List.of("<svg></svg>"));
+        when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
+        when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn("AQID");
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testInjiVcRendererNotInvokedForLdpVcWhenV2ContextAbsent() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v1"));
+        credentialMap.put("renderMethod", List.of(Map.of("template", "<svg></svg>")));
+
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(credentialMap)
+                .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(Map.of("name", "John"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(new LinkedHashMap<>());
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString())).thenReturn("<html></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testInjiVcRendererNotInvokedForSdJwt() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("vc+sd-jwt")).thenReturn(sdJwtCredentialFormatHandler);
         String validSdJwt = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOltdLCJuYW1lIjoiSm9obiBEb2UifQ.signature~WyJzYWx0IiwgIm5hbWUiLCAiSm9obiBEb2UiXQ";
 
@@ -1005,6 +1103,53 @@ class CredentialPDFGeneratorServiceTest {
         claims.put("name", "John Doe");
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(claims);
 
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString())).thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString())).thenReturn("<html></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+            "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+            "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testInjiVcRendererNotInvokedForLdpVcWhenOneRenderMethodListEntryMissingTemplate() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
+        credentialMap.put("renderMethod", List.of(
+            Map.of(
+                "type", "TemplateRenderMethod",
+                "renderSuite", "svg-mustache",
+                "template", Map.of("id", "https://certify/rendering-template/5b9c")
+            ),
+            Map.of(
+                "type", "TemplateRenderMethod",
+                "renderSuite", "svg-mustache"
+                // missing "template"
+            ),
+            Map.of(
+                "type", "TemplateRenderMethod",
+                "renderSuite", "svg-mustache",
+                "template", Map.of("id", "https://certify/rendering-template/5b8c")
+            )
+        ));
+
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+            .format("ldp_vc")
+            .credential(credentialMap)
+            .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(Map.of("name", "John Doe"));
         LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
         displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
         when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString())).thenReturn(displayProps);

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -949,7 +949,7 @@ class CredentialPDFGeneratorServiceTest {
             "https://example.com/share", "", "en");
 
         assertNotNull(result);
-        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString());
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
     }
 
     @Test
@@ -985,7 +985,7 @@ class CredentialPDFGeneratorServiceTest {
             "https://example.com/share", "", "en");
 
         assertNotNull(result);
-        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString());
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
     }
 
     @Test
@@ -1018,6 +1018,6 @@ class CredentialPDFGeneratorServiceTest {
             "https://example.com/share", "", "en");
 
         assertNotNull(result);
-        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString());
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -4,6 +4,7 @@ package io.mosip.mimoto.service;
 import com.authlete.sd.Disclosure;
 import com.authlete.sd.SDJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.dto.BackgroundImageDTO;
 import io.mosip.mimoto.dto.DisplayDTO;
 import io.mosip.mimoto.dto.IssuerDTO;
@@ -14,6 +15,8 @@ import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.service.impl.LdpVcCredentialFormatHandler;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
 import io.mosip.mimoto.service.impl.VcSdJwtCredentialFormatHandler;
+import io.mosip.mimoto.util.Base64Util;
+import io.mosip.mimoto.util.SvgFixerUtil;
 import io.mosip.mimoto.util.Utilities;
 import io.mosip.pixelpass.PixelPass;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.io.ByteArrayInputStream;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -40,6 +43,8 @@ class CredentialPDFGeneratorServiceTest {
     @Mock private PresentationServiceImpl presentationService;
     @Mock private Utilities utilities;
     @Mock private PixelPass pixelPass;
+    @Mock private SvgFixerUtil svgFixerUtil;
+    @Mock private InjiVcRenderer injiVcRenderer;
     @Mock
     private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
     @Mock
@@ -883,5 +888,138 @@ class CredentialPDFGeneratorServiceTest {
                 "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse, "", "", "en");
 
         assertNotNull(result);  // Verifies formatValue converted 25 to "25"
+    }
+
+    @Test
+    void testInjiVcRendererInvokedForLdpVcWithTemplate() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
+        credentialMap.put("renderMethod", List.of(Map.of("template", "<svg></svg>")));
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+            .format("ldp_vc")
+            .credential(credentialMap)
+            .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString()))
+            .thenReturn(List.of("<svg></svg>"));
+        when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
+        when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn("base64pdf");
+
+        try (MockedStatic<Base64Util> mockedBase64 = mockStatic(Base64Util.class)) {
+            mockedBase64.when(() -> Base64Util.decode(anyString())).thenReturn(new byte[]{1,2,3});
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en");
+            assertNotNull(result);
+            verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString());
+        }
+    }
+
+    @Test
+    void testInjiVcRendererNotInvokedForNonLdpVcOrMissingTemplate() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("vc+sd-jwt")).thenReturn(sdJwtCredentialFormatHandler);
+        String validSdJwt = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOltdLCJuYW1lIjoiSm9obiBEb2UifQ.signature~WyJzYWx0IiwgIm5hbWUiLCAiSm9obiBEb2UiXQ";
+
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+            .format("vc+sd-jwt")
+            .credential(validSdJwt)
+            .build();
+
+        Map<String, Object> extractedClaims = new HashMap<>();
+        extractedClaims.put("name", "John Doe");
+        when(sdJwtCredentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+            .thenReturn(extractedClaims);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(sdJwtCredentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+            .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+            .thenReturn("<html></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any()))
+            .thenReturn(new PresentationDefinitionDTO());
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+            "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+            "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString());
+    }
+
+    @Test
+    void testInjiVcRendererNotInvokedForLdpVcWithRenderMethodButNoTemplate() throws Exception {
+        // Credential with v2 context and renderMethod, but missing "template"
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
+        credentialMap.put("renderMethod", List.of(Map.of("renderSuite", "svg-mustache")));
+
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+            .format("ldp_vc")
+            .credential(credentialMap)
+            .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("name", "John Doe");
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(claims);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString())).thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString())).thenReturn("<html></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+            "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+            "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString());
+    }
+
+    @Test
+    void testInjiVcRendererNotInvokedForLdpVcWithoutRenderMethod() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
+
+        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
+            .format("ldp_vc")
+            .credential(credentialMap)
+            .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("name", "John Doe");
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(claims);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString())).thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString())).thenReturn("<html></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+            "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+            "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString());
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.io.ByteArrayInputStream;
 import java.util.*;
 
+import static io.mosip.mimoto.constant.LdpVcV2Constants.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -892,17 +893,18 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testInjiVcRendererInvokedForLdpVcWithContextStringAndTemplate() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", "https://www.w3.org/ns/credentials/v2");
-        credentialMap.put("renderMethod", List.of(Map.of("template", "<svg></svg>")));
+        credentialMap.put(CONTEXT, V2_CONTEXT_URL);
+        credentialMap.put(RENDER_METHOD, List.of(Map.of(TEMPLATE, "<svg></svg>",
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE)));
         VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
             .format("ldp_vc")
             .credential(credentialMap)
             .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
-        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString(), anyString()))
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
             .thenReturn(List.of("<svg></svg>"));
         when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -913,14 +915,15 @@ class CredentialPDFGeneratorServiceTest {
             "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
             "https://example.com/share", "", "en");
         assertNotNull(result);
-        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), any(), anyString(), any());
     }
 
     @Test
     void testInjiVcRendererInvokedForLdpVcWithContextListAndTemplate() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2", "https://w3id.org/security/v1"));
-        credentialMap.put("renderMethod", List.of(Map.of("template", "<svg></svg>")));
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL, "https://w3id.org/security/v1"));
+        credentialMap.put(RENDER_METHOD, List.of(Map.of(TEMPLATE, "<svg></svg>",
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE)));
 
         VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
                 .format("ldp_vc")
@@ -930,7 +933,7 @@ class CredentialPDFGeneratorServiceTest {
         issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
-        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString(), anyString()))
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
                 .thenReturn(List.of("<svg></svg>"));
         when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
         when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn("AQID");
@@ -940,28 +943,28 @@ class CredentialPDFGeneratorServiceTest {
                 "https://example.com/share", "", "en");
 
         assertNotNull(result);
-        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), any(), anyString(), any());
     }
 
     @Test
     void testInjiVcRendererInvokedForLdpVcWhenRenderMethodListWithTemplates() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
-        credentialMap.put("renderMethod", List.of(
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL));
+        credentialMap.put(RENDER_METHOD, List.of(
             Map.of(
                 "type", "TemplateRenderMethod",
-                "renderSuite", "svg-mustache",
-                "template", Map.of("id", "https://certify/rendering-template/5b9c")
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE,
+                TEMPLATE, Map.of("id", "https://certify/rendering-template/5b9c")
             ),
             Map.of(
                 "type", "TemplateRenderMethod",
-                "renderSuite", "svg-mustache",
-                "template", Map.of("id", "https://certify/rendering-template/6b9c")
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE,
+                TEMPLATE, Map.of("id", "https://certify/rendering-template/6b9c")
             ),
             Map.of(
                 "type", "TemplateRenderMethod",
-                "renderSuite", "svg-mustache",
-                "template", Map.of("id", "https://certify/rendering-template/7b9c")
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE,
+                TEMPLATE, Map.of("id", "https://certify/rendering-template/7b9c")
             )
         ));
 
@@ -973,7 +976,7 @@ class CredentialPDFGeneratorServiceTest {
         issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
-        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString(), anyString()))
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
                 .thenReturn(List.of("<svg></svg>"));
         when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
         when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn("AQID");
@@ -983,14 +986,70 @@ class CredentialPDFGeneratorServiceTest {
                 "https://example.com/share", "", "en");
 
         assertNotNull(result);
-        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), any(), anyString(), any());
+    }
+
+    @Test
+    void testV2ContextNullDisablesSvgRendering() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put(CONTEXT, null); // contextField is null
+        credentialMap.put(RENDER_METHOD, List.of(Map.of(TEMPLATE, "<svg></svg>", RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE)));
+
+        VCCredentialResponse vc = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(credentialMap)
+                .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        when(credentialFormatHandler.extractCredentialClaims(any())).thenReturn(Map.of("name", "John"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString())).thenReturn(new LinkedHashMap<>());
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString())).thenReturn("<html></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vc, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testInjiVcRendererNotInvokedWhenRenderSuiteIsNotSvgMustache() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL));
+        credentialMap.put(RENDER_METHOD, Map.of(TEMPLATE, "<svg></svg>", RENDER_SUITE, "pdf-mustache"));
+
+        VCCredentialResponse vc = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(credentialMap)
+                .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        when(credentialFormatHandler.extractCredentialClaims(any())).thenReturn(Map.of("name", "John"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString())).thenReturn(new LinkedHashMap<>());
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString())).thenReturn("<html></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vc, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en");
+
+        assertNotNull(result);
+        verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
     }
 
     @Test
     void testInjiVcRendererNotInvokedForLdpVcWhenV2ContextAbsent() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v1"));
-        credentialMap.put("renderMethod", List.of(Map.of("template", "<svg></svg>")));
+        credentialMap.put(CONTEXT, List.of("https://www.w3.org/ns/credentials/v1"));
+        credentialMap.put(RENDER_METHOD, List.of(Map.of(TEMPLATE, "<svg></svg>")));
 
         VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
                 .format("ldp_vc")
@@ -1054,8 +1113,8 @@ class CredentialPDFGeneratorServiceTest {
     void testInjiVcRendererNotInvokedForLdpVcWithRenderMethodButNoTemplate() throws Exception {
         // Credential with v2 context and renderMethod, but missing "template"
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
-        credentialMap.put("renderMethod", List.of(Map.of("renderSuite", "svg-mustache")));
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL));
+        credentialMap.put(RENDER_METHOD, List.of(Map.of(RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE)));
 
         VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
             .format("ldp_vc")
@@ -1089,7 +1148,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testInjiVcRendererNotInvokedForLdpVcWithoutRenderMethod() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL));
 
         VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
             .format("ldp_vc")
@@ -1122,22 +1181,22 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testInjiVcRendererNotInvokedForLdpVcWhenOneRenderMethodListEntryMissingTemplate() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put("@context", List.of("https://www.w3.org/ns/credentials/v2"));
-        credentialMap.put("renderMethod", List.of(
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL));
+        credentialMap.put(RENDER_METHOD, List.of(
             Map.of(
                 "type", "TemplateRenderMethod",
-                "renderSuite", "svg-mustache",
-                "template", Map.of("id", "https://certify/rendering-template/5b9c")
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE,
+                TEMPLATE, Map.of("id", "https://certify/rendering-template/5b9c")
             ),
             Map.of(
                 "type", "TemplateRenderMethod",
-                "renderSuite", "svg-mustache"
-                // missing "template"
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE
+                // missing TEMPLATE
             ),
             Map.of(
                 "type", "TemplateRenderMethod",
-                "renderSuite", "svg-mustache",
-                "template", Map.of("id", "https://certify/rendering-template/5b8c")
+                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE,
+                TEMPLATE, Map.of("id", "https://certify/rendering-template/5b8c")
             )
         ));
 
@@ -1164,5 +1223,53 @@ class CredentialPDFGeneratorServiceTest {
 
         assertNotNull(result);
         verify(injiVcRenderer, never()).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testGeneratePdfForV2CredentialThrowsExceptionWhenRendererReturnsEmptyList() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL));
+        credentialMap.put(RENDER_METHOD, List.of(Map.of(TEMPLATE, "<svg></svg>", RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE)));
+
+        VCCredentialResponse vc = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(credentialMap)
+                .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
+                .thenReturn(Collections.emptyList());
+
+        assertThrows(Exception.class, () -> credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vc, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en"));
+
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), any(), anyString(), any());
+    }
+
+    @Test
+    void testGeneratePdfForV2CredentialCatchBlockWhenRendererThrows() throws Exception {
+        Map<String, Object> credentialMap = new HashMap<>();
+        credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL));
+        credentialMap.put(RENDER_METHOD, List.of(Map.of(TEMPLATE, "<svg></svg>", RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE)));
+
+        VCCredentialResponse vc = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(credentialMap)
+                .build();
+
+        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+        when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
+                .thenThrow(new RuntimeException("Renderer failed"));
+
+        assertThrows(Exception.class, () -> credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vc, issuerDTO, credentialsSupportedResponse,
+                "https://example.com/share", "", "en"));
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -902,7 +902,7 @@ class CredentialPDFGeneratorServiceTest {
         issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
-        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString()))
+        when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString(), anyString()))
             .thenReturn(List.of("<svg></svg>"));
         when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -913,7 +913,7 @@ class CredentialPDFGeneratorServiceTest {
             "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
             "https://example.com/share", "", "en");
         assertNotNull(result);
-        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString());
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString(), anyString());
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -15,7 +15,6 @@ import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.service.impl.LdpVcCredentialFormatHandler;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
 import io.mosip.mimoto.service.impl.VcSdJwtCredentialFormatHandler;
-import io.mosip.mimoto.util.Base64Util;
 import io.mosip.mimoto.util.SvgFixerUtil;
 import io.mosip.mimoto.util.Utilities;
 import io.mosip.pixelpass.PixelPass;
@@ -906,16 +905,15 @@ class CredentialPDFGeneratorServiceTest {
         when(injiVcRenderer.generateCredentialDisplayContent(any(), anyString(), anyString()))
             .thenReturn(List.of("<svg></svg>"));
         when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
-        when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn("base64pdf");
 
-        try (MockedStatic<Base64Util> mockedBase64 = mockStatic(Base64Util.class)) {
-            mockedBase64.when(() -> Base64Util.decode(anyString())).thenReturn(new byte[]{1,2,3});
-            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
-                "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
-                "https://example.com/share", "", "en");
-            assertNotNull(result);
-            verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString());
-        }
+        String urlSafeBase64Pdf = "AQID";
+        when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn(urlSafeBase64Pdf);
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+            "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+            "https://example.com/share", "", "en");
+        assertNotNull(result);
+        verify(injiVcRenderer).generateCredentialDisplayContent(any(), anyString(), anyString());
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -630,4 +630,67 @@ public class PresentationServiceTest {
 
     // Tests for rejectVerifier removed - method moved to WalletPresentationService
 
+    @Test
+    public void constructPresentationDefinitionWithComplexRenderMethod() {
+        VCCredentialResponse vcCredentialResponse = new VCCredentialResponse();
+        vcCredentialResponse.setFormat(CredentialFormat.LDP_VC.getFormat());
+
+        Map<String, Object> template = Map.of(
+            "id", "https://degree.example/credential-templates/bachelors",
+            "mediaType", "image/svg+xml",
+            "digestMultibase", "zQmerWC85Wg6wFl9znFCwYxApG270iEu5h6JqWAPdhyxz2dR"
+        );
+        Map<String, Object> renderMethod = Map.of(
+            "type", "TemplateRenderMethod",
+            "renderSuite", "svg-mustache",
+            "template", template
+        );
+
+        VCCredentialProperties credential = new VCCredentialProperties();
+        credential.setType(Arrays.asList("VerifiableCredential", "TestCredential"));
+        credential.setContext("https://www.w3.org/2018/credentials/v2");
+        credential.setRenderMethod(renderMethod);
+        VCCredentialResponseProof proof = new VCCredentialResponseProof();
+        proof.setType("Ed25519Signature2020");
+        credential.setProof(proof);
+
+        vcCredentialResponse.setCredential(credential);
+
+        when(objectMapper.convertValue(eq(vcCredentialResponse.getCredential()), eq(VCCredentialProperties.class)))
+                .thenReturn(credential);
+
+        PresentationDefinitionDTO result = presentationService.constructPresentationDefinition(vcCredentialResponse);
+
+        assertNotNull(result);
+        assertNotNull(credential.getRenderMethod());
+        Map<?, ?> render = (Map<?, ?>) credential.getRenderMethod();
+        assertEquals("TemplateRenderMethod", render.get("type"));
+        assertEquals("svg-mustache", render.get("renderSuite"));
+        Map<?, ?> tmpl = (Map<?, ?>) render.get("template");
+        assertEquals("https://degree.example/credential-templates/bachelors", tmpl.get("id"));
+    }
+
+    @Test
+    public void constructPresentationDefinitionWithRenderMethodAbsent() {
+        VCCredentialResponse vcCredentialResponse = new VCCredentialResponse();
+        vcCredentialResponse.setFormat(CredentialFormat.LDP_VC.getFormat());
+
+        VCCredentialProperties credential = new VCCredentialProperties();
+        credential.setType(Arrays.asList("VerifiableCredential", "TestCredential"));
+        credential.setContext("https://www.w3.org/2018/credentials/v2");
+        // renderMethod not set
+        VCCredentialResponseProof proof = new VCCredentialResponseProof();
+        proof.setType("Ed25519Signature2020");
+        credential.setProof(proof);
+
+        vcCredentialResponse.setCredential(credential);
+
+        when(objectMapper.convertValue(eq(vcCredentialResponse.getCredential()), eq(VCCredentialProperties.class)))
+                .thenReturn(credential);
+
+        PresentationDefinitionDTO result = presentationService.constructPresentationDefinition(vcCredentialResponse);
+
+        assertNotNull(result);
+        assertNull(credential.getRenderMethod());
+    }
 }

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -631,7 +631,7 @@ public class PresentationServiceTest {
     // Tests for rejectVerifier removed - method moved to WalletPresentationService
 
     @Test
-    public void constructPresentationDefinitionWithRenderMethod() {
+    public void constructPresentationDefinitionWithRenderMethod() throws Exception{
         VCCredentialResponse vcCredentialResponse = new VCCredentialResponse();
         vcCredentialResponse.setFormat(CredentialFormat.LDP_VC.getFormat());
 
@@ -662,16 +662,14 @@ public class PresentationServiceTest {
         PresentationDefinitionDTO result = presentationService.constructPresentationDefinition(vcCredentialResponse);
 
         assertNotNull(result);
-        assertNotNull(credential.getRenderMethod());
-        Map<?, ?> render = (Map<?, ?>) credential.getRenderMethod();
-        assertEquals("TemplateRenderMethod", render.get("type"));
-        assertEquals("svg-mustache", render.get("renderSuite"));
-        Map<?, ?> tmpl = (Map<?, ?>) render.get("template");
-        assertEquals("https://degree.example/credential-templates/bachelors", tmpl.get("id"));
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(credential);
+        assertTrue(json.contains("renderMethod"));
     }
 
     @Test
-    public void constructPresentationDefinitionWithRenderMethodAbsent() throws Exception {
+    public void constructPresentationDefinitionWithoutRenderMethod() throws Exception {
         VCCredentialResponse vcCredentialResponse = new VCCredentialResponse();
         vcCredentialResponse.setFormat(CredentialFormat.LDP_VC.getFormat());
 
@@ -691,11 +689,10 @@ public class PresentationServiceTest {
         PresentationDefinitionDTO result = presentationService.constructPresentationDefinition(vcCredentialResponse);
 
         assertNotNull(result);
-        assertNull(credential.getRenderMethod());
 
         //Not mocking the ObjectMapper here to test the actual serialization : renderMethod should be absent
-        ObjectMapper realMapper = new ObjectMapper();
-        String json = realMapper.writeValueAsString(credential);
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(credential);
         assertFalse(json.contains("renderMethod"));
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -631,7 +631,7 @@ public class PresentationServiceTest {
     // Tests for rejectVerifier removed - method moved to WalletPresentationService
 
     @Test
-    public void constructPresentationDefinitionWithComplexRenderMethod() {
+    public void constructPresentationDefinitionWithRenderMethod() {
         VCCredentialResponse vcCredentialResponse = new VCCredentialResponse();
         vcCredentialResponse.setFormat(CredentialFormat.LDP_VC.getFormat());
 
@@ -671,7 +671,7 @@ public class PresentationServiceTest {
     }
 
     @Test
-    public void constructPresentationDefinitionWithRenderMethodAbsent() {
+    public void constructPresentationDefinitionWithRenderMethodAbsent() throws Exception {
         VCCredentialResponse vcCredentialResponse = new VCCredentialResponse();
         vcCredentialResponse.setFormat(CredentialFormat.LDP_VC.getFormat());
 
@@ -692,5 +692,10 @@ public class PresentationServiceTest {
 
         assertNotNull(result);
         assertNull(credential.getRenderMethod());
+
+        //Not mocking the ObjectMapper here to test the actual serialization : renderMethod should be absent
+        ObjectMapper realMapper = new ObjectMapper();
+        String json = realMapper.writeValueAsString(credential);
+        assertFalse(json.contains("renderMethod"));
     }
 }

--- a/src/test/java/io/mosip/mimoto/util/SvgFixerUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/SvgFixerUtilTest.java
@@ -1,0 +1,35 @@
+package io.mosip.mimoto.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SvgFixerUtilTest {
+
+    private final SvgFixerUtil util = new SvgFixerUtil();
+
+    @Test
+    void testAddMissingOffsetToStopElements_withMissingOffset() {
+        String input = "<svg><stop/></svg>";
+        String expected = "<svg><stop offset=\"0\" /></svg>";
+        Assertions.assertEquals(expected, util.addMissingOffsetToStopElements(input));
+    }
+
+    @Test
+    void testAddMissingOffsetToStopElements_withExistingOffset() {
+        String input = "<svg><stop offset=\"0.5\"/></svg>";
+        String expected = "<svg><stop offset=\"0.5\"/></svg>";
+        Assertions.assertEquals(expected, util.addMissingOffsetToStopElements(input));
+    }
+
+    @Test
+    void testAddMissingOffsetToStopElements_multipleStops() {
+        String input = "<svg><stop/><stop offset=\"0.2\"/><stop/></svg>";
+        String expected = "<svg><stop offset=\"0\" /><stop offset=\"0.2\"/><stop offset=\"0\" /></svg>";
+        Assertions.assertEquals(expected, util.addMissingOffsetToStopElements(input));
+    }
+
+    @Test
+    void testAddMissingOffsetToStopElements_nullInput() {
+        Assertions.assertNull(util.addMissingOffsetToStopElements(null));
+    }
+}


### PR DESCRIPTION
Integration of injivcrenderer library in mimoto to support svg to pdf conversion for LDP VC credentials with v2 context and having template in the renderMethod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SVG-based rendering for V2 credentials, including QR handling and support for credential renderMethod metadata.
  * Added an SVG normalization utility to fix missing gradient stop offsets.

* **Chores**
  * Updated PDF/SVG rendering libraries and removed the previous caching dependency.

* **Tests**
  * Added unit tests for SVG normalization, conditional SVG-to-PDF flows, and renderer invocation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->