### PR TITLE
[INJIWEB-1721] - Update readme for deploying Mimoto without datashare

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -204,4 +204,6 @@ fileignoreconfig:
   checksum: f533f57817732d29d33338ee67fed3af74a6c3492d2539d0b36152ec6822d9a3
 - filename: src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
   checksum: 273142b1d86eeea43034c17265459707c9c487b37c63fe28b48916a44189944f
+- filename: deploy/README.md
+  checksum: 1bef019be00c0eae8714ce8a71a4e33c68aa5e2bfe4a6d7f72eaad35b8dd64a9
 version: ""

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -41,8 +41,38 @@ cd ../partner-onboarder
 ## Install mimoto and datashare
 * Execute mimoto install script
 * Before installing Mimoto, please ensure that the database host and port are correctly configured in the [values.yaml](mimoto/values.yaml) file.
-* Datashare will be deployed as part of the Mimoto installation.
+* **Datashare Deployment:**
+  * If you are using **Inji Web Wallet**, datashare will be deployed as part of the Mimoto installation.
+  * If you are using **Inji Mobile Wallet with offline credentials**, datashare deployment is not required.
 * Note: During the installation of Mimoto and Datashare, ensure that the active_profile_env parameter in the ConfigMap of the config-server-share (in the injiweb namespace) is set to: default,inji-default,standalone
+
+### To Deploy Mimoto WITHOUT Datashare (For Offline Credentials Only)
+If you are using Inji Mobile Wallet with offline credentials and do not need datashare, follow these steps:
+
+1. **Edit the install.sh script:**
+   - Open `deploy/mimoto/install.sh`
+   - Locate the datashare deployment section (around line 61-66)
+   - Comment out or remove the following lines:
+     ```bash
+     INJI_DATASHARE_HOST=$(kubectl get cm inji-stack-config -o jsonpath={.data.inji-datashare-host})
+     echo "Installing datashare"
+     helm -n $NS install datashare-inji mosip/datashare \
+     -f datashare-values.yaml \
+     --version $DATASHARE_CHART_VERSION
+     ```
+
+2. **Configure Mimoto for offline credentials:**
+   - Ensure that `qr_code_type` is set to `"EmbeddedVC"` in your `mimoto-issuers-config.json` file
+   - This embeds the entire Verifiable Credential in the QR code for offline verification
+
+3. **Run the modified install script:**
+```
+cd ../deploy/mimoto
+./install.sh
+ ```
+
+### To Deploy Mimoto WITH Datashare (Default)
+If you are using Inji Web Wallet or need datashare for online verification:
 ```
 cd ../deploy/mimoto
 ./install.sh
@@ -51,6 +81,8 @@ cd ../deploy/mimoto
 * If the server lacks a public domain and a valid SSL certificate, it is advisable to select the `n` option. Opting it will enable the `init-container` with an `emptyDir` volume and include it in the deployment process.
 * The init-container will proceed to download the server's self-signed SSL certificate and mount it to the specified location within the container's Java keystore (i.e., `cacerts`) file.
 * This particular functionality caters to scenarios where the script needs to be employed on a server utilizing self-signed SSL certificates.
+
+  2. **Keystore Choice**: A prompt will ask you to choose the key management method (SoftHSM, .p12 keystore, or External HSM).
 
 ### For Onboarding new Issuer for VCI:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -66,14 +66,14 @@ If you are using only Inji Mobile Wallet and do not need datashare, follow these
    - This embeds the entire Verifiable Credential in the QR code for offline verification
 
 3. **Run the modified install script:**
-```
+```bash
 cd ../deploy/mimoto
 ./install.sh
  ```
 
 ### To Deploy Mimoto WITH Datashare (Default)
 If you are using Inji Web Wallet or need datashare for online verification:
-```bash
+```
 cd ../deploy/mimoto
 ./install.sh
  ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -46,8 +46,8 @@ cd ../partner-onboarder
   * If you are using **Inji Mobile Wallet with offline credentials**, datashare deployment is not required.
 * Note: During the installation of Mimoto and Datashare, ensure that the active_profile_env parameter in the ConfigMap of the config-server-share (in the injiweb namespace) is set to: default,inji-default,standalone
 
-### To Deploy Mimoto WITHOUT Datashare (For Offline Credentials Only)
-If you are using Inji Mobile Wallet with offline credentials and do not need datashare, follow these steps:
+### To Deploy Mimoto WITHOUT Datashare
+If you are only using Inji Mobile Wallet and do not need datashare, follow these steps:
 
 1. **Edit the install.sh script:**
    - Open `deploy/mimoto/install.sh`
@@ -81,8 +81,6 @@ cd ../deploy/mimoto
 * If the server lacks a public domain and a valid SSL certificate, it is advisable to select the `n` option. Opting it will enable the `init-container` with an `emptyDir` volume and include it in the deployment process.
 * The init-container will proceed to download the server's self-signed SSL certificate and mount it to the specified location within the container's Java keystore (i.e., `cacerts`) file.
 * This particular functionality caters to scenarios where the script needs to be employed on a server utilizing self-signed SSL certificates.
-
-  2. **Keystore Choice**: A prompt will ask you to choose the key management method (SoftHSM, .p12 keystore, or External HSM).
 
 ### For Onboarding new Issuer for VCI:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,11 +43,11 @@ cd ../partner-onboarder
 * Before installing Mimoto, please ensure that the database host and port are correctly configured in the [values.yaml](mimoto/values.yaml) file.
 * **Datashare Deployment:**
   * If you are using **Inji Web Wallet**, datashare will be deployed as part of the Mimoto installation.
-  * If you are using **Inji Mobile Wallet with offline credentials**, datashare deployment is not required.
+  * If you are using only **Inji Mobile Wallet**, datashare deployment is not required.
 * Note: During the installation of Mimoto and Datashare, ensure that the active_profile_env parameter in the ConfigMap of the config-server-share (in the injiweb namespace) is set to: default,inji-default,standalone
 
 ### To Deploy Mimoto WITHOUT Datashare
-If you are only using Inji Mobile Wallet and do not need datashare, follow these steps:
+If you are using only Inji Mobile Wallet and do not need datashare, follow these steps:
 
 1. **Edit the install.sh script:**
    - Open `deploy/mimoto/install.sh`

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,9 +61,9 @@ If you are using only Inji Mobile Wallet and do not need datashare, follow these
      --version $DATASHARE_CHART_VERSION
      ```
 
-2. **Configure Mimoto for offline credentials:**
+2. **Configure Mimoto for Mobile Wallet only:**
    - Ensure that `qr_code_type` is set to `"EmbeddedVC"` in your `mimoto-issuers-config.json` file
-   - This embeds the entire Verifiable Credential in the QR code for offline verification
+   - This embeds the entire Verifiable Credential in the QR code.
 
 3. **Run the modified install script:**
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -73,7 +73,7 @@ cd ../deploy/mimoto
 
 ### To Deploy Mimoto WITH Datashare (Default)
 If you are using Inji Web Wallet or need datashare for online verification:
-```
+```bash
 cd ../deploy/mimoto
 ./install.sh
  ```

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -196,3 +196,13 @@ To bind an Android or iOS wallet using the e-signet service via Mimoto, ensure t
 
 Note:
 - Replace mosipbox.public.url, mosip.api.public.url with your public accessible domain. For dev or local env [ngrok](https://ngrok.com/docs/getting-started/) is recommended.
+
+### Deploying Mimoto Without Datashare (For Offline Credentials Only)
+
+If the country uses Mobile wallet with Offline credentials, deploying datashare and its dependent services is not required. This also eliminates the need for pulling the datashare and minio images from Docker and running them.
+
+To deploy Mimoto without datashare:
+1. Remove the datashare dependency from `depends_on` under `mimoto-service` in the `docker-compose.yml` file.
+2. Update the services section by removing the `datashare` and `minio` services from the `docker-compose.yml` file.
+
+**Note:** When using offline credentials, ensure that the `qr_code_type` field in the Mimoto Issuers Configuration (`mimoto-issuers-config.json`) is set to `"EmbeddedVC"` for all the issuers.

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -205,4 +205,4 @@ To deploy Mimoto without datashare:
 1. Remove the datashare dependency from `depends_on` under `mimoto-service` in the `docker-compose.yml` file.
 2. Update the services section by removing the `datashare` and `minio` services from the `docker-compose.yml` file.
 
-**Note:** When using offline credentials, ensure that the `qr_code_type` field in the Mimoto Issuers Configuration (`mimoto-issuers-config.json`) is set to `"EmbeddedVC"` for all the issuers.
+**Note:** When using only Inji Mobile Wallet, ensure that the `qr_code_type` field in the Mimoto Issuers Configuration (`mimoto-issuers-config.json`) is set to `"EmbeddedVC"` for all the issuers.

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -197,9 +197,9 @@ To bind an Android or iOS wallet using the e-signet service via Mimoto, ensure t
 Note:
 - Replace mosipbox.public.url, mosip.api.public.url with your public accessible domain. For dev or local env [ngrok](https://ngrok.com/docs/getting-started/) is recommended.
 
-### Deploying Mimoto Without Datashare (For Offline Credentials Only)
+### Deploying Mimoto Without Datashare
 
-If the country uses Mobile wallet with Offline credentials, deploying datashare and its dependent services is not required. This also eliminates the need for pulling the datashare and minio images from Docker and running them.
+If the country uses only Mobile wallet, deploying datashare and its dependent services is not required. This also eliminates the need for pulling the datashare and minio images from Docker and running them.
 
 To deploy Mimoto without datashare:
 1. Remove the datashare dependency from `depends_on` under `mimoto-service` in the `docker-compose.yml` file.

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -199,7 +199,7 @@ Note:
 
 ### Deploying Mimoto Without Datashare
 
-If the country uses only Mobile wallet, deploying datashare and its dependent services is not required. This also eliminates the need for pulling the datashare and minio images from Docker and running them.
+If an entity (Ex: Country, Organization) uses only Mobile wallet, deploying datashare and its dependent services is not required. This also eliminates the need for pulling the datashare and minio images from Docker and running them.
 
 To deploy Mimoto without datashare:
 1. Remove the datashare dependency from `depends_on` under `mimoto-service` in the `docker-compose.yml` file.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Deployment guidance updated: Datashare is now conditional by wallet type (Web includes Datashare; Mobile can omit it).
  * New instructions added for deploying without Datashare, including steps to remove Datashare services and configure EmbeddedVC for Mobile Wallet/offline credentials.
  * Compose-based docs clarified and formatting improved.

* **Chores**
  * Repository metadata updated to ignore one additional deployment document.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->