### PR TITLE
Revert injiweb 1818

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,10 @@ ENV artifactory_url_env=${artifactory_url}
 ENV iam_adapter_url_env=${iam_adapter_url}
 
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
-ARG container_user=inji
+ARG container_user=mosip
 
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
-ARG container_user_group=inji
+ARG container_user_group=mosip
 
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
 ARG container_user_uid=1002

--- a/api-test/Dockerfile
+++ b/api-test/Dockerfile
@@ -10,10 +10,10 @@ LABEL commit_id=${COMMIT_ID}
 LABEL build_time=${BUILD_TIME}
 
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
-ARG container_user=inji
+ARG container_user=mosip
 
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
-ARG container_user_group=inji
+ARG container_user_group=mosip
 
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
 ARG container_user_uid=1001

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-mimoto</name>
 	<description>Parent project of apitest-mimoto</description>
 	<url>https://github.com/mosip/mimoto</url>
-	<version>0.20.0-SNAPSHOT</version>
+	<version>0.20.0</version>
 
 	<licenses>
 		<license>
@@ -61,7 +61,7 @@
 		<maven.source.plugin.version>2.2.1</maven.source.plugin.version>
 
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
-		<fileName>apitest-mimoto-0.20.0-SNAPSHOT-jar-with-dependencies</fileName>
+		<fileName>apitest-mimoto-0.20.0-jar-with-dependencies</fileName>
 	</properties>
 
 	<dependencies>

--- a/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/mimoto/testrunner/MosipTestRunner.java
@@ -102,7 +102,9 @@ public class MosipTestRunner {
 			PartnerRegistration.deviceGeneration();
 
 			// Generating biometric details with mock MDS
+			BaseTestCase.domain=".mosip.net";
 			BiometricDataProvider.generateBiometricTestData("Registration");
+			BaseTestCase.domain = System.getProperty("env.endpoint", "localhost").replaceFirst("^https?://", "").replaceAll("/$", "");
 			
 			String testCasesToExecuteString = MimotoConfigManager.getproperty("testCasesToExecute");
 

--- a/api-test/src/main/resources/mimoto/LoginFlow/DownloadMosipIssuerCredential/DownloadIssuerCredential/DownloadIssuerCredential.yml
+++ b/api-test/src/main/resources/mimoto/LoginFlow/DownloadMosipIssuerCredential/DownloadIssuerCredential/DownloadIssuerCredential.yml
@@ -20,7 +20,7 @@ DownloadMosipIssuerCredentialWithGoogleLogin:
 }'
       output: '{
       "issuerDisplayName": "National Identity Department",
-      "credentialTypeDisplayName": "MOSIP National ID"
+      "credentialTypeDisplayName": "$IGNORE$"
 }'
 
    Mimoto_DownloadIssuerCredentialWithGoogleLogin_IssuerMosip_DownloadSameVC_Neg:

--- a/db_scripts/init_values.yaml
+++ b/db_scripts/init_values.yaml
@@ -12,4 +12,4 @@ databases:
         name: postgres-postgresql
         key: postgres-password
     dml: 1
-    branch: release-0.20.x
+    branch: v0.20.0

--- a/db_scripts/init_values.yaml
+++ b/db_scripts/init_values.yaml
@@ -12,4 +12,4 @@ databases:
         name: postgres-postgresql
         key: postgres-password
     dml: 1
-    branch: develop
+    branch: release-0.20.x

--- a/deploy/mimoto-apitestrig/install.sh
+++ b/deploy/mimoto-apitestrig/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb
-CHART_VERSION=1.3.4
+CHART_VERSION=1.3.5
 
 echo Create $NS namespace
 kubectl create ns $NS

--- a/deploy/mimoto-apitestrig/install.sh
+++ b/deploy/mimoto-apitestrig/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb
-CHART_VERSION=0.0.1-develop
+CHART_VERSION=1.3.4
 
 echo Create $NS namespace
 kubectl create ns $NS

--- a/deploy/mimoto-apitestrig/values.yaml
+++ b/deploy/mimoto-apitestrig/values.yaml
@@ -3,53 +3,5 @@ modules:
     enabled: true
     image:
       repository: mosipqa/apitest-mimoto
-      tag: develop
-      pullPolicy: Always
-  masterdata:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-masterdata
-      tag: develop
-      pullPolicy: Always
-  prereg:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-prereg
-      tag: develop
-      pullPolicy: Always
-  idrepo:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-idrepo
-      tag: develop
-      pullPolicy: Always
-  partner:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-partner
-      tag: develop
-      pullPolicy: Always
-  resident:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-resident
-      tag: develop
-      pullPolicy: Always
-  auth:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-auth
-      tag: develop
-      pullPolicy: Always
-  esignet:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-esignet
-      tag: develop
-      pullPolicy: Always
-  pms:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-pms
-      tag: develop
+      tag: 0.20.x
       pullPolicy: Always

--- a/deploy/mimoto-apitestrig/values.yaml
+++ b/deploy/mimoto-apitestrig/values.yaml
@@ -2,6 +2,6 @@ modules:
   mimoto:
     enabled: true
     image:
-      repository: mosipqa/apitest-mimoto
-      tag: 0.20.x
+      repository: mosipid/apitest-mimoto
+      tag: 0.20.0
       pullPolicy: Always

--- a/deploy/mimoto/install.sh
+++ b/deploy/mimoto/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb
-CHART_VERSION=0.20.0-develop
+CHART_VERSION=0.20.0
 KEYGEN_CHART_VERSION=1.3.0-beta.2
 SOFTHSM_NS=softhsm
 SOFTHSM_CHART_VERSION=1.3.0-beta.2

--- a/deploy/mimoto/install.sh
+++ b/deploy/mimoto/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb
-CHART_VERSION=0.0.1-develop
+CHART_VERSION=0.20.0-develop
 KEYGEN_CHART_VERSION=1.3.0-beta.2
 SOFTHSM_NS=softhsm
 SOFTHSM_CHART_VERSION=1.3.0-beta.2

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: 'mosipqa/mimoto:0.15.x'
+    image: 'mosipid/mimoto:0.20.0'
     user: root
     ports:
       - '8099:8099'

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: 'mosipdev/mimoto:develop'
+    image: 'mosipqa/mimoto:0.15.x'
     user: root
     ports:
       - '8099:8099'

--- a/helm/mimoto/Chart.yaml
+++ b/helm/mimoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimoto
 description: A Helm chart for MOSIP mimoto Application
 type: application
-version: 0.0.1-develop
+version: 0.20.0-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mimoto/Chart.yaml
+++ b/helm/mimoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimoto
 description: A Helm chart for MOSIP mimoto Application
 type: application
-version: 0.20.0-develop
+version: 0.20.0
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mimoto/values.yaml
+++ b/helm/mimoto/values.yaml
@@ -53,8 +53,8 @@ service:
 
 image:
   registry: docker.io
-  repository: mosipqa/mimoto
-  tag: 0.20.x
+  repository: mosipid/mimoto
+  tag: 0.20.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -377,7 +377,7 @@ volumePermissions:
   enabled: true
   image:
     registry: docker.io
-    repository: mosipint/os-shell
+    repository: mosipid/os-shell
     tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.

--- a/helm/mimoto/values.yaml
+++ b/helm/mimoto/values.yaml
@@ -54,7 +54,7 @@ service:
 image:
   registry: docker.io
   repository: mosipqa/mimoto
-  tag: develop
+  tag: 0.20.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/partner-onboarder/install.sh
+++ b/partner-onboarder/install.sh
@@ -89,7 +89,7 @@ fi
   fi
 
   export NS=$custom_ns
-  CHART_VERSION=0.0.1-develop
+  CHART_VERSION=1.3.0-beta.1
 
   echo Create $NS namespace
   kubectl create ns $NS || true


### PR DESCRIPTION
Adding the commit to revert the changrs made in injiweb-1818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated application version from snapshot (0.20.0-SNAPSHOT) to stable release (0.20.0)
  * Updated container configuration: changed default user from inji to mosip
  * Updated Helm chart versions for mimoto and partner-onboarder deployments
  * Updated Docker image repositories and tags to production versions
  * Updated test and database configuration references

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->