### PR TITLE
Updated readMe with License Link and with org changes

### DIFF
--- a/api-test/README.md
+++ b/api-test/README.md
@@ -181,4 +181,4 @@ Update the below **config maps** if required
 
 ## License
 
-This project is licensed under the terms of the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/) and [MIT License](https://mit-license.org/)
+This project is licensed under the terms of the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/)

--- a/api-test/README.md
+++ b/api-test/README.md
@@ -48,17 +48,17 @@ You can access the test automation code using either of the following methods:
 
 ### From Browser
 
-1. Clone or download the repository as a zip file from [GitHub](https://github.com/mosip/mimoto).
+1. Clone or download the repository as a zip file from [GitHub](https://github.com/inji/mimoto).
 2. Unzip the contents to your local machine.
 3. Open a terminal (Linux) or command prompt (Windows) and continue with the following steps.
 
 ### From Git Bash
 
-1. Copy the Git repository URL: `https://github.com/mosip/mimoto`
+1. Copy the Git repository URL: `https://github.com/inji/mimoto`
 2. Open **Git Bash** on your local machine.
 3. Run the following command to clone the repository:
    ```sh
-   git clone https://github.com/mosip/mimoto
+   git clone https://github.com/inji/mimoto
    ```
 
 ---
@@ -128,7 +128,7 @@ To execute the tests using Eclipse IDE, use the following steps:
    - Go to `Run` > `Run Configurations`.
    - In the **Run Configurations** window, create a new configuration for your tests:
      - Right-click on **Java Application** and select **New**.
-     - In the **Main** tab, select the project by browsing the location where the `api-test` folder is saved, and select the **Main class** as `io.mosip.testrig.apirig.mimoto.testrunner.MosipTestRunner`.
+     - In the **Main** tab, select the project by browsing the location where the `api-test` folder is saved, and select the **Main class** as `io.inji.testrig.apirig.mimoto.testrunner.InjiTestRunner`.
    - In the **Arguments** tab, add the necessary **VM arguments**:
      - **VM Arguments**:
        ```
@@ -181,4 +181,4 @@ Update the below **config maps** if required
 
 ## License
 
-This project is licensed under the terms of the [Mozilla Public License 2.0](https://github.com/mosip/mosip-platform/blob/master/LICENSE)
+This project is licensed under the terms of the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/) and [MIT License](https://mit-license.org/)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated external repository links and GitHub URLs to point to the new project location.
  * Updated test runner and run-configuration references in the README.
  * Replaced GitHub-hosted license link with the official Mozilla MPL 2.0 page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->