### PR TITLE
[INJIWEB-1819] - Add claim169 extraction logic (#1003)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -24,9 +24,9 @@ fileignoreconfig:
 - filename: src/main/java/io/mosip/mimoto/controller/CredentialShareController.java
   checksum: 666c22ca63adb8770de901e220f8efeb5ec1d3f63064a58dea33ba49b8e15872
 - filename: src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
-  checksum: 4ed9e188c7dbf07b18eecc3051fb48e8b72072af9963d19972d70b609ebe8045
+  checksum: 9203516612d01a036d7d304ddd448974ecd1cdda3cac21145490315a09facdc0
 - filename: src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
-  checksum: 3349bda92b9e594f99bf0f0e79f7c52fb378c82384a8d3997986e85fb5ce1ec6
+  checksum: bc6b9e27699e1ec3bb024f38509ff9d9bc90edb8888168259f218caa5e829059
 - filename: src/main/java/io/mosip/mimoto/controller/IssuersController.java
   checksum: 856d860de2562fa019ac23bd724b84e1d67b834883b332c12415e6714de9bb05
 - filename: helm/mimoto/templates/deployment.yaml

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -93,8 +93,7 @@ public class CredentialPDFGeneratorService {
     private boolean maskDisclosures;
 
     private static final String CLAIM_169_KEY = "claim169";
-    private static final String IDENTITY_QR_CODE_KEY = "identityQRCode";
-
+    
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
         // Check if the credential can support SVG based rendering
         if (isSvgBasedRenderingSupported(vcCredentialResponse)) {
@@ -212,8 +211,11 @@ public class CredentialPDFGeneratorService {
         Map<String, Object> credentialSubject = credentialFormatHandler.extractCredentialClaims(vcCredentialResponse);
         Object claim169QrObj = credentialSubject.get(CLAIM_169_KEY);
         if (claim169QrObj instanceof Map<?, ?> claim169Map) {
-            Object identityQr = claim169Map.get(IDENTITY_QR_CODE_KEY);
-            return identityQr != null ? identityQr.toString() : "";
+            if (!claim169Map.isEmpty()) {
+                Object firstValue = claim169Map.values().iterator().next();
+                return firstValue != null ? firstValue.toString() : "";
+            }
+            return "";
         }
         return "";
     }

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -92,6 +92,9 @@ public class CredentialPDFGeneratorService {
     @Value("${mosip.injiweb.mask.disclosures:true}")
     private boolean maskDisclosures;
 
+    private static final String CLAIM_169_KEY = "claim169";
+    private static final String IDENTITY_QR_CODE_KEY = "identityQRCode";
+
     public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
         // Check if the credential can support SVG based rendering
         if (isSvgBasedRenderingSupported(vcCredentialResponse)) {
@@ -177,7 +180,13 @@ public class CredentialPDFGeneratorService {
         if (QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type())) {
             qrCodeImage = constructQRCodeWithAuthorizeRequest(vcCredentialResponse, dataShareUrl);
         } else if (QRCodeType.EmbeddedVC.equals(issuerDTO.getQr_code_type())) {
-            qrCodeImage = constructQRCodeWithVCData(vcCredentialResponse);
+            String claim169Qr = extractClaim169Qr(vcCredentialResponse);
+            if(!claim169Qr.isEmpty()) {
+                qrCodeImage = constructQRCode(claim169Qr);
+            }
+            else {
+                qrCodeImage = constructQRCodeWithVCData(vcCredentialResponse);
+            }
         }
 
         // is sd-jwt and has disclosures
@@ -196,6 +205,17 @@ public class CredentialPDFGeneratorService {
         data.put("titleName", credentialSupportedType);
         data.put("face", face);
         return data;
+    }
+
+    private String extractClaim169Qr(VCCredentialResponse vcCredentialResponse) {
+        CredentialFormatHandler credentialFormatHandler = credentialFormatHandlerFactory.getHandler(vcCredentialResponse.getFormat());
+        Map<String, Object> credentialSubject = credentialFormatHandler.extractCredentialClaims(vcCredentialResponse);
+        Object claim169QrObj = credentialSubject.get(CLAIM_169_KEY);
+        if (claim169QrObj instanceof Map<?, ?> claim169Map) {
+            Object identityQr = claim169Map.get(IDENTITY_QR_CODE_KEY);
+            return identityQr != null ? identityQr.toString() : "";
+        }
+        return "";
     }
 
     private SelectedFace extractFace(VCCredentialResponse vcCredentialResponse) {

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -21,6 +21,9 @@ import io.mosip.pixelpass.PixelPass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -29,6 +32,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayInputStream;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static io.mosip.mimoto.constant.LdpVcV2Constants.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -1271,5 +1275,440 @@ class CredentialPDFGeneratorServiceTest {
         assertThrows(Exception.class, () -> credentialPDFGeneratorService.generatePdfForVerifiableCredential(
                 "TestCredential", vc, issuerDTO, credentialsSupportedResponse,
                 "https://example.com/share", "", "en"));
+    }
+
+    @Test
+    void testExtractClaim169QrWithValidIdentityQRCode() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        // Setup credential with claim169 containing identityQRCode
+        Map<String, Object> claim169Map = new HashMap<>();
+        claim169Map.put("identityQRCode", "valid-qr-code-data-from-claim169");
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-claim169");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            verify(pixelPass, never()).generateQRData(anyString(), anyString());
+            mocked.verify(() -> Utilities.encodeToString(any(), anyString()));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideClaim169QrFallbackScenarios")
+    void testExtractClaim169QrFallbackToVCData(String scenarioName, Map<String, Object> claim169Map) throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
+        when(pixelPass.generateQRData(anyString(), anyString())).thenReturn("generated-qr-data");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-vc");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            // Should fallback to VC data QR generation since identityQRCode is null/empty/missing
+            verify(pixelPass).generateQRData(anyString(), anyString());
+        }
+    }
+
+    private static Stream<Arguments> provideClaim169QrFallbackScenarios() {
+        // Scenario 1: claim169 Map with null identityQRCode
+        Map<String, Object> nullIdentityQRCodeMap = new HashMap<>();
+        nullIdentityQRCodeMap.put("identityQRCode", null);
+
+        // Scenario 2: claim169 Map without identityQRCode key
+        Map<String, Object> missingIdentityQRCodeMap = new HashMap<>();
+        missingIdentityQRCodeMap.put("otherKey", "some-value");
+
+        // Scenario 3: claim169 Map with empty string identityQRCode
+        Map<String, Object> emptyIdentityQRCodeMap = new HashMap<>();
+        emptyIdentityQRCodeMap.put("identityQRCode", "");
+
+        return Stream.of(
+                Arguments.of("null identityQRCode", nullIdentityQRCodeMap),
+                Arguments.of("missing identityQRCode key", missingIdentityQRCodeMap),
+                Arguments.of("empty string identityQRCode", emptyIdentityQRCodeMap)
+        );
+    }
+
+    @Test
+    void testExtractClaim169QrWithClaim169NotAsMap() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        // Setup credential with claim169 as String (not Map)
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", "not-a-map-value");
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
+        when(pixelPass.generateQRData(anyString(), anyString())).thenReturn("generated-qr-data");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-vc");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            // Should fallback to VC data QR generation since claim169 is not a Map
+            verify(pixelPass).generateQRData(anyString(), anyString());
+        }
+    }
+
+    @Test
+    void testExtractClaim169QrWithClaim169Missing() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        // Setup credential without claim169
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("email", "john@example.com");
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        displayProps.put("email", Map.of(createDisplayResponse("Email", "en"), "john@example.com"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
+        when(pixelPass.generateQRData(anyString(), anyString())).thenReturn("generated-qr-data");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-vc");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            verify(pixelPass).generateQRData(anyString(), anyString());
+        }
+    }
+
+    @Test
+    void testExtractClaim169QrWithWhitespaceOnlyIdentityQRCode() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        // Setup credential with claim169 containing whitespace-only identityQRCode
+        Map<String, Object> claim169Map = new HashMap<>();
+        claim169Map.put("identityQRCode", "   \t\n  ");
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-claim169");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            verify(pixelPass, never()).generateQRData(anyString(), anyString());
+            verify(objectMapper, never()).writeValueAsString(vcCredentialResponse.getCredential());
+            mocked.verify(() -> Utilities.encodeToString(any(), anyString()));
+        }
+    }
+
+    @Test
+    void testExtractClaim169QrWithSdJwtFormat() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("vc+sd-jwt")).thenReturn(sdJwtCredentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        vcCredentialResponse.setFormat("vc+sd-jwt");
+        String mockSDJWTString = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOltdfQ.signature";
+        vcCredentialResponse.setCredential(mockSDJWTString);
+
+        // Setup credential with claim169 containing identityQRCode for SD-JWT format
+        Map<String, Object> claim169Map = new HashMap<>();
+        claim169Map.put("identityQRCode", "sd-jwt-qr-code-data");
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(sdJwtCredentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(sdJwtCredentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+
+        try (MockedStatic<SDJWT> mockedSDJWT = mockStatic(SDJWT.class);
+             MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            
+            // Mock SDJWT parsing for disclosure extraction
+            SDJWT mockSDJWT = mock(SDJWT.class);
+            mockedSDJWT.when(() -> SDJWT.parse(mockSDJWTString)).thenReturn(mockSDJWT);
+            when(mockSDJWT.getDisclosures()).thenReturn(Collections.emptyList());
+
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-claim169");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            verify(pixelPass, never()).generateQRData(anyString(), anyString());
+            mocked.verify(() -> Utilities.encodeToString(any(), anyString()));
+            mockedSDJWT.verify(() -> SDJWT.parse(mockSDJWTString));
+        }
+    }
+
+    @Test
+    void testExtractClaim169QrWithNumericIdentityQRCode() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        // Setup credential with claim169 containing numeric identityQRCode (will be converted to string)
+        Map<String, Object> claim169Map = new HashMap<>();
+        claim169Map.put("identityQRCode", 12345);
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-claim169");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            verify(pixelPass, never()).generateQRData(anyString(), anyString());
+            mocked.verify(() -> Utilities.encodeToString(any(), anyString()));
+        }
+    }
+
+    @Test
+    void testExtractClaim169QrWithEmptyClaim169Map() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        // Setup credential with claim169 as empty Map
+        Map<String, Object> claim169Map = new HashMap<>();
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
+        when(pixelPass.generateQRData(anyString(), anyString())).thenReturn("generated-qr-data");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-vc");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            verify(pixelPass).generateQRData(anyString(), anyString());
+        }
+    }
+
+    @Test
+    void testExtractClaim169QrWithClaim169AsList() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+
+        // Setup credential with claim169 as List (not Map)
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", List.of("item1", "item2"));
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
+        when(pixelPass.generateQRData(anyString(), anyString())).thenReturn("generated-qr-data");
+
+        try (MockedStatic<Utilities> mocked = mockStatic(Utilities.class)) {
+            mocked.when(() -> Utilities.encodeToString(any(), anyString()))
+                    .thenReturn("base64-encoded-qr-from-vc");
+
+            ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                    "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                    "", "", "en");
+
+            assertNotNull(result);
+            verify(pixelPass).generateQRData(anyString(), anyString());
+        }
+    }
+
+    @Test
+    void testExtractClaim169QrNotCalledWhenQRCodeTypeIsNone() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(QRCodeType.None);
+
+        // Setup credential with claim169 containing identityQRCode
+        Map<String, Object> claim169Map = new HashMap<>();
+        claim169Map.put("identityQRCode", "valid-qr-code-data-from-claim169");
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                "", "", "en");
+
+        assertNotNull(result);
+        verify(pixelPass, never()).generateQRData(anyString(), anyString());
+        verify(presentationService, never()).constructPresentationDefinition(any());
+    }
+
+    @Test
+    void testExtractClaim169QrNotCalledWhenQRCodeTypeIsNull() throws Exception {
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
+        issuerDTO.setQr_code_type(null);
+
+        // Setup credential with claim169 containing identityQRCode
+        Map<String, Object> claim169Map = new HashMap<>();
+        claim169Map.put("identityQRCode", "valid-qr-code-data-from-claim169");
+
+        Map<String, Object> subjectData = new HashMap<>();
+        subjectData.put("name", "John Doe");
+        subjectData.put("claim169", claim169Map);
+
+        when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse))
+                .thenReturn(subjectData);
+
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProps = new LinkedHashMap<>();
+        displayProps.put("name", Map.of(createDisplayResponse("Name", "en"), "John Doe"));
+        when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
+                .thenReturn(displayProps);
+
+        when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
+                .thenReturn("<html><body>Test</body></html>");
+
+        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
+                "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
+                "", "", "en");
+
+        assertNotNull(result);
+        verify(pixelPass, never()).generateQRData(anyString(), anyString());
+        verify(presentationService, never()).constructPresentationDefinition(any());
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -1357,17 +1357,12 @@ class CredentialPDFGeneratorServiceTest {
         Map<String, Object> nullIdentityQRCodeMap = new HashMap<>();
         nullIdentityQRCodeMap.put("identityQRCode", null);
 
-        // Scenario 2: claim169 Map without identityQRCode key
-        Map<String, Object> missingIdentityQRCodeMap = new HashMap<>();
-        missingIdentityQRCodeMap.put("otherKey", "some-value");
-
-        // Scenario 3: claim169 Map with empty string identityQRCode
+        // Scenario 2: claim169 Map with empty string identityQRCode
         Map<String, Object> emptyIdentityQRCodeMap = new HashMap<>();
         emptyIdentityQRCodeMap.put("identityQRCode", "");
 
         return Stream.of(
                 Arguments.of("null identityQRCode", nullIdentityQRCodeMap),
-                Arguments.of("missing identityQRCode key", missingIdentityQRCodeMap),
                 Arguments.of("empty string identityQRCode", emptyIdentityQRCodeMap)
         );
     }


### PR DESCRIPTION
* [INJIWEB-1819] - Add claim169 extraction logic Add test cases for possible scenarios of claim 169



* [INJIWEB-1819] - Rename variable and remove unnecessary string initialization



* [INJIWEB-1819] - Replace multiple test cases into single parameterised test case



---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhanced Features**
  * Improved QR extraction and processing for credential PDF generation with prioritized source selection and clearer fallback behavior.

* **Tests**
  * Expanded unit test coverage across many QR extraction and credential format scenarios, including edge cases and rendering paths.

* **Chores**
  * Updated repository ignore/configuration entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->