### PR TITLE
INJIWEB-1832 Updated the pom and added tests to util factory 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>

--- a/src/test/java/io/mosip/mimoto/util/factory/Ed25519AlgorithmHandlerTest.java
+++ b/src/test/java/io/mosip/mimoto/util/factory/Ed25519AlgorithmHandlerTest.java
@@ -1,11 +1,17 @@
 package io.mosip.mimoto.util.factory;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.util.Base64URL;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 
@@ -62,5 +68,47 @@ public class Ed25519AlgorithmHandlerTest {
         
         handler.createSigner(invalidJwk);
     }
+
+    @Test
+    public void shouldSignAndProduce64ByteSignature() throws Exception {
+        KeyPair keyPair = handler.generateKeyPair();
+        JWK jwk = handler.createJWK(keyPair);
+        JWSSigner signer = handler.createSigner(jwk);
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.Ed25519).build();
+        byte[] payload = "test-payload".getBytes(StandardCharsets.UTF_8);
+
+        com.nimbusds.jose.util.Base64URL signature = signer.sign(header, payload);
+        assertNotNull("Signature must not be null", signature);
+        byte[] sigBytes = signature.decode();
+        assertEquals("Ed25519 signature should be 64 bytes", 64, sigBytes.length);
+
+        assertTrue("supported algorithms must contain Ed25519", signer.supportedJWSAlgorithms().contains(JWSAlgorithm.Ed25519));
+        assertNotNull("JCAContext should not be null", signer.getJCAContext());
+    }
+
+    @Test(expected = JOSEException.class)
+    public void shouldThrowJOSEExceptionWhenPrivateKeyIsInvalidDuringSign() throws Exception {
+        byte[] fakeX = new byte[32];
+        for (int i = 0; i < fakeX.length; i++) fakeX[i] = (byte) (i + 1);
+        byte[] invalidD = new byte[1];
+
+        OctetKeyPair invalidOkp = new OctetKeyPair.Builder(Curve.Ed25519, Base64URL.encode(fakeX))
+                .d(Base64URL.encode(invalidD))
+                .algorithm(JWSAlgorithm.Ed25519)
+                .keyUse(KeyUse.SIGNATURE)
+                .build();
+
+        JWSSigner signer = handler.createSigner(invalidOkp);
+
+        signer.sign(new JWSHeader.Builder(JWSAlgorithm.Ed25519).build(), "payload".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void shouldThrowExceptionWhenCreateJWKWithNonEdKeyPair() throws Exception {
+        KeyPair rsaKeyPair = new RS256AlgorithmHandler().generateKeyPair();
+        handler.createJWK(rsaKeyPair);
+    }
+
 }
 

--- a/src/test/java/io/mosip/mimoto/util/factory/SigningAlgorithmHandlerFactoryTest.java
+++ b/src/test/java/io/mosip/mimoto/util/factory/SigningAlgorithmHandlerFactoryTest.java
@@ -3,6 +3,9 @@ package io.mosip.mimoto.util.factory;
 import io.mosip.mimoto.constant.SigningAlgorithm;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+
 import static org.junit.Assert.*;
 
 /**
@@ -50,6 +53,28 @@ public class SigningAlgorithmHandlerFactoryTest {
         } catch (IllegalArgumentException e) {
             assertTrue("Exception message should mention null", 
                     e.getMessage().contains("null") || e.getMessage().contains("Unsupported"));
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenHandlerNotPresentInMap() throws Exception {
+        Field handlersField = SigningAlgorithmHandlerFactory.class.getDeclaredField("handlers");
+        handlersField.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Map<SigningAlgorithm, SigningAlgorithmHandler> handlers =
+                (Map<SigningAlgorithm, SigningAlgorithmHandler>) handlersField.get(null);
+
+        SigningAlgorithmHandler removed = handlers.remove(SigningAlgorithm.RS256);
+        try {
+            SigningAlgorithmHandlerFactory.getHandler(SigningAlgorithm.RS256);
+            fail("Should throw IllegalArgumentException when handler is missing in map");
+        } catch (IllegalArgumentException e) {
+            assertTrue("Exception message should mention unsupported", e.getMessage().contains("Unsupported"));
+        } finally {
+            if (removed != null) {
+                handlers.put(SigningAlgorithm.RS256, removed);
+            }
         }
     }
 }


### PR DESCRIPTION
Added Junit vintage engine in pom dependency to run the JUnit 4 tests.
Added tests in util.factory to improve the coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for Ed25519 signature validation, including signature length verification and error handling for invalid keys.
  * Enhanced test coverage for algorithm handler factory to validate unsupported handler scenarios.
  * Updated testing infrastructure to support legacy test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->