### PR TITLE
Updated postgres volume mount path for compatibility with latest version

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
       - ./mimoto_init.sql:/docker-entrypoint-initdb.d/mimoto_init.sql
 
   mimoto-service:


### PR DESCRIPTION
Updated the volume mount path from `postgres-data:/var/lib/postgresql/data` to `postgres-data:/var/lib/postgresql`
inorder to have compatibility with latest version.

https://hub.docker.com/_/postgres#pgdata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL data directory configuration in Docker Compose to modify the container's database storage location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->