### PR TITLE
[INJIWEB-1823] Remove unused constants, org changes in pom.xml and remove unnecessary handling of context field as string

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -29,7 +29,7 @@
 			<name>Mosip</name>
 			<email>mosip.emailnotifier@gmail.com</email>
 			<organization>io.inji</organization>
-			<organizationUrl>https://github.com/inji/mimoto</organizationUrl>
+			<organizationUrl>https://inji.io/</organizationUrl>
 		</developer>
 	</developers>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.mosip</groupId>
+    <groupId>io.inji</groupId>
     <artifactId>mimoto</artifactId>
     <version>0.21.0-SNAPSHOT</version>
     <name>mimoto</name>
-    <url>https://github.com/mosip/mimoto</url>
+    <url>https://github.com/inji/mimoto</url>
     <description>Mobile server backend supporting Inji.</description>
 
     <licenses>
@@ -15,17 +15,17 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/mosip/mimoto.git</connection>
-        <developerConnection>scm:git:ssh://github.com:mosip/mimoto.git</developerConnection>
-        <url>https://github.com/mosip/mimoto</url>
+        <connection>scm:git:git://github.com/inji/mimoto.git</connection>
+        <developerConnection>scm:git:ssh://github.com:inji/mimoto.git</developerConnection>
+        <url>https://github.com/inji/mimoto</url>
         <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>
             <name>Mosip</name>
             <email>mosip.emailnotifier@gmail.com</email>
-            <organization>io.mosip</organization>
-            <organizationUrl>https://github.com/mosip/mimoto</organizationUrl>
+            <organization>io.inji</organization>
+            <organizationUrl>https://inji.io/</organizationUrl>
         </developer>
     </developers>
 
@@ -435,7 +435,7 @@
             <version>0.7.0</version>
         </dependency>
         <dependency>
-            <groupId>io.mosip</groupId>
+            <groupId>io.inji</groupId>
             <artifactId>injivcrenderer-jar</artifactId>
             <version>0.2.0-SNAPSHOT</version>
         </dependency>

--- a/src/main/java/io/mosip/mimoto/constant/SigningAlgorithmConstants.java
+++ b/src/main/java/io/mosip/mimoto/constant/SigningAlgorithmConstants.java
@@ -1,20 +1,20 @@
 package io.mosip.mimoto.constant;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class SigningAlgorithmConstants {
 
     // Algorithm Names
     public static final String RSA = "RSA";
     public static final String EC = "EC";
     public static final String ED25519 = "Ed25519";
-    public static final String AES = "AES";
+
     // EC curve names (JCA)
     public static final String CURVE_SECP256K1 = "secp256k1";
     public static final String CURVE_SECP256R1 = "secp256r1";
 
     // Provider Names
     public static final String BC_PROVIDER = "BC";
-
-    private SigningAlgorithmConstants() {
-
-    }
 }

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -331,8 +331,6 @@ public class CredentialPDFGeneratorService {
 
         if (contextField instanceof List<?> contextList)
             return contextList.stream().anyMatch(entry -> LdpVcV2Constants.V2_CONTEXT_URL.equals(entry.toString()));
-        if (contextField instanceof String contextString)
-            return LdpVcV2Constants.V2_CONTEXT_URL.equals(contextString);
 
         return false;
     }

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -895,34 +895,6 @@ class CredentialPDFGeneratorServiceTest {
     }
 
     @Test
-    void testInjiVcRendererInvokedForLdpVcWithContextStringAndTemplate() throws Exception {
-        Map<String, Object> credentialMap = new HashMap<>();
-        credentialMap.put(CONTEXT, V2_CONTEXT_URL);
-        credentialMap.put(RENDER_METHOD, List.of(Map.of(TEMPLATE, "<svg></svg>",
-                RENDER_SUITE, SVG_MUSTACHE_RENDER_SUITE)));
-        VCCredentialResponse vcCredentialResponse = VCCredentialResponse.builder()
-            .format("ldp_vc")
-            .credential(credentialMap)
-            .build();
-
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
-
-        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
-        when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
-            .thenReturn(List.of("<svg></svg>"));
-        when(svgFixerUtil.addMissingOffsetToStopElements(anyString())).thenAnswer(inv -> inv.getArgument(0));
-
-        String urlSafeBase64Pdf = "AQID";
-        when(injiVcRenderer.convertSvgToPdf(anyList())).thenReturn(urlSafeBase64Pdf);
-
-        ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
-            "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
-            "https://example.com/share", "", "en");
-        assertNotNull(result);
-        verify(injiVcRenderer).generateCredentialDisplayContent(any(), any(), anyString(), any());
-    }
-
-    @Test
     void testInjiVcRendererInvokedForLdpVcWithContextListAndTemplate() throws Exception {
         Map<String, Object> credentialMap = new HashMap<>();
         credentialMap.put(CONTEXT, List.of(V2_CONTEXT_URL, "https://w3id.org/security/v1"));


### PR DESCRIPTION
- Update org name from mosip to inji in pom.xml and artifact groupIds
- Remove unused constant and replace private constructor with lombok annotation
- Remove additional handling introduced to treat context field as string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project identifiers, build configuration, and repository references across the codebase.
  * Refactored internal utility classes and removed deprecated constant definitions to improve code maintainability.

* **Bug Fixes**
  * Removed unsupported context data type handling in credential processing to enhance logic clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->