### PR TITLE
Injiweb 1622 : Refactor Crypto Utility Classes

### DIFF
--- a/src/main/java/io/mosip/mimoto/controller/CredentialShareController.java
+++ b/src/main/java/io/mosip/mimoto/controller/CredentialShareController.java
@@ -64,9 +64,6 @@ public class CredentialShareController {
     private String partnerId;
 
     @Autowired
-    public CryptoCoreUtil cryptoCoreUtil;
-
-    @Autowired
     RequestValidator requestValidator;
 
     private Gson gson = new Gson();

--- a/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
+++ b/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
@@ -1,8 +1,6 @@
 package io.mosip.mimoto.service;
 
 import io.mosip.kernel.core.util.CryptoUtil;
-import io.mosip.kernel.cryptomanager.dto.CryptoWithPinRequestDto;
-import io.mosip.kernel.cryptomanager.dto.CryptoWithPinResponseDto;
 import io.mosip.kernel.cryptomanager.dto.CryptomanagerRequestDto;
 import io.mosip.kernel.cryptomanager.dto.CryptomanagerResponseDto;
 import io.mosip.kernel.cryptomanager.service.CryptomanagerService;
@@ -233,65 +231,6 @@ public class DataProtectionService {
         } catch (Exception e) {
             log.error("Failed to convert bytes to PrivateKey for algorithm: {}", algorithmName, e);
             throw new Exception("Failed to create PrivateKey", e);
-        }
-    }
-
-    /**
-     * Encrypts a SecretKey with a user PIN.
-     *
-     * @param encryptionKey The SecretKey to encrypt.
-     * @param pin           The user PIN.
-     * @return The encrypted key data.
-     */
-    public String encryptKeyWithPin(SecretKey encryptionKey, String pin) {
-        if (encryptionKey == null) {
-            log.error("Encryption key is null");
-            throw new IllegalArgumentException("Encryption key cannot be null");
-        }
-        if (pin == null || pin.isEmpty()) {
-            log.error("PIN is null or empty");
-            throw new IllegalArgumentException("PIN cannot be null or empty");
-        }
-        try {
-            CryptoWithPinRequestDto requestDto = new CryptoWithPinRequestDto();
-            requestDto.setUserPin(pin);
-            String dataAsString = Base64.getEncoder().encodeToString(encryptionKey.getEncoded());
-            requestDto.setData(dataAsString);
-            CryptoWithPinResponseDto responseDto = cryptomanagerService.encryptWithPin(requestDto);
-            log.debug("Key encrypted with PIN successfully");
-            return responseDto.getData();
-        } catch (Exception e) {
-            log.error("Failed to encrypt key with PIN", e);
-            throw new RuntimeException("Failed to encrypt key with PIN", e);
-        }
-    }
-
-    /**
-     * Decrypts data using a user PIN.
-     *
-     * @param encryptedString The encrypted data.
-     * @param pin             The user PIN.
-     * @return The decrypted data.
-     */
-    public String decryptWithPin(String encryptedString, String pin) {
-        if (encryptedString == null || encryptedString.isEmpty()) {
-            log.error("Encrypted string is null or empty");
-            throw new IllegalArgumentException("Encrypted string cannot be null or empty");
-        }
-        if (pin == null || pin.isEmpty()) {
-            log.error("PIN is null or empty");
-            throw new IllegalArgumentException("PIN cannot be null or empty");
-        }
-        try {
-            CryptoWithPinRequestDto requestDto = new CryptoWithPinRequestDto();
-            requestDto.setUserPin(pin);
-            requestDto.setData(encryptedString);
-            CryptoWithPinResponseDto responseDto = cryptomanagerService.decryptWithPin(requestDto);
-            log.debug("Data decrypted with PIN successfully");
-            return responseDto.getData();
-        } catch (Exception e) {
-            log.error("Failed to decrypt with PIN", e);
-            throw new RuntimeException("Failed to decrypt with PIN", e);
         }
     }
 

--- a/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
+++ b/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
@@ -1,4 +1,4 @@
-package io.mosip.mimoto.util;
+package io.mosip.mimoto.service;
 
 import io.mosip.kernel.core.util.CryptoUtil;
 import io.mosip.kernel.cryptomanager.dto.CryptoWithPinRequestDto;
@@ -12,7 +12,7 @@ import io.mosip.openID4VP.common.DecoderKt;
 import io.mosip.openID4VP.common.EncoderKt;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -31,8 +31,8 @@ import static io.mosip.mimoto.exception.ErrorConstants.ENCRYPTION_FAILED;
  * Utility class for encryption and decryption operations.
  */
 @Slf4j
-@Component
-public class EncryptionDecryptionUtil {
+@Service
+public class DataProtectionService {
     private static final String AES_ALGORITHM = "AES/GCM/NoPadding";
     private static final int NONCE_LENGTH = 12; // Recommended nonce length for GCM
     private static final int TAG_LENGTH = 128; // Authentication tag length in bits (16 bytes)
@@ -43,7 +43,7 @@ public class EncryptionDecryptionUtil {
     @Value("${mosip.inji.app.id:MIMOTO}")
     private String appId;
 
-    public EncryptionDecryptionUtil(CryptomanagerService cryptomanagerService) {
+    public DataProtectionService(CryptomanagerService cryptomanagerService) {
         this.cryptomanagerService = cryptomanagerService;
     }
 
@@ -415,7 +415,7 @@ public class EncryptionDecryptionUtil {
             inputBytes[headerBytes.length] = (byte) '.';
             System.arraycopy(payloadBytes, 0, inputBytes, headerBytes.length + 1, payloadBytes.length);
 
-            log.debug("Detached JWT signing input created successfully, header length: {}, payload length: {}", 
+            log.debug("Detached JWT signing input created successfully, header length: {}, payload length: {}",
                     headerBytes.length, payloadBytes.length);
             return inputBytes;
         } catch (Exception e) {

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
@@ -15,7 +15,7 @@ import io.mosip.mimoto.service.CredentialRequestService;
 import io.mosip.mimoto.service.CredentialService;
 import io.mosip.mimoto.service.CredentialVerifierService;
 import io.mosip.mimoto.service.IssuersService;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
+import io.mosip.mimoto.service.DataProtectionService;
 import io.mosip.mimoto.util.RestApiClient;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -33,7 +33,7 @@ import static io.mosip.mimoto.exception.ErrorConstants.*;
 public class CredentialServiceImpl implements CredentialService {
 
     private final ObjectMapper objectMapper;
-    private final EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private final DataProtectionService dataProtectionService;
     private final WalletCredentialsRepository walletCredentialsRepository;
     private final IssuersService issuersService;
     private final CredentialVerifierService credentialVerifierService;
@@ -45,7 +45,7 @@ public class CredentialServiceImpl implements CredentialService {
     @Autowired
     public CredentialServiceImpl(
             ObjectMapper objectMapper,
-            EncryptionDecryptionUtil encryptionDecryptionUtil,
+            DataProtectionService dataProtectionService,
             WalletCredentialsRepository walletCredentialsRepository,
             IssuersService issuersService,
             CredentialVerifierService credentialVerifierService,
@@ -55,7 +55,7 @@ public class CredentialServiceImpl implements CredentialService {
             DataShareServiceImpl dataShareService) {
 
         this.objectMapper = objectMapper;
-        this.encryptionDecryptionUtil = encryptionDecryptionUtil;
+        this.dataProtectionService = dataProtectionService;
         this.walletCredentialsRepository = walletCredentialsRepository;
         this.issuersService = issuersService;
         this.credentialVerifierService = credentialVerifierService;
@@ -247,7 +247,7 @@ public class CredentialServiceImpl implements CredentialService {
                                                String issuerId, String credentialConfigurationId) throws CredentialProcessingException {
         try {
             String vcResponseAsJsonString = objectMapper.writeValueAsString(vcCredentialResponse);
-            return encryptionDecryptionUtil.encryptCredential(vcResponseAsJsonString, base64Key);
+            return dataProtectionService.encryptCredential(vcResponseAsJsonString, base64Key);
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize credential response for issuerId: {}, credentialConfigurationId: {}", issuerId, credentialConfigurationId, e);
             throw new CredentialProcessingException(

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialShareServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialShareServiceImpl.java
@@ -66,7 +66,7 @@ public class CredentialShareServiceImpl implements CredentialShareService {
     public DataShareUtil dataShareUtil;
 
     @Autowired
-    CryptoUtil cryptoUtil;
+    DerivedKeyCryptoUtil derivedKeyCryptoUtil;
 
     @Autowired
     public RestApiClient restApiClient;
@@ -390,7 +390,7 @@ public class CredentialShareServiceImpl implements CredentialShareService {
                 cryptoWithPinRequestDto.setUserPin(encryptionPin);
                 cryptoWithPinRequestDto.setData(data.getString(str.toString()));
                 try {
-                    cryptoWithPinResponseDto = cryptoUtil.decryptWithPin(cryptoWithPinRequestDto);
+                    cryptoWithPinResponseDto = derivedKeyCryptoUtil.decryptWithPin(cryptoWithPinRequestDto);
                 } catch (InvalidKeyException | NoSuchAlgorithmException | InvalidKeySpecException
                          | InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException e) {
                     log.error("Error while decrypting the data", e);

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialShareServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialShareServiceImpl.java
@@ -72,7 +72,7 @@ public class CredentialShareServiceImpl implements CredentialShareService {
     public RestApiClient restApiClient;
 
     @Autowired
-    public CryptoCoreUtil cryptoCoreUtil;
+    public P12KeyStoreManager p12KeyStoreManager;
 
     @Autowired
     CbeffToBiometricUtil util;
@@ -128,7 +128,7 @@ public class CredentialShareServiceImpl implements CredentialShareService {
                 credential = restApiClient.getApi(dataShareUri, String.class);
             }
             String encryptionPin = eventModel.getEvent().getData().get("protectionKey").toString();
-            decodedCredential = cryptoCoreUtil.decrypt(credential);
+            decodedCredential = p12KeyStoreManager.decrypt(credential);
             @SuppressWarnings("unchecked")
             Map<String, String> proofMap = (Map<String, String>) eventModel.getEvent().getData().get("proof");
             String sign = proofMap.get("signature").toString();

--- a/src/main/java/io/mosip/mimoto/service/impl/EncryptionServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/EncryptionServiceImpl.java
@@ -2,8 +2,8 @@ package io.mosip.mimoto.service.impl;
 
 import io.mosip.mimoto.exception.EncryptionException;
 import io.mosip.mimoto.exception.DecryptionException;
+import io.mosip.mimoto.service.DataProtectionService;
 import io.mosip.mimoto.service.EncryptionService;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,20 +13,20 @@ public class EncryptionServiceImpl implements EncryptionService {
     private static final String EMPTY_AAD = "";
     private static final String EMPTY_SALT = "";
 
-    private final EncryptionDecryptionUtil encryptionUtil;
+    private final DataProtectionService dataProtectionService;
 
     @Autowired
-    public EncryptionServiceImpl(EncryptionDecryptionUtil encryptionUtil) {
-        this.encryptionUtil = encryptionUtil;
+    public EncryptionServiceImpl(DataProtectionService dataProtectionService) {
+        this.dataProtectionService = dataProtectionService;
     }
 
     @Override
     public String encrypt(String data) throws EncryptionException {
-        return encryptionUtil.encrypt(data, USER_PII_KEY_REFERENCE_ID, EMPTY_AAD, EMPTY_SALT);
+        return dataProtectionService.encrypt(data, USER_PII_KEY_REFERENCE_ID, EMPTY_AAD, EMPTY_SALT);
     }
 
     @Override
     public String decrypt(String data) throws DecryptionException {
-        return encryptionUtil.decrypt(data, USER_PII_KEY_REFERENCE_ID, EMPTY_AAD, EMPTY_SALT);
+        return dataProtectionService.decrypt(data, USER_PII_KEY_REFERENCE_ID, EMPTY_AAD, EMPTY_SALT);
     }
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/KeyPairRetrievalServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/KeyPairRetrievalServiceImpl.java
@@ -5,8 +5,8 @@ import io.mosip.mimoto.exception.DecryptionException;
 import io.mosip.mimoto.exception.KeyGenerationException;
 import io.mosip.mimoto.model.ProofSigningKey;
 import io.mosip.mimoto.repository.ProofSigningKeyRepository;
+import io.mosip.mimoto.service.DataProtectionService;
 import io.mosip.mimoto.service.KeyPairRetrievalService;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
 import io.mosip.mimoto.util.SigningKeyUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,7 @@ public class KeyPairRetrievalServiceImpl implements KeyPairRetrievalService {
     private ProofSigningKeyRepository proofSigningKeyRepository;
 
     @Autowired
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     @Override
     public KeyPair getKeyPairFromDB(String walletId, String base64EncodedWalletKey, SigningAlgorithm signingAlgorithm) throws KeyGenerationException, DecryptionException {
@@ -51,7 +51,7 @@ public class KeyPairRetrievalServiceImpl implements KeyPairRetrievalService {
             throw new DecryptionException("INVALID_WALLET_KEY", "Invalid base64 encoded wallet key", e);
         }
 
-        SecretKey walletKey = EncryptionDecryptionUtil.bytesToSecretKey(decodedWalletKey);
+        SecretKey walletKey = DataProtectionService.bytesToSecretKey(decodedWalletKey);
 
         // Step 3: Decode public key
         byte[] publicKeyBytes;
@@ -65,7 +65,7 @@ public class KeyPairRetrievalServiceImpl implements KeyPairRetrievalService {
         // Step 4: Decrypt private key
         byte[] privateKeyInBytes;
         try {
-            privateKeyInBytes = encryptionDecryptionUtil.decryptWithAES(walletKey, proofSigningKey.get().getEncryptedSecretKey());
+            privateKeyInBytes = dataProtectionService.decryptWithAES(walletKey, proofSigningKey.get().getEncryptedSecretKey());
         } catch (Exception e) {
             log.error("Failed to decrypt private key for walletId: {} with algorithm: {}", walletId, signingAlgorithm, e);
             throw new DecryptionException("DECRYPTION_FAILED", "Failed to decrypt private key for walletId: " + walletId, e);

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletCredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletCredentialServiceImpl.java
@@ -19,7 +19,7 @@ import io.mosip.mimoto.service.CredentialPDFGeneratorService;
 import io.mosip.mimoto.service.CredentialService;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.service.WalletCredentialService;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
+import io.mosip.mimoto.service.DataProtectionService;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,7 +56,7 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
     private final IssuersService issuersService;
     private final CredentialService credentialService;
     private final ObjectMapper objectMapper;
-    private final EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private final DataProtectionService dataProtectionService;
     private final CredentialPDFGeneratorService credentialPDFGeneratorService;
     private final DataShareServiceImpl dataShareService;
 
@@ -65,12 +65,12 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
                                        IssuersService issuersService,
                                        CredentialService credentialService,
                                        ObjectMapper objectMapper,
-                                       EncryptionDecryptionUtil encryptionDecryptionUtil,CredentialPDFGeneratorService credentialPDFGeneratorService,DataShareServiceImpl dataShareService) {
+                                       DataProtectionService dataProtectionService,CredentialPDFGeneratorService credentialPDFGeneratorService,DataShareServiceImpl dataShareService) {
         this.repository = repository;
         this.issuersService = issuersService;
         this.credentialService = credentialService;
         this.objectMapper = objectMapper;
-        this.encryptionDecryptionUtil = encryptionDecryptionUtil;
+        this.dataProtectionService = dataProtectionService;
         this.credentialPDFGeneratorService = credentialPDFGeneratorService;
         this.dataShareService = dataShareService;
     }
@@ -129,7 +129,7 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
                 .orElseThrow(getCredentialNotFoundExceptionSupplier(walletId, credentialId));
 
         try {
-            String decryptedCredential = encryptionDecryptionUtil.decryptCredential(credential.getCredential(), base64Key);
+            String decryptedCredential = dataProtectionService.decryptCredential(credential.getCredential(), base64Key);
 
             WalletCredentialResponseDTO response = generateCredentialResponse(decryptedCredential, credential.getCredentialMetadata(), locale);
             log.debug("Credential fetched successfully: {}", credentialId);
@@ -254,7 +254,7 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
             throw new IllegalArgumentException("Credential data cannot be null");
         }
 
-        String decryptedCredential = encryptionDecryptionUtil.decryptCredential(credential.getCredential(), base64Key);
+        String decryptedCredential = dataProtectionService.decryptCredential(credential.getCredential(), base64Key);
         if (decryptedCredential == null || decryptedCredential.trim().isEmpty()) {
             throw new IllegalArgumentException("Failed to decrypt credential or decrypted data is empty");
         }

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
@@ -22,7 +22,7 @@ import io.mosip.mimoto.service.CredentialMatchingService;
 import io.mosip.mimoto.service.KeyPairRetrievalService;
 import io.mosip.mimoto.service.VerifierService;
 import io.mosip.mimoto.service.WalletPresentationService;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
+import io.mosip.mimoto.service.DataProtectionService;
 import io.mosip.mimoto.util.SigningKeyUtil;
 import io.mosip.mimoto.util.Utilities;
 import io.mosip.mimoto.util.UrlParameterUtils;
@@ -86,7 +86,7 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     private VerifiablePresentationsRepository verifiablePresentationsRepository;
 
     @Autowired
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     @Override
     public VPResponseDTO handleVPAuthorizationRequest(String urlEncodedVPAuthorizationRequest, String walletId) throws ApiNotAccessibleException, IOException, URISyntaxException {
@@ -317,9 +317,9 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
 
         JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA).criticalParams(Set.of(OpenID4VPConstants.JWT_CRITICAL_PARAM_B64)).base64URLEncodePayload(false).build();
 
-        // Create detached JWT signing input using EncryptionDecryptionUtil
+        // Create detached JWT signing input using DataProtectionService
         String headerJson = header.toString();
-        byte[] inputBytes = encryptionDecryptionUtil.createDetachedJwtSigningInput(headerJson, dataToSign);
+        byte[] inputBytes = dataProtectionService.createDetachedJwtSigningInput(headerJson, dataToSign);
         
         // Get Base64URL encoded header for proof construction
         String header64 = EncoderKt.encodeToBase64Url(headerJson.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/io/mosip/mimoto/util/DerivedKeyCryptoUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/DerivedKeyCryptoUtil.java
@@ -27,7 +27,7 @@ import io.mosip.mimoto.exception.CryptoManagerException;
 import io.mosip.mimoto.exception.PlatformErrorMessages;
 
 @Component
-public class CryptoUtil {
+public class DerivedKeyCryptoUtil {
 
     private static final int GCM_NONCE_LENGTH = 12;
 

--- a/src/main/java/io/mosip/mimoto/util/JoseUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/JoseUtil.java
@@ -47,7 +47,7 @@ public class JoseUtil {
     private ObjectMapper mapper;
 
     @Autowired
-    private CryptoCoreUtil cryptoCoreUtil;
+    private P12KeyStoreManager p12KeyStoreManager;
 
     public static JwkDto getJwkFromPublicKey(String publicKeyString) throws NoSuchAlgorithmException, InvalidKeySpecException {
 
@@ -138,7 +138,7 @@ public class JoseUtil {
         Date expiresAt = Date.from(Instant.now().plusMillis(120000));
         RSAPrivateKey privateKey = null;
         try {
-            KeyStore.PrivateKeyEntry privateKeyEntry = cryptoCoreUtil.loadP12(keyStorePathWithFileName, alias, cyptoPassword);
+            KeyStore.PrivateKeyEntry privateKeyEntry = p12KeyStoreManager.loadP12(keyStorePathWithFileName, alias, cyptoPassword);
             if(privateKeyEntry == null){
                 throw new IssuerOnboardingException("Private Key Entry is Missing for the alias " + alias);
             }

--- a/src/main/java/io/mosip/mimoto/util/P12KeyStoreManager.java
+++ b/src/main/java/io/mosip/mimoto/util/P12KeyStoreManager.java
@@ -50,7 +50,7 @@ import io.mosip.mimoto.exception.PlatformErrorMessages;
 
 @Slf4j
 @Component
-public class CryptoCoreUtil {
+public class P12KeyStoreManager {
 
     private final static String RSA_ECB_OAEP_PADDING = "RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING";
 

--- a/src/main/java/io/mosip/mimoto/util/WalletUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/WalletUtil.java
@@ -42,7 +42,7 @@ public class WalletUtil {
         try {
             return decryptWithPin(encryptedWalletKey, pin);
         } catch (Exception e) {
-            throw new InvalidRequestException(INVALID_PIN.getErrorCode(), INVALID_PIN.getErrorMessage() + " " + e);
+            throw new InvalidRequestException(INVALID_PIN.getErrorCode(), INVALID_PIN.getErrorMessage(), e);
         }
     }
 

--- a/src/main/java/io/mosip/mimoto/util/WalletUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/WalletUtil.java
@@ -1,5 +1,8 @@
 package io.mosip.mimoto.util;
 
+import io.mosip.kernel.cryptomanager.dto.CryptoWithPinRequestDto;
+import io.mosip.kernel.cryptomanager.dto.CryptoWithPinResponseDto;
+import io.mosip.kernel.cryptomanager.service.CryptomanagerService;
 import io.mosip.mimoto.constant.SessionKeys;
 import io.mosip.mimoto.model.ProofSigningKey;
 import io.mosip.mimoto.model.Wallet;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,9 +35,12 @@ public class WalletUtil {
     @Autowired
     private DataProtectionService dataProtectionService;
 
+    @Autowired
+    private CryptomanagerService cryptomanagerService;
+
     public String decryptWalletKey(String encryptedWalletKey, String pin) {
         try {
-            return dataProtectionService.decryptWithPin(encryptedWalletKey, pin);
+            return decryptWithPin(encryptedWalletKey, pin);
         } catch (Exception e) {
             throw new InvalidRequestException(INVALID_PIN.getErrorCode(), INVALID_PIN.getErrorMessage() + " " + e);
         }
@@ -49,7 +56,7 @@ public class WalletUtil {
         String walletId = UUID.randomUUID().toString();
         PasscodeControl passcodeControl = new PasscodeControl();
         WalletMetadata walletMetadata = createWalletMetadata(walletName, encryptionAlgorithm, encryptionType, passcodeControl);
-        String walletKey = dataProtectionService.encryptKeyWithPin(encryptionKey, walletPin);
+        String walletKey = encryptKeyWithPin(encryptionKey, walletPin);
         Wallet newWallet = Wallet.builder()
                 .id(walletId)
                 .userId(userId)
@@ -102,6 +109,65 @@ public class WalletUtil {
         String walletIdInSession = sessionWalletId.toString();
         if (!walletIdInSession.equals(walletIdFromRequest)) {
             throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Invalid Wallet ID. Session and request Wallet ID do not match");
+        }
+    }
+
+    /**
+     * Encrypts a SecretKey with a user PIN.
+     *
+     * @param encryptionKey The SecretKey to encrypt.
+     * @param pin           The user PIN.
+     * @return The encrypted key data.
+     */
+    private String encryptKeyWithPin(SecretKey encryptionKey, String pin) {
+        if (encryptionKey == null) {
+            log.error("Encryption key is null");
+            throw new IllegalArgumentException("Encryption key cannot be null");
+        }
+        if (pin == null || pin.isEmpty()) {
+            log.error("PIN is null or empty");
+            throw new IllegalArgumentException("PIN cannot be null or empty");
+        }
+        try {
+            CryptoWithPinRequestDto requestDto = new CryptoWithPinRequestDto();
+            requestDto.setUserPin(pin);
+            String dataAsString = Base64.getEncoder().encodeToString(encryptionKey.getEncoded());
+            requestDto.setData(dataAsString);
+            CryptoWithPinResponseDto responseDto = cryptomanagerService.encryptWithPin(requestDto);
+            log.debug("Key encrypted with PIN successfully");
+            return responseDto.getData();
+        } catch (Exception e) {
+            log.error("Failed to encrypt key with PIN", e);
+            throw new RuntimeException("Failed to encrypt key with PIN", e);
+        }
+    }
+
+    /**
+     * Decrypts data using a user PIN.
+     *
+     * @param encryptedString The encrypted data.
+     * @param pin             The user PIN.
+     * @return The decrypted data.
+     */
+    private String decryptWithPin(String encryptedString, String pin) {
+        if (encryptedString == null || encryptedString.isEmpty()) {
+            log.error("Encrypted string is null or empty");
+            throw new IllegalArgumentException("Encrypted string cannot be null or empty");
+        }
+        if (pin == null || pin.isEmpty()) {
+            log.error("PIN is null or empty");
+            throw new IllegalArgumentException("PIN cannot be null or empty");
+        }
+        try {
+            CryptoWithPinRequestDto requestDto = new CryptoWithPinRequestDto();
+            requestDto.setUserPin(pin);
+            requestDto.setData(encryptedString);
+            CryptoWithPinResponseDto responseDto = cryptomanagerService.decryptWithPin(requestDto);
+            log.debug("Data decrypted with PIN successfully");
+            return responseDto.getData();
+        } catch (Exception e) {
+            log.error("Failed to decrypt with PIN", e);
+            throw new RuntimeException("Failed to decrypt with PIN", e);
         }
     }
 }

--- a/src/main/java/io/mosip/mimoto/util/WalletUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/WalletUtil.java
@@ -8,6 +8,7 @@ import io.mosip.mimoto.model.PasscodeControl;
 import io.mosip.mimoto.exception.InvalidRequestException;
 import io.mosip.mimoto.constant.SigningAlgorithm;
 import io.mosip.mimoto.repository.WalletRepository;
+import io.mosip.mimoto.service.DataProtectionService;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,11 +29,11 @@ public class WalletUtil {
     private WalletRepository walletRepository;
 
     @Autowired
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     public String decryptWalletKey(String encryptedWalletKey, String pin) {
         try {
-            return encryptionDecryptionUtil.decryptWithPin(encryptedWalletKey, pin);
+            return dataProtectionService.decryptWithPin(encryptedWalletKey, pin);
         } catch (Exception e) {
             throw new InvalidRequestException(INVALID_PIN.getErrorCode(), INVALID_PIN.getErrorMessage() + " " + e);
         }
@@ -48,7 +49,7 @@ public class WalletUtil {
         String walletId = UUID.randomUUID().toString();
         PasscodeControl passcodeControl = new PasscodeControl();
         WalletMetadata walletMetadata = createWalletMetadata(walletName, encryptionAlgorithm, encryptionType, passcodeControl);
-        String walletKey = encryptionDecryptionUtil.encryptKeyWithPin(encryptionKey, walletPin);
+        String walletKey = dataProtectionService.encryptKeyWithPin(encryptionKey, walletPin);
         Wallet newWallet = Wallet.builder()
                 .id(walletId)
                 .userId(userId)
@@ -79,7 +80,7 @@ public class WalletUtil {
         for (SigningAlgorithm algorithm : algorithms) {
             ProofSigningKey signingKey = SigningKeyUtil.createProofSigningKey(algorithm);
             signingKey.setWallet(wallet);
-            signingKey.setEncryptedSecretKey(encryptionDecryptionUtil.encryptWithAES(encryptionKey,
+            signingKey.setEncryptedSecretKey(dataProtectionService.encryptWithAES(encryptionKey,
                     signingKey.getSecretKey().getEncoded()));
             proofSigningKeys.add(signingKey);
         }

--- a/src/test/java/io/mosip/mimoto/controller/CredentialShareControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/CredentialShareControllerTest.java
@@ -13,7 +13,6 @@ import io.mosip.mimoto.model.Event;
 import io.mosip.mimoto.model.EventModel;
 import io.mosip.mimoto.service.RestClientService;
 import io.mosip.mimoto.service.impl.CredentialShareServiceImpl;
-import io.mosip.mimoto.util.CryptoCoreUtil;
 import io.mosip.mimoto.util.RequestValidator;
 import io.mosip.mimoto.util.RestApiClient;
 import io.mosip.mimoto.util.Utilities;
@@ -58,9 +57,6 @@ public class CredentialShareControllerTest {
 
     @MockBean
     Utilities utilities;
-
-    @MockBean
-    public CryptoCoreUtil cryptoCoreUtil;
 
     @MockBean
     RequestValidator requestValidator;

--- a/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
@@ -12,7 +12,6 @@ import io.mosip.mimoto.exception.InvalidRequestException;
 import io.mosip.mimoto.model.CredentialMetadata;
 import io.mosip.mimoto.service.impl.CredentialMatchingServiceImpl;
 import io.mosip.mimoto.service.impl.OpenID4VPService;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class CredentialMatchingServiceTest {
     private WalletCredentialService walletCredentialService;
 
     @Mock
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     @Mock
     private IssuersService issuersService;
@@ -94,7 +93,7 @@ public class CredentialMatchingServiceTest {
 
         verify(openID4VPService).resolvePresentationDefinition(any(), any(), anyBoolean());
         verify(walletCredentialService).getDecryptedCredentials(eq(walletId), any());
-        verify(encryptionDecryptionUtil).decryptCredential(anyString(), eq(base64Key));
+        verify(dataProtectionService).decryptCredential(anyString(), eq(base64Key));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
@@ -39,9 +39,6 @@ public class CredentialRequestServiceTest {
     private ProofSigningKeyRepository proofSigningKeyRepository;
 
     @MockBean
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
-
-    @MockBean
     private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
 
     @MockBean

--- a/src/test/java/io/mosip/mimoto/service/CredentialServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialServiceTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.mock;
 import io.mosip.mimoto.repository.WalletCredentialsRepository;
 import io.mosip.mimoto.dto.mimoto.IssuerConfig;
 import io.mosip.mimoto.dto.mimoto.VerifiableCredentialResponseDTO;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import static io.mosip.mimoto.exception.ErrorConstants.INVALID_REQUEST;
 import io.mosip.mimoto.exception.CredentialProcessingException;
@@ -79,7 +78,7 @@ public class CredentialServiceTest {
     WalletCredentialsRepository walletCredentialsRepository;
 
     @Mock
-    EncryptionDecryptionUtil encryptionDecryptionUtil;
+    DataProtectionService dataProtectionService;
 
     @Mock
     ObjectMapper objectMapper;
@@ -257,7 +256,7 @@ public class CredentialServiceTest {
                 .thenReturn(getVerifiableCredentialResponseDTO(credentialConfigurationId));
         when(credentialVerifierService.verify(any(VCCredentialResponse.class))).thenReturn(true);
         when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
-        when(encryptionDecryptionUtil.encryptCredential(any(), eq(base64Key))).thenReturn("encrypted-credential");
+        when(dataProtectionService.encryptCredential(any(), eq(base64Key))).thenReturn("encrypted-credential");
         when(walletCredentialsRepository.save(any(VerifiableCredential.class))).thenReturn(savedCredential);
 
         // Execute
@@ -560,8 +559,8 @@ public class CredentialServiceTest {
         when(credentialVerifierService.verify(any(VCCredentialResponse.class))).thenReturn(true);
         when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
 
-        // Mock encryptionDecryptionUtil to throw exception
-        when(encryptionDecryptionUtil.encryptCredential(any(), eq(base64Key)))
+        // Mock dataProtectionService to throw exception
+        when(dataProtectionService.encryptCredential(any(), eq(base64Key)))
                 .thenThrow(new RuntimeException("Encryption failed"));
 
         // Execute and verify exception
@@ -597,7 +596,7 @@ public class CredentialServiceTest {
                 .thenReturn(getVerifiableCredentialResponseDTO(credentialConfigurationId));
         when(credentialVerifierService.verify(any(VCCredentialResponse.class))).thenReturn(true);
         when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
-        when(encryptionDecryptionUtil.encryptCredential(any(), eq(base64Key))).thenReturn("encrypted-credential");
+        when(dataProtectionService.encryptCredential(any(), eq(base64Key))).thenReturn("encrypted-credential");
 
         // Mock walletCredentialsRepository to throw exception
         when(walletCredentialsRepository.save(any(VerifiableCredential.class)))

--- a/src/test/java/io/mosip/mimoto/service/CredentialShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialShareServiceTest.java
@@ -43,7 +43,7 @@ public class CredentialShareServiceTest {
     public AuditLogRequestBuilder auditLogRequestBuilder;
 
     @Mock
-    private CryptoCoreUtil cryptoCoreUtil;
+    private P12KeyStoreManager p12KeyStoreManager;
 
     @Mock
     DerivedKeyCryptoUtil derivedKeyCryptoUtil;
@@ -79,7 +79,7 @@ public class CredentialShareServiceTest {
         Mockito.when(derivedKeyCryptoUtil.decryptWithPin(ArgumentMatchers.any())).thenReturn(cryptoWithPinResponseDto);
         Mockito.when(utilities.getDataPath()).thenReturn("target");
         Mockito.when(restApiClient.getApi(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn("credential");
-        Mockito.when(cryptoCoreUtil.decrypt(Mockito.anyString())).thenReturn("{\"credentialSubject\":{\"biometrics\":\"biometrics\"},\"protectedAttributes\":[\"biometrics\"]}");
+        Mockito.when(p12KeyStoreManager.decrypt(Mockito.anyString())).thenReturn("{\"credentialSubject\":{\"biometrics\":\"biometrics\"},\"protectedAttributes\":[\"biometrics\"]}");
         Map<String, String> templateMap = new HashMap<>();
         templateMap.put("biometrics", "biometrics");
         JSONObject templateJSON = new JSONObject(templateMap);

--- a/src/test/java/io/mosip/mimoto/service/CredentialShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialShareServiceTest.java
@@ -46,7 +46,7 @@ public class CredentialShareServiceTest {
     private CryptoCoreUtil cryptoCoreUtil;
 
     @Mock
-    CryptoUtil cryptoUtil;
+    DerivedKeyCryptoUtil derivedKeyCryptoUtil;
 
     @Mock
     private Utilities utilities;
@@ -76,7 +76,7 @@ public class CredentialShareServiceTest {
         CryptoWithPinResponseDto cryptoWithPinResponseDto = new CryptoWithPinResponseDto();
         cryptoWithPinResponseDto.setData("biometrics");
 
-        Mockito.when(cryptoUtil.decryptWithPin(ArgumentMatchers.any())).thenReturn(cryptoWithPinResponseDto);
+        Mockito.when(derivedKeyCryptoUtil.decryptWithPin(ArgumentMatchers.any())).thenReturn(cryptoWithPinResponseDto);
         Mockito.when(utilities.getDataPath()).thenReturn("target");
         Mockito.when(restApiClient.getApi(Mockito.any(URI.class), Mockito.any(Class.class))).thenReturn("credential");
         Mockito.when(cryptoCoreUtil.decrypt(Mockito.anyString())).thenReturn("{\"credentialSubject\":{\"biometrics\":\"biometrics\"},\"protectedAttributes\":[\"biometrics\"]}");
@@ -112,7 +112,7 @@ public class CredentialShareServiceTest {
     @Test
     public void documentExceptionTest() throws Exception {
 
-        Mockito.when(cryptoUtil.decryptWithPin(ArgumentMatchers.any())).thenThrow(new InvalidKeyException("exception"));
+        Mockito.when(derivedKeyCryptoUtil.decryptWithPin(ArgumentMatchers.any())).thenThrow(new InvalidKeyException("exception"));
 
         boolean result = service.generateDocuments(eventModel);
 

--- a/src/test/java/io/mosip/mimoto/service/DataProtectionServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataProtectionServiceTest.java
@@ -1,10 +1,11 @@
-package io.mosip.mimoto.util;
+package io.mosip.mimoto.service;
 
 import io.mosip.kernel.cryptomanager.dto.CryptomanagerRequestDto;
 import io.mosip.kernel.cryptomanager.dto.CryptomanagerResponseDto;
 import io.mosip.kernel.cryptomanager.service.CryptomanagerService;
 import io.mosip.kernel.core.util.CryptoUtil;
 import io.mosip.mimoto.constant.SigningAlgorithm;
+import io.mosip.mimoto.util.SigningKeyUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,13 +28,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class EncryptionDecryptionUtilTest {
+public class DataProtectionServiceTest {
 
     @Mock
     private CryptomanagerService cryptomanagerService;
 
     @InjectMocks
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     private final String refId = "ref123";
     private final String aad = "aad123";
@@ -47,7 +48,7 @@ public class EncryptionDecryptionUtilTest {
     @Before
     public void setUp() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
         String appId = "MIMOTO";
-        ReflectionTestUtils.setField(encryptionDecryptionUtil, "appId", appId);
+        ReflectionTestUtils.setField(dataProtectionService, "appId", appId);
         encryptionKey = SigningKeyUtil.generateEncryptionKey("AES", 256);
         keyPair = SigningKeyUtil.generateKeyPair(SigningAlgorithm.ED25519);
     }
@@ -59,14 +60,14 @@ public class EncryptionDecryptionUtilTest {
         when(cryptomanagerService.encrypt(any(CryptomanagerRequestDto.class))).thenReturn(responseDto);
 
         String data = "testData";
-        String result = encryptionDecryptionUtil.encrypt(data, refId, aad, salt);
+        String result = dataProtectionService.encrypt(data, refId, aad, salt);
 
         assertEquals(encryptedData, result);
     }
 
     @Test
     public void shouldReturnNullIfDataToEncryptIsNull() {
-        String result = encryptionDecryptionUtil.encrypt(null, refId, aad, salt);
+        String result = dataProtectionService.encrypt(null, refId, aad, salt);
 
         assertNull(result);
     }
@@ -78,14 +79,14 @@ public class EncryptionDecryptionUtilTest {
         responseDto.setData(CryptoUtil.encodeToURLSafeBase64(decryptedData.getBytes(StandardCharsets.UTF_8)));
         when(cryptomanagerService.decrypt(any(CryptomanagerRequestDto.class))).thenReturn(responseDto);
 
-        String result = encryptionDecryptionUtil.decrypt(encryptedData, refId, aad, salt);
+        String result = dataProtectionService.decrypt(encryptedData, refId, aad, salt);
 
         assertEquals(decryptedData, result);
     }
 
     @Test
     public void shouldReturnNullIfDataToDecryptIsNull() {
-        String result = encryptionDecryptionUtil.decrypt(null, refId, aad, salt);
+        String result = dataProtectionService.decrypt(null, refId, aad, salt);
         assertNull(result);
     }
 
@@ -95,7 +96,7 @@ public class EncryptionDecryptionUtilTest {
         SecretKey aesKey = SigningKeyUtil.generateEncryptionKey("AES", 256);
         KeyPair keyPair = SigningKeyUtil.generateKeyPair(SigningAlgorithm.ED25519);
 
-        String encryptedPrivateKey = encryptionDecryptionUtil.encryptWithAES(aesKey, keyPair.getPrivate().getEncoded());
+        String encryptedPrivateKey = dataProtectionService.encryptWithAES(aesKey, keyPair.getPrivate().getEncoded());
 
         assertNotNull(encryptedPrivateKey);
         assertFalse(StringUtils.isBlank(encryptedPrivateKey));
@@ -103,8 +104,8 @@ public class EncryptionDecryptionUtilTest {
 
     @Test
     public void testIVChangesButCiphertextRemainsSameForSameEncryptionKeyAndSecretKey() throws Exception {
-        String encryptedPrivateKey1 = encryptionDecryptionUtil.encryptWithAES(encryptionKey, keyPair.getPrivate().getEncoded());
-        String encryptedPrivateKey2 = encryptionDecryptionUtil.encryptWithAES(encryptionKey, keyPair.getPrivate().getEncoded());
+        String encryptedPrivateKey1 = dataProtectionService.encryptWithAES(encryptionKey, keyPair.getPrivate().getEncoded());
+        String encryptedPrivateKey2 = dataProtectionService.encryptWithAES(encryptionKey, keyPair.getPrivate().getEncoded());
 
         byte[] encryptedBytes1 = Base64.getDecoder().decode(encryptedPrivateKey1);
         byte[] encryptedBytes2 = Base64.getDecoder().decode(encryptedPrivateKey2);
@@ -112,10 +113,10 @@ public class EncryptionDecryptionUtilTest {
         byte[] iv1 = Arrays.copyOfRange(encryptedBytes1, 0, 12);
         byte[] iv2 = Arrays.copyOfRange(encryptedBytes2, 0, 12);
 
-        byte[] decryptedPrivateKey1Bytes = encryptionDecryptionUtil.decryptWithAES(encryptionKey, encryptedPrivateKey1);
-        byte[] decryptedPrivateKey2Bytes = encryptionDecryptionUtil.decryptWithAES(encryptionKey, encryptedPrivateKey2);
-        PrivateKey decryptedPrivateKey1 = EncryptionDecryptionUtil.bytesToPrivateKey(decryptedPrivateKey1Bytes, "ed25519");
-        PrivateKey decryptedPrivateKey2 = EncryptionDecryptionUtil.bytesToPrivateKey(decryptedPrivateKey2Bytes,"ed25519");
+        byte[] decryptedPrivateKey1Bytes = dataProtectionService.decryptWithAES(encryptionKey, encryptedPrivateKey1);
+        byte[] decryptedPrivateKey2Bytes = dataProtectionService.decryptWithAES(encryptionKey, encryptedPrivateKey2);
+        PrivateKey decryptedPrivateKey1 = DataProtectionService.bytesToPrivateKey(decryptedPrivateKey1Bytes, "ed25519");
+        PrivateKey decryptedPrivateKey2 = DataProtectionService.bytesToPrivateKey(decryptedPrivateKey2Bytes,"ed25519");
 
         assertFalse(Arrays.equals(iv1, iv2), "IVs should be different");
         assertEquals(decryptedPrivateKey1, decryptedPrivateKey2);

--- a/src/test/java/io/mosip/mimoto/service/KeyPairServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/KeyPairServiceTest.java
@@ -7,7 +7,6 @@ import io.mosip.mimoto.model.ProofSigningKey;
 import io.mosip.mimoto.model.Wallet;
 import io.mosip.mimoto.repository.ProofSigningKeyRepository;
 import io.mosip.mimoto.service.impl.KeyPairRetrievalServiceImpl;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
 import io.mosip.mimoto.util.SigningKeyUtil;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +39,7 @@ public class KeyPairServiceTest {
     private ProofSigningKeyRepository proofSigningKeyRepository;
 
     @Mock
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     private String walletId;
     private String base64EncodedWalletKey;
@@ -80,13 +79,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(proofSigningKey));
         
         byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -98,7 +97,7 @@ public class KeyPairServiceTest {
             assertNotNull(result);
             assertEquals(keyPair, result);
             verify(proofSigningKeyRepository).findByWalletIdAndAlgorithm(walletId, algorithm.name());
-            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq("encrypted-private-key"));
+            verify(dataProtectionService).decryptWithAES(any(SecretKey.class), eq("encrypted-private-key"));
         }
     }
 
@@ -116,13 +115,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(proofSigningKey));
         
         byte[] decryptedPrivateKey = rsaKeyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -150,13 +149,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(proofSigningKey));
         
         byte[] decryptedPrivateKey = ecKeyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -216,8 +215,8 @@ public class KeyPairServiceTest {
         when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
                 .thenReturn(Optional.of(proofSigningKey));
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class)) {
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class)) {
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             try {
@@ -239,11 +238,11 @@ public class KeyPairServiceTest {
         when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
                 .thenReturn(Optional.of(proofSigningKey));
         
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenThrow(new RuntimeException("Decryption error"));
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class)) {
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class)) {
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             try {
@@ -266,13 +265,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(proofSigningKey));
         
         byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -311,13 +310,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(key2));
         
         byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), anyString()))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), anyString()))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -331,8 +330,8 @@ public class KeyPairServiceTest {
             assertNotNull(result2);
             verify(proofSigningKeyRepository).findByWalletIdAndAlgorithm(wallet1, algorithm.name());
             verify(proofSigningKeyRepository).findByWalletIdAndAlgorithm(wallet2, algorithm.name());
-            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq("encrypted-key-1"));
-            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq("encrypted-key-2"));
+            verify(dataProtectionService).decryptWithAES(any(SecretKey.class), eq("encrypted-key-1"));
+            verify(dataProtectionService).decryptWithAES(any(SecretKey.class), eq("encrypted-key-2"));
         }
     }
 
@@ -343,13 +342,13 @@ public class KeyPairServiceTest {
                     .thenReturn(Optional.of(proofSigningKey));
             
             byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
-            when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+            when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                     .thenReturn(decryptedPrivateKey);
             
-            try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+            try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
                  MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
                 
-                mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+                mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                         .thenReturn(mock(SecretKey.class));
                 
                 mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -361,7 +360,7 @@ public class KeyPairServiceTest {
                 assertNotNull(result);
             }
             
-            reset(proofSigningKeyRepository, encryptionDecryptionUtil);
+            reset(proofSigningKeyRepository, dataProtectionService);
         }
     }
 
@@ -384,13 +383,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(proofSigningKey));
         
         byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -413,13 +412,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(proofSigningKey));
         
         byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("")))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(
@@ -429,7 +428,7 @@ public class KeyPairServiceTest {
             KeyPair result = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, algorithm);
             
             assertNotNull(result);
-            verify(encryptionDecryptionUtil).decryptWithAES(any(SecretKey.class), eq(""));
+            verify(dataProtectionService).decryptWithAES(any(SecretKey.class), eq(""));
         }
     }
 
@@ -440,11 +439,11 @@ public class KeyPairServiceTest {
         when(proofSigningKeyRepository.findByWalletIdAndAlgorithm(walletId, algorithm.name()))
                 .thenReturn(Optional.of(proofSigningKey));
         
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenThrow(new RuntimeException("Corrupted key - decryption failed"));
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class)) {
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class)) {
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             try {
@@ -467,13 +466,13 @@ public class KeyPairServiceTest {
                 .thenReturn(Optional.of(proofSigningKey));
         
         byte[] decryptedPrivateKey = keyPair.getPrivate().getEncoded();
-        when(encryptionDecryptionUtil.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
+        when(dataProtectionService.decryptWithAES(any(SecretKey.class), eq("encrypted-private-key")))
                 .thenReturn(decryptedPrivateKey);
         
-        try (MockedStatic<EncryptionDecryptionUtil> mockedStaticUtil = Mockito.mockStatic(EncryptionDecryptionUtil.class);
+        try (MockedStatic<DataProtectionService> mockedStaticUtil = Mockito.mockStatic(DataProtectionService.class);
              MockedStatic<SigningKeyUtil> mockedStaticKeyGen = Mockito.mockStatic(SigningKeyUtil.class)) {
             
-            mockedStaticUtil.when(() -> EncryptionDecryptionUtil.bytesToSecretKey(any(byte[].class)))
+            mockedStaticUtil.when(() -> DataProtectionService.bytesToSecretKey(any(byte[].class)))
                     .thenReturn(mock(SecretKey.class));
             
             mockedStaticKeyGen.when(() -> SigningKeyUtil.generateKeyPair(

--- a/src/test/java/io/mosip/mimoto/service/WalletCredentialServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/WalletCredentialServiceTest.java
@@ -11,7 +11,6 @@ import io.mosip.mimoto.model.CredentialMetadata;
 import io.mosip.mimoto.model.VerifiableCredential;
 import io.mosip.mimoto.repository.WalletCredentialsRepository;
 import io.mosip.mimoto.service.impl.WalletCredentialServiceImpl;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +54,7 @@ public class WalletCredentialServiceTest {
     private CredentialPDFGeneratorService credentialPDFGeneratorService;
 
     @Mock
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     private final String walletId = "wallet123";
     private final String issuerId = "issuer123";
@@ -230,7 +229,7 @@ public class WalletCredentialServiceTest {
                 .thenReturn(Optional.of(verifiableCredential));
 
         // Setup decryption
-        when(encryptionDecryptionUtil.decryptCredential("encryptedCredential", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedCredential", base64Key))
                 .thenReturn(decryptedCredentialJson);
         when(objectMapper.readValue(decryptedCredentialJson, VCCredentialResponse.class))
                 .thenReturn(vcResponse);
@@ -278,7 +277,7 @@ public class WalletCredentialServiceTest {
         assertNotNull(actualResponse.getFileContentStream());
 
         verify(walletCredentialsRepository).findByIdAndWalletId(credentialId, walletId);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedCredential", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedCredential", base64Key);
         verify(issuersService).getIssuerDetails(issuerId);
         verify(issuersService).getIssuerConfig(issuerId, credentialType);
         verify(credentialPDFGeneratorService).generatePdfForVerifiableCredential(
@@ -304,13 +303,13 @@ public class WalletCredentialServiceTest {
         assertEquals(RESOURCE_NOT_FOUND.getErrorCode(), exception.getErrorCode());
         assertEquals(RESOURCE_NOT_FOUND.getErrorCode() +" --> "+RESOURCE_NOT_FOUND.getErrorMessage(), exception.getMessage());
         verify(walletCredentialsRepository).findByIdAndWalletId(credentialId, walletId);
-        verifyNoInteractions(encryptionDecryptionUtil, credentialPDFGeneratorService);
+        verifyNoInteractions(dataProtectionService, credentialPDFGeneratorService);
     }
 
     @Test
     public void shouldThrowCredentialProcessingExceptionOnDecryptionFailure() throws Exception {
         when(walletCredentialsRepository.findByIdAndWalletId(credentialId, walletId)).thenReturn(Optional.of(verifiableCredential));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedCredential", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedCredential", base64Key))
                 .thenThrow(new DecryptionException("DECRYPTION_ERROR", "Decryption failed"));
 
         CredentialProcessingException exception = assertThrows(CredentialProcessingException.class, () ->
@@ -318,7 +317,7 @@ public class WalletCredentialServiceTest {
 
         assertEquals(CREDENTIAL_FETCH_EXCEPTION.getErrorCode(), exception.getErrorCode());
         verify(walletCredentialsRepository).findByIdAndWalletId(credentialId, walletId);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedCredential", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedCredential", base64Key);
         verifyNoInteractions(credentialPDFGeneratorService);
     }
 
@@ -348,7 +347,7 @@ public class WalletCredentialServiceTest {
     @Test
     public void shouldThrowCredentialProcessingExceptionOnJsonProcessingError() throws Exception {
         when(walletCredentialsRepository.findByIdAndWalletId(credentialId, walletId)).thenReturn(Optional.of(verifiableCredential));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedCredential", base64Key)).thenReturn("bad-json");
+        when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("bad-json");
         when(objectMapper.readValue("bad-json", VCCredentialResponse.class)).thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("error") {});
 
         CredentialProcessingException exception = assertThrows(CredentialProcessingException.class, () ->
@@ -356,14 +355,14 @@ public class WalletCredentialServiceTest {
 
         assertEquals(CREDENTIAL_FETCH_EXCEPTION.getErrorCode(), exception.getErrorCode());
         verify(walletCredentialsRepository).findByIdAndWalletId(credentialId, walletId);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedCredential", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedCredential", base64Key);
         verify(objectMapper).readValue("bad-json", VCCredentialResponse.class);
     }
 
     @Test
     public void shouldThrowCredentialProcessingExceptionOnNullIssuerConfig() throws Exception {
         when(walletCredentialsRepository.findByIdAndWalletId(credentialId, walletId)).thenReturn(Optional.of(verifiableCredential));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
+        when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
         VCCredentialResponse vcResponse = VCCredentialResponse.builder().credential(VCCredentialProperties.builder().type(List.of(credentialType)).build()).build();
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class))).thenReturn(vcResponse);
         when(issuersService.getIssuerDetails(issuerId)).thenReturn(new IssuerDTO());
@@ -378,7 +377,7 @@ public class WalletCredentialServiceTest {
     @Test
     public void shouldThrowCredentialProcessingExceptionOnCredentialTypeMismatch() throws Exception {
         when(walletCredentialsRepository.findByIdAndWalletId(credentialId, walletId)).thenReturn(Optional.of(verifiableCredential));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
+        when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
         VCCredentialResponse vcResponse = VCCredentialResponse.builder().credential(VCCredentialProperties.builder().type(List.of("OtherType")).build()).build();
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class))).thenReturn(vcResponse);
         when(issuersService.getIssuerDetails(issuerId)).thenReturn(new IssuerDTO());
@@ -400,7 +399,7 @@ public class WalletCredentialServiceTest {
     @Test
     public void shouldThrowCredentialProcessingExceptionOnIssuerServiceException() throws Exception {
         when(walletCredentialsRepository.findByIdAndWalletId(credentialId, walletId)).thenReturn(Optional.of(verifiableCredential));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
+        when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
         VCCredentialResponse vcResponse = VCCredentialResponse.builder().credential(VCCredentialProperties.builder().type(List.of(credentialType)).build()).build();
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class))).thenReturn(vcResponse);
         when(issuersService.getIssuerDetails(issuerId)).thenThrow(new ApiNotAccessibleException("API error"));
@@ -414,7 +413,7 @@ public class WalletCredentialServiceTest {
     @Test
     public void shouldThrowCredentialProcessingExceptionOnPdfGenerationException() throws Exception {
         when(walletCredentialsRepository.findByIdAndWalletId(credentialId, walletId)).thenReturn(Optional.of(verifiableCredential));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
+        when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
         VCCredentialResponse vcResponse = VCCredentialResponse.builder().credential(VCCredentialProperties.builder().type(List.of(credentialType)).build()).build();
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class))).thenReturn(vcResponse);
         when(issuersService.getIssuerDetails(issuerId)).thenReturn(new IssuerDTO());
@@ -443,9 +442,9 @@ public class WalletCredentialServiceTest {
         when(walletCredentialsRepository.findByWalletIdOrderByCreatedAtDesc(walletId))
                 .thenReturn(walletCredentials);
 
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn(new ObjectMapper().writeValueAsString(testVcResponse1));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred2", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred2", base64Key))
                 .thenReturn(new ObjectMapper().writeValueAsString(testVcResponse2));
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class)))
                 .thenReturn(testVcResponse1, testVcResponse2);
@@ -459,8 +458,8 @@ public class WalletCredentialServiceTest {
         assertEquals(testVcResponse2, result.get(1).getCredential());
 
         verify(walletCredentialsRepository).findByWalletIdOrderByCreatedAtDesc(walletId);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred2", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred2", base64Key);
         verify(objectMapper, times(2)).readValue(anyString(), eq(VCCredentialResponse.class));
     }
 
@@ -471,9 +470,9 @@ public class WalletCredentialServiceTest {
         when(walletCredentialsRepository.findByWalletIdOrderByCreatedAtDesc(walletId))
                 .thenReturn(walletCredentials);
 
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn(new ObjectMapper().writeValueAsString(testVcResponse1));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred2", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred2", base64Key))
                 .thenThrow(new DecryptionException("DECRYPTION_ERROR", "Decryption failed"));
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class)))
                 .thenReturn(testVcResponse1);
@@ -485,8 +484,8 @@ public class WalletCredentialServiceTest {
         assertEquals(testVcResponse1, result.get(0).getCredential());
 
         verify(walletCredentialsRepository).findByWalletIdOrderByCreatedAtDesc(walletId);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred2", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred2", base64Key);
         verify(objectMapper).readValue(anyString(), eq(VCCredentialResponse.class));
     }
 
@@ -498,9 +497,9 @@ public class WalletCredentialServiceTest {
         when(walletCredentialsRepository.findByWalletIdOrderByCreatedAtDesc(walletId))
                 .thenReturn(walletCredentials);
 
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn("invalid-json");
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred2", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred2", base64Key))
                 .thenReturn(validJson);
         
         when(objectMapper.readValue("invalid-json", VCCredentialResponse.class))
@@ -515,8 +514,8 @@ public class WalletCredentialServiceTest {
         assertEquals(testVcResponse2, result.get(0).getCredential());
 
         verify(walletCredentialsRepository).findByWalletIdOrderByCreatedAtDesc(walletId);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred2", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred2", base64Key);
         verify(objectMapper).readValue("invalid-json", VCCredentialResponse.class);
         verify(objectMapper).readValue(validJson, VCCredentialResponse.class);
     }
@@ -531,7 +530,7 @@ public class WalletCredentialServiceTest {
         assertTrue(result.isEmpty());
 
         verify(walletCredentialsRepository).findByWalletIdOrderByCreatedAtDesc(walletId);
-        verifyNoInteractions(encryptionDecryptionUtil);
+        verifyNoInteractions(dataProtectionService);
         verifyNoInteractions(objectMapper);
     }
 
@@ -542,9 +541,9 @@ public class WalletCredentialServiceTest {
         when(walletCredentialsRepository.findByWalletIdOrderByCreatedAtDesc(walletId))
                 .thenReturn(walletCredentials);
 
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenThrow(new DecryptionException("DECRYPTION_ERROR", "Decryption failed"));
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred2", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred2", base64Key))
                 .thenThrow(new DecryptionException("DECRYPTION_ERROR", "Decryption failed"));
 
         List<DecryptedCredentialDTO> result = walletCredentialService.getDecryptedCredentials(walletId, base64Key);
@@ -552,8 +551,8 @@ public class WalletCredentialServiceTest {
         assertTrue(result.isEmpty());
 
         verify(walletCredentialsRepository).findByWalletIdOrderByCreatedAtDesc(walletId);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred2", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred2", base64Key);
         verifyNoInteractions(objectMapper);
     }
 
@@ -561,7 +560,7 @@ public class WalletCredentialServiceTest {
     public void shouldDecryptAndParseCredentialSuccessfully() throws Exception {
         String decryptedJson = new ObjectMapper().writeValueAsString(testVcResponse1);
 
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn(decryptedJson);
         when(objectMapper.readValue(decryptedJson, VCCredentialResponse.class))
                 .thenReturn(testVcResponse1);
@@ -570,7 +569,7 @@ public class WalletCredentialServiceTest {
                 walletCredentialService, "decryptAndParseCredential", testCredential1, base64Key);
 
         assertEquals(testVcResponse1, result);
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
         verify(objectMapper).readValue(decryptedJson, VCCredentialResponse.class);
     }
 
@@ -580,7 +579,7 @@ public class WalletCredentialServiceTest {
                 ReflectionTestUtils.invokeMethod(walletCredentialService, "decryptAndParseCredential", null, base64Key));
 
         assertEquals("Credential cannot be null", exception.getMessage());
-        verifyNoInteractions(encryptionDecryptionUtil);
+        verifyNoInteractions(dataProtectionService);
         verifyNoInteractions(objectMapper);
     }
 
@@ -593,52 +592,52 @@ public class WalletCredentialServiceTest {
                 ReflectionTestUtils.invokeMethod(walletCredentialService, "decryptAndParseCredential", credentialWithNullData, base64Key));
 
         assertEquals("Credential data cannot be null", exception.getMessage());
-        verifyNoInteractions(encryptionDecryptionUtil);
+        verifyNoInteractions(dataProtectionService);
         verifyNoInteractions(objectMapper);
     }
 
     @Test
     public void shouldThrowIllegalArgumentExceptionWhenDecryptedDataIsNull() throws Exception {
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn(null);
 
         java.lang.IllegalArgumentException exception = assertThrows(java.lang.IllegalArgumentException.class, () ->
                 ReflectionTestUtils.invokeMethod(walletCredentialService, "decryptAndParseCredential", testCredential1, base64Key));
 
         assertEquals("Failed to decrypt credential or decrypted data is empty", exception.getMessage());
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
         verifyNoInteractions(objectMapper);
     }
 
     @Test
     public void shouldThrowIllegalArgumentExceptionWhenDecryptedDataIsEmpty() throws Exception {
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn("");
 
         java.lang.IllegalArgumentException exception = assertThrows(java.lang.IllegalArgumentException.class, () ->
                 ReflectionTestUtils.invokeMethod(walletCredentialService, "decryptAndParseCredential", testCredential1, base64Key));
 
         assertEquals("Failed to decrypt credential or decrypted data is empty", exception.getMessage());
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
         verifyNoInteractions(objectMapper);
     }
 
     @Test
     public void shouldThrowIllegalArgumentExceptionWhenDecryptedDataIsWhitespace() throws Exception {
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn("   ");
 
         java.lang.IllegalArgumentException exception = assertThrows(java.lang.IllegalArgumentException.class, () ->
                 ReflectionTestUtils.invokeMethod(walletCredentialService, "decryptAndParseCredential", testCredential1, base64Key));
 
         assertEquals("Failed to decrypt credential or decrypted data is empty", exception.getMessage());
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
         verifyNoInteractions(objectMapper);
     }
 
     @Test
     public void shouldThrowDecryptionExceptionWhenDecryptionFails() throws Exception {
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenThrow(new DecryptionException("DECRYPTION_ERROR", "Decryption failed"));
 
         Exception thrownException = assertThrows(Exception.class, () ->
@@ -659,7 +658,7 @@ public class WalletCredentialServiceTest {
         assertNotNull("Exception should not be null", exception);
         assertEquals("DECRYPTION_ERROR", exception.getErrorCode());
         assertEquals("DECRYPTION_ERROR --> Decryption failed", exception.getMessage());
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
         verifyNoInteractions(objectMapper);
     }
 
@@ -667,7 +666,7 @@ public class WalletCredentialServiceTest {
     public void shouldThrowIOExceptionWhenJsonParsingFails() throws Exception {
         String invalidJson = "invalid-json";
 
-        when(encryptionDecryptionUtil.decryptCredential("encryptedcred1", base64Key))
+        when(dataProtectionService.decryptCredential("encryptedcred1", base64Key))
                 .thenReturn(invalidJson);
         when(objectMapper.readValue(invalidJson, VCCredentialResponse.class))
                 .thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("Invalid JSON") {});
@@ -689,7 +688,7 @@ public class WalletCredentialServiceTest {
 
         assertNotNull("Exception should not be null", exception);
         assertEquals("Invalid JSON", exception.getMessage());
-        verify(encryptionDecryptionUtil).decryptCredential("encryptedcred1", base64Key);
+        verify(dataProtectionService).decryptCredential("encryptedcred1", base64Key);
         verify(objectMapper).readValue(invalidJson, VCCredentialResponse.class);
     }
 

--- a/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
@@ -20,7 +20,6 @@ import io.mosip.mimoto.model.VerifiablePresentation;
 import io.mosip.mimoto.repository.VerifiablePresentationsRepository;
 import io.mosip.mimoto.service.impl.OpenID4VPService;
 import io.mosip.mimoto.service.impl.WalletPresentationServiceImpl;
-import io.mosip.mimoto.util.EncryptionDecryptionUtil;
 import io.mosip.mimoto.util.SigningKeyUtil;
 import io.mosip.mimoto.util.UrlParameterUtils;
 import io.mosip.openID4VP.OpenID4VP;
@@ -70,7 +69,7 @@ public class WalletPresentationServiceTest {
     private VerifiablePresentationsRepository verifiablePresentationsRepository;
 
     @Mock
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     @InjectMocks
     private WalletPresentationServiceImpl walletPresentationService;
@@ -235,7 +234,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -451,7 +450,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -493,7 +492,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -532,7 +531,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -681,7 +680,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -816,7 +815,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -859,7 +858,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             when(jwsSigner.sign(any(JWSHeader.class), any(byte[].class))).thenReturn(Base64URL.encode("signature"));
@@ -903,7 +902,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -950,7 +949,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -994,7 +993,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))
@@ -1037,7 +1036,7 @@ public class WalletPresentationServiceTest {
             jwtUtilMock.when(() -> SigningKeyUtil.generateJwk(any(), any())).thenReturn(jwk);
             jwtUtilMock.when(() -> SigningKeyUtil.createSigner(any(), any())).thenReturn(jwsSigner);
 
-            when(encryptionDecryptionUtil.createDetachedJwtSigningInput(anyString(), anyString()))
+            when(dataProtectionService.createDetachedJwtSigningInput(anyString(), anyString()))
                     .thenReturn("signing-input".getBytes());
 
             urlUtilMock.when(() -> UrlParameterUtils.extractQueryParameter(anyString(), anyString()))

--- a/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
@@ -1,0 +1,285 @@
+package io.mosip.mimoto.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.mosip.mimoto.dto.CryptoWithPinRequestDto;
+import io.mosip.mimoto.dto.CryptoWithPinResponseDto;
+import io.mosip.mimoto.exception.CryptoManagerException;
+import io.mosip.mimoto.exception.ParseException;
+
+@ExtendWith(MockitoExtension.class)
+class DerivedKeyCryptoUtilTest {
+
+    @InjectMocks
+    private DerivedKeyCryptoUtil derivedKeyCryptoUtil;
+
+    private static final String AES_KEY_TYPE = "AES";
+    private static final String TEST_DATA = "testdata";
+    private static final String USER_PIN = "12345";
+    private static final byte[] SALT = "testsalt123456789012345678901234".getBytes();
+    private static final byte[] NONCE = "testnonce123".getBytes();
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "symmetricKeyLength", 256);
+        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "iterations", 100000);
+        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "passwordAlgorithm", "PBKDF2WithHmacSHA512");
+    }
+
+    private byte[] encrypt(String data, SecretKey key, byte[] nonce, byte[] aad) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, key, gcmParameterSpec);
+        if (aad != null) {
+            cipher.updateAAD(aad);
+        }
+        return cipher.doFinal(data.getBytes());
+    }
+
+    @Test
+    void testDecryptWithPin() throws Exception {
+        SecretKey derivedKey = getDerivedKey(USER_PIN, SALT);
+        byte[] encryptedData = encrypt(TEST_DATA, derivedKey, NONCE, SALT);
+
+        byte[] combined = new byte[SALT.length + NONCE.length + encryptedData.length];
+        System.arraycopy(SALT, 0, combined, 0, SALT.length);
+        System.arraycopy(NONCE, 0, combined, SALT.length, NONCE.length);
+        System.arraycopy(encryptedData, 0, combined, SALT.length + NONCE.length, encryptedData.length);
+
+        CryptoWithPinRequestDto requestDto = new CryptoWithPinRequestDto();
+        requestDto.setData(Base64.getEncoder().encodeToString(combined));
+        requestDto.setUserPin(USER_PIN);
+
+        CryptoWithPinResponseDto response = derivedKeyCryptoUtil.decryptWithPin(requestDto);
+        assertNotNull(response);
+        assertEquals(TEST_DATA, response.getData());
+    }
+
+    @Test
+    void testSymmetricDecryptWithIV() throws Exception {
+        SecretKey key = new SecretKeySpec("testkey123456789".getBytes(), AES_KEY_TYPE);
+        byte[] encryptedData = encrypt(TEST_DATA, key, NONCE, null);
+
+        byte[] decryptedData = invokeSymmetricDecrypt(key, encryptedData, NONCE, null);
+        assertEquals(TEST_DATA, new String(decryptedData));
+    }
+
+    @Test
+    void testSymmetricDecryptWithIVAndAad() throws Exception {
+        SecretKey key = new SecretKeySpec("testkey123456789".getBytes(), AES_KEY_TYPE);
+        byte[] aad = "testaad".getBytes();
+        byte[] encryptedData = encrypt(TEST_DATA, key, NONCE, aad);
+
+        byte[] decryptedData = invokeSymmetricDecrypt(key, encryptedData, NONCE, aad);
+        assertEquals(TEST_DATA, new String(decryptedData));
+    }
+
+    @Test
+    void testSymmetricDecryptWithIVWithNullIV() throws Exception {
+        SecretKey key = new SecretKeySpec("testkey123456789".getBytes(), AES_KEY_TYPE);
+        byte[] iv16 = "testnonce1234567".getBytes();
+        byte[] encryptedData = encrypt(TEST_DATA, key, iv16, null);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        byte[] combined = new byte[encryptedData.length + cipher.getBlockSize()];
+        System.arraycopy(encryptedData, 0, combined, 0, encryptedData.length);
+        System.arraycopy(iv16, 0, combined, encryptedData.length, iv16.length);
+
+
+        byte[] decryptedData = invokeSymmetricDecrypt(key, combined, null, null);
+        assertEquals(TEST_DATA, new String(decryptedData));
+    }
+
+    @Test
+    void testSymmetricDecryptWithIVWithNullIVAndAad() throws Exception {
+        SecretKey key = new SecretKeySpec("testkey123456789".getBytes(), AES_KEY_TYPE);
+        byte[] aad = "testaad".getBytes();
+        byte[] iv16 = "testnonce1234567".getBytes(); // 16 bytes
+        byte[] encryptedData = encrypt(TEST_DATA, key, iv16, aad);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        byte[] combined = new byte[encryptedData.length + cipher.getBlockSize()];
+        System.arraycopy(encryptedData, 0, combined, 0, encryptedData.length);
+        System.arraycopy(iv16, 0, combined, encryptedData.length, iv16.length);
+
+
+        byte[] decryptedData = invokeSymmetricDecrypt(key, combined, null, aad);
+        assertEquals(TEST_DATA, new String(decryptedData));
+    }
+
+    @Test
+    void testSymmetricDecryptWithIVThrowsCryptoManagerException() throws Exception {
+        SecretKey key = new SecretKeySpec("testkey".getBytes(), AES_KEY_TYPE);
+        byte[] data = "testdata".getBytes();
+        byte[] iv = "testiv".getBytes();
+        byte[] aad = "testaad".getBytes();
+
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
+            invokeSymmetricDecrypt(key, data, iv, aad);
+        });
+
+        assertEquals(InvalidKeyException.class, exception.getTargetException().getClass());
+    }
+
+    @Test
+    void testSymmetricDecryptWithoutIVThrowsCryptoManagerException() throws Exception {
+        SecretKey key = new SecretKeySpec("testkey1234567890123456".getBytes(), AES_KEY_TYPE);
+        byte[] data = "testdata".getBytes();
+        byte[] aad = "testaad".getBytes();
+
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
+            invokeSymmetricDecrypt(key, data, null, aad);
+        });
+
+        assertEquals(CryptoManagerException.class, exception.getTargetException().getClass());
+    }
+
+    @Test
+    void testSymmetricDecryptThrowsCryptoManagerException() throws Exception {
+        java.security.Provider[] original = java.security.Security.getProviders();
+
+        java.security.Provider bogus = new java.security.Provider("BogusProv", 1.0, "for tests") {
+            {
+                put("Cipher.AES/GCM/NoPadding", "non.existent.CipherImpl");
+            }
+        };
+
+        SecretKey key = new SecretKeySpec("0123456789ABCDEF".getBytes(), AES_KEY_TYPE);
+        byte[] iv = NONCE;
+        byte[] encrypted = encrypt(TEST_DATA, key, iv, null);
+
+        try {
+            for (java.security.Provider p : original) {
+                java.security.Security.removeProvider(p.getName());
+            }
+            java.security.Security.insertProviderAt(bogus, 1);
+
+            Exception exception = assertThrows(Exception.class, () -> {
+                invokeSymmetricDecrypt(key, encrypted, iv, null);
+            });
+
+            Throwable targetException = exception;
+            if (exception instanceof InvocationTargetException) {
+                targetException = ((InvocationTargetException) exception).getTargetException();
+            }
+
+            if (targetException instanceof ExceptionInInitializerError) {
+                targetException = targetException.getCause();
+            }
+
+            boolean isExpectedException = targetException instanceof CryptoManagerException ||
+                                         targetException instanceof NoSuchAlgorithmException ||
+                                         targetException instanceof NoSuchPaddingException ||
+                                         targetException instanceof SecurityException;
+
+            assertTrue(isExpectedException,
+                "Expected CryptoManagerException, NoSuchAlgorithmException, NoSuchPaddingException, or SecurityException but got: " +
+                targetException.getClass().getName());
+        } finally {
+            java.security.Security.removeProvider(bogus.getName());
+            for (java.security.Provider p : original) {
+                java.security.Security.addProvider(p);
+            }
+        }
+    }
+
+    @Test
+    void testGetDerivedKey() throws Exception {
+        SecretKey derivedKey = getDerivedKey(USER_PIN, SALT);
+        assertNotNull(derivedKey);
+        assertEquals(AES_KEY_TYPE, derivedKey.getAlgorithm());
+    }
+
+    @Test
+    void testHash() throws Exception {
+        String hash = invokeHash(USER_PIN.getBytes(), SALT);
+        assertNotNull(hash);
+    }
+
+    @Test
+    void testHashThrowsCryptoManagerException() {
+        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "passwordAlgorithm", "InvalidAlgo");
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
+            invokeHash(USER_PIN.getBytes(), SALT);
+        });
+        assertEquals(CryptoManagerException.class, exception.getTargetException().getClass());
+    }
+
+    @Test
+    void testHexDecode() throws Exception {
+        String hexData = "7465737464617461";
+        byte[] decodedBytes = invokeHexDecode(hexData);
+        assertEquals(TEST_DATA, new String(decodedBytes));
+    }
+
+    @Test
+    void testHexDecodeWithOddLength() {
+        String hexData = "7465737464617461F";
+        InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
+            invokeHexDecode(hexData);
+        });
+        assertEquals(ParseException.class, exception.getTargetException().getClass());
+    }
+
+    @Test
+    void testStaticSymmetricDecryptWithEmptyAadDoesNotUseAad() throws Exception {
+        SecretKey key = new SecretKeySpec("testkey123456789".getBytes(), AES_KEY_TYPE);
+        byte[] iv16 = "testnonce1234567".getBytes();
+        byte[] encryptedData = encrypt(TEST_DATA, key, iv16, null);
+
+        byte[] combined = new byte[encryptedData.length + iv16.length];
+        System.arraycopy(encryptedData, 0, combined, 0, encryptedData.length);
+        System.arraycopy(iv16, 0, combined, encryptedData.length, iv16.length);
+
+        Method staticMethod = DerivedKeyCryptoUtil.class.getDeclaredMethod("symmetricDecrypt", SecretKey.class, byte[].class, byte[].class);
+        staticMethod.setAccessible(true);
+        byte[] decrypted = (byte[]) staticMethod.invoke(null, key, combined, new byte[0]);
+        assertEquals(TEST_DATA, new String(decrypted));
+    }
+
+    private byte[] invokeSymmetricDecrypt(SecretKey key, byte[] data, byte[] iv, byte[] aad) throws Exception {
+        Method method = DerivedKeyCryptoUtil.class.getDeclaredMethod("symmetricDecrypt", SecretKey.class, byte[].class, byte[].class, byte[].class);
+        method.setAccessible(true);
+        return (byte[]) method.invoke(derivedKeyCryptoUtil, key, data, iv, aad);
+    }
+
+    private SecretKey getDerivedKey(String userPin, byte[] salt) throws Exception {
+        Method method = DerivedKeyCryptoUtil.class.getDeclaredMethod("getDerivedKey", String.class, byte[].class);
+        method.setAccessible(true);
+        return (SecretKey) method.invoke(derivedKeyCryptoUtil, userPin, salt);
+    }
+
+    private String invokeHash(byte[] data, byte[] salt) throws Exception {
+        Method method = DerivedKeyCryptoUtil.class.getDeclaredMethod("hash", byte[].class, byte[].class);
+        method.setAccessible(true);
+        return (String) method.invoke(derivedKeyCryptoUtil, data, salt);
+    }
+
+    private byte[] invokeHexDecode(String hexData) throws Exception {
+        Method method = DerivedKeyCryptoUtil.class.getDeclaredMethod("hexDecode", String.class);
+        method.setAccessible(true);
+        return (byte[]) method.invoke(derivedKeyCryptoUtil, hexData);
+    }
+}

--- a/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
@@ -12,7 +12,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 import javax.crypto.Cipher;
-import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -21,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -130,7 +131,7 @@ class DerivedKeyCryptoUtilTest {
     }
 
     @Test
-    void testSymmetricDecryptWithIVThrowsCryptoManagerException() throws Exception {
+    void testSymmetricDecryptWithIVThrowsInvalidKeyException() throws Exception {
         SecretKey key = new SecretKeySpec("testkey".getBytes(), AES_KEY_TYPE);
         byte[] data = "testdata".getBytes();
         byte[] iv = "testiv".getBytes();
@@ -145,7 +146,7 @@ class DerivedKeyCryptoUtilTest {
 
     @Test
     void testSymmetricDecryptWithoutIVThrowsCryptoManagerException() throws Exception {
-        SecretKey key = new SecretKeySpec("testkey1234567890123456".getBytes(), AES_KEY_TYPE);
+        SecretKey key = new SecretKeySpec("testkey12345678901234567".getBytes(), AES_KEY_TYPE);
         byte[] data = "testdata".getBytes();
         byte[] aad = "testaad".getBytes();
 
@@ -158,50 +159,21 @@ class DerivedKeyCryptoUtilTest {
 
     @Test
     void testSymmetricDecryptThrowsCryptoManagerException() throws Exception {
-        java.security.Provider[] original = java.security.Security.getProviders();
-
-        java.security.Provider bogus = new java.security.Provider("BogusProv", 1.0, "for tests") {
-            {
-                put("Cipher.AES/GCM/NoPadding", "non.existent.CipherImpl");
-            }
-        };
-
         SecretKey key = new SecretKeySpec("0123456789ABCDEF".getBytes(), AES_KEY_TYPE);
         byte[] iv = NONCE;
         byte[] encrypted = encrypt(TEST_DATA, key, iv, null);
 
-        try {
-            for (java.security.Provider p : original) {
-                java.security.Security.removeProvider(p.getName());
-            }
-            java.security.Security.insertProviderAt(bogus, 1);
+        try (MockedStatic<Cipher> mocked = Mockito.mockStatic(Cipher.class)) {
+            mocked.when(() -> Cipher.getInstance("AES/GCM/NoPadding"))
+                  .thenThrow(new NoSuchAlgorithmException("for tests"));
 
-            Exception exception = assertThrows(Exception.class, () -> {
+            InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
                 invokeSymmetricDecrypt(key, encrypted, iv, null);
             });
 
-            Throwable targetException = exception;
-            if (exception instanceof InvocationTargetException) {
-                targetException = ((InvocationTargetException) exception).getTargetException();
-            }
-
-            if (targetException instanceof ExceptionInInitializerError) {
-                targetException = targetException.getCause();
-            }
-
-            boolean isExpectedException = targetException instanceof CryptoManagerException ||
-                                         targetException instanceof NoSuchAlgorithmException ||
-                                         targetException instanceof NoSuchPaddingException ||
-                                         targetException instanceof SecurityException;
-
-            assertTrue(isExpectedException,
-                "Expected CryptoManagerException, NoSuchAlgorithmException, NoSuchPaddingException, or SecurityException but got: " +
-                targetException.getClass().getName());
-        } finally {
-            java.security.Security.removeProvider(bogus.getName());
-            for (java.security.Provider p : original) {
-                java.security.Security.addProvider(p);
-            }
+            Throwable targetException = exception.getTargetException();
+            assertEquals(CryptoManagerException.class, targetException.getClass());
+            assertTrue(targetException.getCause() instanceof NoSuchAlgorithmException);
         }
     }
 

--- a/src/test/java/io/mosip/mimoto/util/P12KeyStoreManagerTest.java
+++ b/src/test/java/io/mosip/mimoto/util/P12KeyStoreManagerTest.java
@@ -117,13 +117,17 @@ public class P12KeyStoreManagerTest {
     public void testLoadP12_InvalidFile() throws Exception {
         java.io.File tempFile = java.io.File.createTempFile("invalid", ".p12");
         tempFile.deleteOnExit();
-        java.io.FileWriter writer = new java.io.FileWriter(tempFile);
-        writer.write("Not a valid PKCS12 file");
-        writer.close();
+        try {
+            try (java.io.FileWriter writer = new java.io.FileWriter(tempFile)) {
+                writer.write("Not a valid PKCS12 file");
+            }
 
-        KeyStore.PrivateKeyEntry entry = p12KeyStoreManager.loadP12(tempFile.getAbsolutePath(), "alias", "password");
-        assertNull(entry);
-        tempFile.delete();
+            KeyStore.PrivateKeyEntry entry = p12KeyStoreManager.loadP12(tempFile.getAbsolutePath(), "alias", "password");
+            assertNull(entry);
+        } finally {
+            // Ensure cleanup even if writer.write(...) or loadP12(...) throws
+            tempFile.delete();
+        }
     }
 
     @Test
@@ -194,7 +198,7 @@ public class P12KeyStoreManagerTest {
         byte[] result = p12KeyStoreManager.symmetricDecrypt(symmetricKey, encryptedBytes, nonce, null);
 
         assertNotNull(result);
-        assertEquals(plainText, new String(result));
+        assertEquals(plainText, new String(result, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -217,7 +221,7 @@ public class P12KeyStoreManagerTest {
         byte[] result = p12KeyStoreManager.symmetricDecrypt(symmetricKey, encryptedBytes, nonce, aad);
 
         assertNotNull(result);
-        assertEquals(plainText, new String(result));
+        assertEquals(plainText, new String(result, StandardCharsets.UTF_8));
     }
 
     @Test(expected = CryptoManagerException.class)
@@ -289,7 +293,7 @@ public class P12KeyStoreManagerTest {
         byte[] result = (byte[]) method.invoke(null, symmetricKey, dataWithIV, aad);
 
         assertNotNull(result);
-        assertEquals(plainText, new String(result));
+        assertEquals(plainText, new String(result, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -332,7 +336,7 @@ public class P12KeyStoreManagerTest {
         byte[] result = p12KeyStoreManager.decryptData(finalData, privateKeyEntry);
 
         assertNotNull(result);
-        assertEquals(plainText, new String(result));
+        assertEquals(plainText, new String(result, StandardCharsets.UTF_8));
     }
 
     @Test
@@ -370,7 +374,6 @@ public class P12KeyStoreManagerTest {
         byte[] result = p12KeyStoreManager.decryptData(finalData, privateKeyEntry);
 
         assertNotNull(result);
-        assertEquals(plainText, new String(result));
+        assertEquals(plainText, new String(result, StandardCharsets.UTF_8));
     }
 }
-

--- a/src/test/java/io/mosip/mimoto/util/P12KeyStoreManagerTest.java
+++ b/src/test/java/io/mosip/mimoto/util/P12KeyStoreManagerTest.java
@@ -1,0 +1,376 @@
+package io.mosip.mimoto.util;
+
+import io.mosip.mimoto.exception.CryptoManagerException;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class P12KeyStoreManagerTest {
+
+    @InjectMocks
+    private P12KeyStoreManager p12KeyStoreManager;
+
+    private KeyPair keyPair;
+    private KeyStore.PrivateKeyEntry privateKeyEntry;
+    private SecretKey symmetricKey;
+    private static final String KEY_SPLITTER = "#KEY_SPLITTER#";
+    private static final byte[] VERSION_RSA_2048 = "VER_R2".getBytes();
+    private static final int THUMBPRINT_LENGTH = 32;
+    private static final int NONCE = 12;
+
+    @Before
+    public void setUp() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        keyPair = keyPairGenerator.generateKeyPair();
+
+        Certificate certificate = generateSelfSignedCertificate(keyPair);
+        Certificate[] certChain = new Certificate[]{certificate};
+        privateKeyEntry = new KeyStore.PrivateKeyEntry(keyPair.getPrivate(), certChain);
+
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(256);
+        symmetricKey = keyGen.generateKey();
+
+        ReflectionTestUtils.setField(p12KeyStoreManager, "fileName", "test.p12");
+        ReflectionTestUtils.setField(p12KeyStoreManager, "cyptoPassword", "test123");
+        ReflectionTestUtils.setField(p12KeyStoreManager, "alias", "testalias");
+        ReflectionTestUtils.setField(p12KeyStoreManager, "isThumbprint", true);
+    }
+
+    private java.security.cert.X509Certificate generateSelfSignedCertificate(KeyPair keyPair) throws Exception {
+        long now = System.currentTimeMillis();
+        java.util.Date startDate = new java.util.Date(now);
+        org.bouncycastle.asn1.x500.X500Name dnName = new org.bouncycastle.asn1.x500.X500Name("CN=Test");
+        java.math.BigInteger certSerialNumber = java.math.BigInteger.valueOf(now);
+
+        java.util.Calendar calendar = java.util.Calendar.getInstance();
+        calendar.setTime(startDate);
+        calendar.add(java.util.Calendar.YEAR, 1);
+        java.util.Date endDate = calendar.getTime();
+
+        org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder certBuilder =
+            new org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder(
+                dnName, certSerialNumber, startDate, endDate, dnName, keyPair.getPublic());
+
+        org.bouncycastle.operator.ContentSigner contentSigner =
+            new org.bouncycastle.operator.jcajce.JcaContentSignerBuilder("SHA256WithRSA")
+                .build(keyPair.getPrivate());
+
+        org.bouncycastle.cert.X509CertificateHolder certHolder = certBuilder.build(contentSigner);
+        return new org.bouncycastle.cert.jcajce.JcaX509CertificateConverter().getCertificate(certHolder);
+    }
+
+    @Test
+    public void testDecrypt_Success() throws Exception {
+        String plainText = "Test Data";
+        P12KeyStoreManager spyManager = spy(p12KeyStoreManager);
+        doReturn(privateKeyEntry).when(spyManager).loadP12();
+        doReturn(plainText.getBytes()).when(spyManager).decryptData(any(byte[].class), any(KeyStore.PrivateKeyEntry.class));
+
+        String result = spyManager.decrypt(Base64.encodeBase64String("test".getBytes()));
+
+        assertEquals(plainText, result);
+    }
+
+    @Test
+    public void testDecrypt_WithNullData() throws Exception {
+        String result = p12KeyStoreManager.decrypt(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testDecrypt_ExceptionHandling() throws Exception {
+        P12KeyStoreManager spyManager = spy(p12KeyStoreManager);
+        doThrow(new IOException("Test exception")).when(spyManager).loadP12();
+
+        String result = spyManager.decrypt("invalid_data");
+        assertNull(result);
+    }
+
+    @Test
+    public void testLoadP12_FileNotFound() throws Exception {
+        KeyStore.PrivateKeyEntry entry = p12KeyStoreManager.loadP12("nonexistent.p12", "alias", "password");
+        assertNull(entry);
+    }
+
+    @Test
+    public void testLoadP12_InvalidFile() throws Exception {
+        java.io.File tempFile = java.io.File.createTempFile("invalid", ".p12");
+        tempFile.deleteOnExit();
+        java.io.FileWriter writer = new java.io.FileWriter(tempFile);
+        writer.write("Not a valid PKCS12 file");
+        writer.close();
+
+        KeyStore.PrivateKeyEntry entry = p12KeyStoreManager.loadP12(tempFile.getAbsolutePath(), "alias", "password");
+        assertNull(entry);
+        tempFile.delete();
+    }
+
+    @Test
+    public void testDecryptData_InvalidFormat() throws Exception {
+        byte[] invalidData = "invalid_data_no_splitter".getBytes();
+        byte[] result = p12KeyStoreManager.decryptData(invalidData, privateKeyEntry);
+        assertNull(result);
+    }
+
+    @Test
+    public void testDecryptData_WithNullPrivateKey() throws Exception {
+        byte[] data = ("key" + KEY_SPLITTER + "data").getBytes();
+        byte[] result = p12KeyStoreManager.decryptData(data, null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testParseEncryptKeyHeader_WithVersionHeader() {
+        byte[] encryptedKey = new byte[THUMBPRINT_LENGTH + VERSION_RSA_2048.length + 256];
+        System.arraycopy(VERSION_RSA_2048, 0, encryptedKey, 0, VERSION_RSA_2048.length);
+
+        byte[] result = p12KeyStoreManager.parseEncryptKeyHeader(encryptedKey);
+        assertArrayEquals(VERSION_RSA_2048, result);
+    }
+
+    @Test
+    public void testParseEncryptKeyHeader_WithoutVersionHeader() {
+        byte[] encryptedKey = new byte[THUMBPRINT_LENGTH + 256];
+        Arrays.fill(encryptedKey, (byte) 0);
+
+        byte[] result = p12KeyStoreManager.parseEncryptKeyHeader(encryptedKey);
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    public void testGetCertificateThumbprint_Success() throws Exception {
+        Certificate mockCert = mock(Certificate.class);
+        when(mockCert.getEncoded()).thenReturn("test certificate data".getBytes());
+
+        byte[] thumbprint = P12KeyStoreManager.getCertificateThumbprint(mockCert);
+
+        assertNotNull(thumbprint);
+        assertEquals(32, thumbprint.length);
+    }
+
+    @Test(expected = CryptoManagerException.class)
+    public void testGetCertificateThumbprint_Exception() throws Exception {
+        Certificate mockCert = mock(Certificate.class);
+        when(mockCert.getEncoded()).thenThrow(new java.security.cert.CertificateEncodingException("Test exception"));
+
+        P12KeyStoreManager.getCertificateThumbprint(mockCert);
+    }
+
+    @Test
+    public void testSymmetricDecrypt_Success() throws Exception {
+        String plainText = "Test Data";
+        byte[] plainBytes = plainText.getBytes(StandardCharsets.UTF_8);
+
+        byte[] nonce = new byte[NONCE];
+        new SecureRandom().nextBytes(nonce);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(symmetricKey.getEncoded(), "AES");
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+        byte[] encryptedBytes = cipher.doFinal(plainBytes);
+
+        byte[] result = p12KeyStoreManager.symmetricDecrypt(symmetricKey, encryptedBytes, nonce, null);
+
+        assertNotNull(result);
+        assertEquals(plainText, new String(result));
+    }
+
+    @Test
+    public void testSymmetricDecrypt_WithAAD() throws Exception {
+        String plainText = "Test Data";
+        byte[] plainBytes = plainText.getBytes(StandardCharsets.UTF_8);
+
+        byte[] nonce = new byte[NONCE];
+        new SecureRandom().nextBytes(nonce);
+        byte[] aad = new byte[32];
+        System.arraycopy(nonce, 0, aad, 0, NONCE);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(symmetricKey.getEncoded(), "AES");
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+        cipher.updateAAD(aad);
+        byte[] encryptedBytes = cipher.doFinal(plainBytes);
+
+        byte[] result = p12KeyStoreManager.symmetricDecrypt(symmetricKey, encryptedBytes, nonce, aad);
+
+        assertNotNull(result);
+        assertEquals(plainText, new String(result));
+    }
+
+    @Test(expected = CryptoManagerException.class)
+    public void testSymmetricDecrypt_WrongKey() throws Exception {
+        String plainText = "Test Data";
+        byte[] plainBytes = plainText.getBytes(StandardCharsets.UTF_8);
+        byte[] nonce = new byte[NONCE];
+        new SecureRandom().nextBytes(nonce);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(symmetricKey.getEncoded(), "AES");
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, nonce);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+        byte[] encryptedBytes = cipher.doFinal(plainBytes);
+
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(256);
+        SecretKey differentKey = keyGen.generateKey();
+
+        p12KeyStoreManager.symmetricDecrypt(differentKey, encryptedBytes, nonce, null);
+    }
+
+    @Test
+    public void testAsymmetricDecrypt_PrivateMethod() throws Exception {
+        String plainText = "Test Symmetric Key";
+        byte[] plainBytes = plainText.getBytes();
+
+        Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING");
+        javax.crypto.spec.OAEPParameterSpec oaepParams = new javax.crypto.spec.OAEPParameterSpec("SHA-256", "MGF1",
+                java.security.spec.MGF1ParameterSpec.SHA256, javax.crypto.spec.PSource.PSpecified.DEFAULT);
+        cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaepParams);
+        byte[] encryptedBytes = cipher.doFinal(plainBytes);
+
+        java.lang.reflect.Method method = P12KeyStoreManager.class.getDeclaredMethod("asymmetricDecrypt",
+                java.security.PrivateKey.class, java.math.BigInteger.class, byte[].class);
+        method.setAccessible(true);
+
+        byte[] result = (byte[]) method.invoke(null, keyPair.getPrivate(),
+                ((java.security.interfaces.RSAPrivateKey) keyPair.getPrivate()).getModulus(), encryptedBytes);
+
+        assertNotNull(result);
+        assertArrayEquals(plainBytes, result);
+    }
+
+    @Test
+    public void testSymmetricDecrypt_PrivateMethod() throws Exception {
+        String plainText = "Test Data";
+        byte[] plainBytes = plainText.getBytes(StandardCharsets.UTF_8);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(symmetricKey.getEncoded(), "AES");
+        byte[] iv = new byte[16];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+        byte[] aad = "additional data".getBytes();
+        cipher.updateAAD(aad);
+        byte[] encryptedData = cipher.doFinal(plainBytes);
+
+        java.io.ByteArrayOutputStream outputStream = new java.io.ByteArrayOutputStream();
+        outputStream.write(encryptedData);
+        outputStream.write(iv);
+        byte[] dataWithIV = outputStream.toByteArray();
+
+        java.lang.reflect.Method method = P12KeyStoreManager.class.getDeclaredMethod("symmetricDecrypt",
+                SecretKey.class, byte[].class, byte[].class);
+        method.setAccessible(true);
+
+        byte[] result = (byte[]) method.invoke(null, symmetricKey, dataWithIV, aad);
+
+        assertNotNull(result);
+        assertEquals(plainText, new String(result));
+    }
+
+    @Test
+    public void testDecryptData_WithThumbprint_NoVersionHeader() throws Exception {
+        ReflectionTestUtils.setField(p12KeyStoreManager, "isThumbprint", true);
+
+        String plainText = "Test Data";
+        byte[] plainBytes = plainText.getBytes(StandardCharsets.UTF_8);
+
+        Cipher aesCipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(symmetricKey.getEncoded(), "AES");
+        byte[] iv = new byte[16];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        aesCipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+        byte[] encryptedData = aesCipher.doFinal(plainBytes);
+
+        java.io.ByteArrayOutputStream dataStream = new java.io.ByteArrayOutputStream();
+        dataStream.write(encryptedData);
+        dataStream.write(iv);
+        byte[] fullEncryptedData = dataStream.toByteArray();
+
+        Cipher rsaCipher = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING");
+        javax.crypto.spec.OAEPParameterSpec oaepParams = new javax.crypto.spec.OAEPParameterSpec("SHA-256", "MGF1",
+                java.security.spec.MGF1ParameterSpec.SHA256, javax.crypto.spec.PSource.PSpecified.DEFAULT);
+        rsaCipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaepParams);
+        byte[] encryptedSymmetricKey = rsaCipher.doFinal(symmetricKey.getEncoded());
+
+        java.io.ByteArrayOutputStream keyStream = new java.io.ByteArrayOutputStream();
+        keyStream.write(new byte[32]); // THUMBPRINT_LENGTH = 32
+        keyStream.write(encryptedSymmetricKey);
+        byte[] fullEncryptedKey = keyStream.toByteArray();
+
+        java.io.ByteArrayOutputStream finalStream = new java.io.ByteArrayOutputStream();
+        finalStream.write(fullEncryptedKey);
+        finalStream.write("#KEY_SPLITTER#".getBytes());
+        finalStream.write(fullEncryptedData);
+        byte[] finalData = finalStream.toByteArray();
+
+        byte[] result = p12KeyStoreManager.decryptData(finalData, privateKeyEntry);
+
+        assertNotNull(result);
+        assertEquals(plainText, new String(result));
+    }
+
+    @Test
+    public void testDecryptData_WithoutThumbprint_NoVersionHeader() throws Exception {
+        ReflectionTestUtils.setField(p12KeyStoreManager, "isThumbprint", false);
+
+        String plainText = "Test Data";
+        byte[] plainBytes = plainText.getBytes(StandardCharsets.UTF_8);
+
+        Cipher aesCipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(symmetricKey.getEncoded(), "AES");
+        byte[] iv = new byte[16];
+        new SecureRandom().nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        aesCipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
+        byte[] encryptedData = aesCipher.doFinal(plainBytes);
+
+        java.io.ByteArrayOutputStream dataStream = new java.io.ByteArrayOutputStream();
+        dataStream.write(encryptedData);
+        dataStream.write(iv);
+        byte[] fullEncryptedData = dataStream.toByteArray();
+
+        Cipher rsaCipher = Cipher.getInstance("RSA/ECB/OAEPWITHSHA-256ANDMGF1PADDING");
+        javax.crypto.spec.OAEPParameterSpec oaepParams = new javax.crypto.spec.OAEPParameterSpec("SHA-256", "MGF1",
+                java.security.spec.MGF1ParameterSpec.SHA256, javax.crypto.spec.PSource.PSpecified.DEFAULT);
+        rsaCipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaepParams);
+        byte[] encryptedSymmetricKey = rsaCipher.doFinal(symmetricKey.getEncoded());
+
+        java.io.ByteArrayOutputStream finalStream = new java.io.ByteArrayOutputStream();
+        finalStream.write(encryptedSymmetricKey);
+        finalStream.write("#KEY_SPLITTER#".getBytes());
+        finalStream.write(fullEncryptedData);
+        byte[] finalData = finalStream.toByteArray();
+
+        byte[] result = p12KeyStoreManager.decryptData(finalData, privateKeyEntry);
+
+        assertNotNull(result);
+        assertEquals(plainText, new String(result));
+    }
+}
+

--- a/src/test/java/io/mosip/mimoto/util/WalletUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/WalletUtilTest.java
@@ -1,5 +1,8 @@
 package io.mosip.mimoto.util;
 
+import io.mosip.kernel.cryptomanager.dto.CryptoWithPinRequestDto;
+import io.mosip.kernel.cryptomanager.dto.CryptoWithPinResponseDto;
+import io.mosip.kernel.cryptomanager.service.CryptomanagerService;
 import io.mosip.mimoto.constant.SessionKeys;
 import io.mosip.mimoto.model.Wallet;
 import io.mosip.mimoto.exception.InvalidRequestException;
@@ -36,6 +39,9 @@ class WalletUtilTest {
     @Mock
     private DataProtectionService dataProtectionService;
 
+    @Mock
+    private CryptomanagerService cryptomanagerService;
+
     @InjectMocks
     private WalletUtil walletUtil;
 
@@ -55,7 +61,7 @@ class WalletUtilTest {
         if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
             Security.addProvider(new BouncyCastleProvider());
         }
-        
+
         pin = "1234";
         name = "default";
         userId = UUID.randomUUID().toString();
@@ -69,7 +75,9 @@ class WalletUtilTest {
 
     @Test
     void shouldDecryptWalletKeySuccessfully() {
-        when(dataProtectionService.decryptWithPin(encryptedWalletKey, pin)).thenReturn(decryptedWalletKey);
+        CryptoWithPinResponseDto responseDto = new CryptoWithPinResponseDto();
+        responseDto.setData(decryptedWalletKey);
+        when(cryptomanagerService.decryptWithPin(any(CryptoWithPinRequestDto.class))).thenReturn(responseDto);
 
         String decrypted = walletUtil.decryptWalletKey(encryptedWalletKey, pin);
 
@@ -78,7 +86,7 @@ class WalletUtilTest {
 
     @Test
     void shouldThrowErrorWhenDecryptionOfWalletKeyFails() {
-        when(dataProtectionService.decryptWithPin(encryptedWalletKey, pin)).thenThrow(new RuntimeException("Failed to decrypt with PIN"));
+        when(cryptomanagerService.decryptWithPin(any(CryptoWithPinRequestDto.class))).thenThrow(new RuntimeException("Failed to decrypt with PIN"));
 
         InvalidRequestException ex = assertThrows(InvalidRequestException.class,
                 () -> walletUtil.decryptWalletKey(encryptedWalletKey, pin));
@@ -89,7 +97,9 @@ class WalletUtilTest {
 
     @Test
     void shouldCreateNewWalletSuccessfully() {
-        when(dataProtectionService.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
+        CryptoWithPinResponseDto responseDto = new CryptoWithPinResponseDto();
+        responseDto.setData(encryptedWalletKey);
+        when(cryptomanagerService.encryptWithPin(any(CryptoWithPinRequestDto.class))).thenReturn(responseDto);
         when(dataProtectionService.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
 
         String walletId = walletUtil.saveWallet(userId, name, pin, encryptionKey, encryptionAlgorithm, encryptionType);
@@ -99,7 +109,9 @@ class WalletUtilTest {
 
     @Test
     void shouldCreateEd25519WalletSuccessfully() {
-        when(dataProtectionService.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
+        CryptoWithPinResponseDto responseDto = new CryptoWithPinResponseDto();
+        responseDto.setData(encryptedWalletKey);
+        when(cryptomanagerService.encryptWithPin(any(CryptoWithPinRequestDto.class))).thenReturn(responseDto);
         when(dataProtectionService.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
 
         String walletId = walletUtil.createWallet(userId, name, pin);
@@ -109,7 +121,9 @@ class WalletUtilTest {
 
     @Test
     void shouldVerifyWalletObjectOnCreateNewWallet() {
-        when(dataProtectionService.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
+        CryptoWithPinResponseDto responseDto = new CryptoWithPinResponseDto();
+        responseDto.setData(encryptedWalletKey);
+        when(cryptomanagerService.encryptWithPin(any(CryptoWithPinRequestDto.class))).thenReturn(responseDto);
         when(dataProtectionService.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
 
         String walletId = walletUtil.saveWallet(userId, name, pin, encryptionKey, encryptionAlgorithm, encryptionType);

--- a/src/test/java/io/mosip/mimoto/util/WalletUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/WalletUtilTest.java
@@ -4,6 +4,7 @@ import io.mosip.mimoto.constant.SessionKeys;
 import io.mosip.mimoto.model.Wallet;
 import io.mosip.mimoto.exception.InvalidRequestException;
 import io.mosip.mimoto.repository.WalletRepository;
+import io.mosip.mimoto.service.DataProtectionService;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +34,7 @@ class WalletUtilTest {
     private WalletRepository walletRepository;
 
     @Mock
-    private EncryptionDecryptionUtil encryptionDecryptionUtil;
+    private DataProtectionService dataProtectionService;
 
     @InjectMocks
     private WalletUtil walletUtil;
@@ -68,7 +69,7 @@ class WalletUtilTest {
 
     @Test
     void shouldDecryptWalletKeySuccessfully() {
-        when(encryptionDecryptionUtil.decryptWithPin(encryptedWalletKey, pin)).thenReturn(decryptedWalletKey);
+        when(dataProtectionService.decryptWithPin(encryptedWalletKey, pin)).thenReturn(decryptedWalletKey);
 
         String decrypted = walletUtil.decryptWalletKey(encryptedWalletKey, pin);
 
@@ -77,7 +78,7 @@ class WalletUtilTest {
 
     @Test
     void shouldThrowErrorWhenDecryptionOfWalletKeyFails() {
-        when(encryptionDecryptionUtil.decryptWithPin(encryptedWalletKey, pin)).thenThrow(new RuntimeException("Failed to decrypt with PIN"));
+        when(dataProtectionService.decryptWithPin(encryptedWalletKey, pin)).thenThrow(new RuntimeException("Failed to decrypt with PIN"));
 
         InvalidRequestException ex = assertThrows(InvalidRequestException.class,
                 () -> walletUtil.decryptWalletKey(encryptedWalletKey, pin));
@@ -88,8 +89,8 @@ class WalletUtilTest {
 
     @Test
     void shouldCreateNewWalletSuccessfully() {
-        when(encryptionDecryptionUtil.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
-        when(encryptionDecryptionUtil.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
+        when(dataProtectionService.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
+        when(dataProtectionService.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
 
         String walletId = walletUtil.saveWallet(userId, name, pin, encryptionKey, encryptionAlgorithm, encryptionType);
 
@@ -98,8 +99,8 @@ class WalletUtilTest {
 
     @Test
     void shouldCreateEd25519WalletSuccessfully() {
-        when(encryptionDecryptionUtil.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
-        when(encryptionDecryptionUtil.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
+        when(dataProtectionService.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
+        when(dataProtectionService.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
 
         String walletId = walletUtil.createWallet(userId, name, pin);
 
@@ -108,8 +109,8 @@ class WalletUtilTest {
 
     @Test
     void shouldVerifyWalletObjectOnCreateNewWallet() {
-        when(encryptionDecryptionUtil.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
-        when(encryptionDecryptionUtil.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
+        when(dataProtectionService.encryptKeyWithPin(any(SecretKey.class), any(String.class))).thenReturn(encryptedWalletKey);
+        when(dataProtectionService.encryptWithAES(any(SecretKey.class), any(byte[].class))).thenReturn(encryptedPrivateKey);
 
         String walletId = walletUtil.saveWallet(userId, name, pin, encryptionKey, encryptionAlgorithm, encryptionType);
 

--- a/src/test/java/io/mosip/mimoto/util/WalletUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/WalletUtilTest.java
@@ -91,7 +91,7 @@ class WalletUtilTest {
         InvalidRequestException ex = assertThrows(InvalidRequestException.class,
                 () -> walletUtil.decryptWalletKey(encryptedWalletKey, pin));
         assertEquals("invalid_pin", ex.getErrorCode());
-        assertEquals("invalid_pin --> Invalid PIN or wallet key provided java.lang.RuntimeException: Failed to decrypt with PIN", ex.getMessage());
+        assertEquals("Failed to decrypt with PIN", ex.getCause().getMessage());
     }
 
 


### PR DESCRIPTION
renamed the files 
- CryptoCoreUtil to P12KeyStoreManager.
- CryptoUtil to  DerivedKeyCryptoUtil.

converted EncryptionDecryptionUtil to  DataProtectionService.

Replaced all the occurances of the old names with new ones

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized and renamed cryptography services, consolidated keystore/key-management components, and reduced publicly injected crypto dependencies for more consistent, secure encryption flows.

* **Tests**
  * Expanded unit test coverage across key management, keystore loading, symmetric/asymmetric crypto, PIN-based flows, and error/edge cases to improve reliability and resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->