### PR TITLE
[INJIWEB-1865] Modified the formatValue function

### DIFF
--- a/src/main/java/io/mosip/mimoto/constant/LdpVcV1Constants.java
+++ b/src/main/java/io/mosip/mimoto/constant/LdpVcV1Constants.java
@@ -1,0 +1,11 @@
+package io.mosip.mimoto.constant;
+
+/**
+ * Constants for LDP VC credentials with V1.1 context
+ */
+public class LdpVcV1Constants {
+    // Language Object and its properties
+    public static final String LANGUAGE = "lang";
+    public static final String VALUE = "value";
+    public static final String DIRECTION = "dir";
+}

--- a/src/main/java/io/mosip/mimoto/constant/LdpVcV1Constants.java
+++ b/src/main/java/io/mosip/mimoto/constant/LdpVcV1Constants.java
@@ -7,5 +7,4 @@ public class LdpVcV1Constants {
     // Language Object and its properties
     public static final String LANGUAGE = "lang";
     public static final String VALUE = "value";
-    public static final String DIRECTION = "dir";
 }

--- a/src/main/java/io/mosip/mimoto/constant/LdpVcV2Constants.java
+++ b/src/main/java/io/mosip/mimoto/constant/LdpVcV2Constants.java
@@ -7,7 +7,6 @@ public class LdpVcV2Constants {
     // Language Object and its properties
     public static final String LANGUAGE = "@language";
     public static final String VALUE = "@value";
-    public static final String DIRECTION = "@direction";
 
     // Credential context and URL
     public static final String CONTEXT = "@context";

--- a/src/main/java/io/mosip/mimoto/constant/LdpVcV2Constants.java
+++ b/src/main/java/io/mosip/mimoto/constant/LdpVcV2Constants.java
@@ -1,9 +1,13 @@
 package io.mosip.mimoto.constant;
 
 /**
- * Constants for LDP VC credentials with V2 context
+ * Constants for LDP VC credentials with V2.0 context
  */
 public class LdpVcV2Constants {
+    // Language Object and its properties
+    public static final String LANGUAGE = "@language";
+    public static final String VALUE = "@value";
+    public static final String DIRECTION = "@direction";
 
     // Credential context and URL
     public static final String CONTEXT = "@context";

--- a/src/main/java/io/mosip/mimoto/constant/SdJwtVcConstants.java
+++ b/src/main/java/io/mosip/mimoto/constant/SdJwtVcConstants.java
@@ -1,0 +1,10 @@
+package io.mosip.mimoto.constant;
+
+/**
+ * Constants for Sd-Jwt credentials
+ */
+public class SdJwtVcConstants {
+    // Language Object and its properties (custom implementation for SD-JWT VCs)
+    public static final String LANGUAGE = "language";
+    public static final String VALUE = "value";
+}

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -16,6 +16,7 @@ import com.itextpdf.kernel.pdf.PdfWriter;
 import com.nimbusds.jose.util.Base64URL;
 import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.CredentialFormat;
+import io.mosip.mimoto.constant.LdpVcV1Constants;
 import io.mosip.mimoto.constant.LdpVcV2Constants;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerDisplayResponse;
@@ -241,7 +242,9 @@ public class CredentialPDFGeneratorService {
 
     private String formatValue(Object val, String locale) {
         if (val instanceof Map) {
-            return Optional.ofNullable(((Map<?, ?>) val).get("value")).map(Object::toString).orElse("");
+            return Optional.ofNullable(((Map<?, Object>) val).getOrDefault(LdpVcV2Constants.VALUE, ((Map<?, Object>) val).get(LdpVcV1Constants.VALUE)))
+                    .map(Object::toString)
+                    .orElse("");
         } else if (val instanceof List) {
             List<?> list = (List<?>) val;
             if (list.isEmpty()) return "";
@@ -252,11 +255,11 @@ public class CredentialPDFGeneratorService {
                         .filter(Objects::nonNull)
                         .map(item -> (Map<?, ?>) item)
                         .filter(m -> {
-                            Object lang = m.getOrDefault("@language", m.get("lang"));  // Safely get language
+                            Object lang = m.getOrDefault(LdpVcV2Constants.LANGUAGE, m.get(LdpVcV1Constants.LANGUAGE));  // Safely get language
                             return lang != null && LocaleUtils.matchesLocale(lang.toString(), locale);
                         })
                         .map(m -> {
-                            Object value = m.getOrDefault("@value", m.get("value")); // Safely get value
+                            Object value = m.getOrDefault(LdpVcV2Constants.VALUE, m.get(LdpVcV1Constants.VALUE)); // Safely get value
                             return value != null ? value.toString() : null;
                         })
                         .filter(Objects::nonNull)

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -18,6 +18,7 @@ import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.constant.LdpVcV1Constants;
 import io.mosip.mimoto.constant.LdpVcV2Constants;
+import io.mosip.mimoto.constant.SdJwtVcConstants;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerDisplayResponse;
 import io.mosip.mimoto.dto.mimoto.CredentialSupportedDisplayResponse;
@@ -47,6 +48,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -242,7 +244,13 @@ public class CredentialPDFGeneratorService {
 
     private String formatValue(Object val, String locale) {
         if (val instanceof Map) {
-            return Optional.ofNullable(((Map<?, Object>) val).getOrDefault(LdpVcV2Constants.VALUE, ((Map<?, Object>) val).get(LdpVcV1Constants.VALUE)))
+            return Optional.ofNullable(Stream.of(
+                                    ((Map<?, ?>) val).get(LdpVcV2Constants.VALUE),
+                                    ((Map<?, ?>) val).get(LdpVcV1Constants.VALUE),
+                                    ((Map<?, ?>) val).get(SdJwtVcConstants.VALUE)
+                            ).filter(Objects::nonNull)
+                            .findFirst()
+                            .orElse(null))
                     .map(Object::toString)
                     .orElse("");
         } else if (val instanceof List) {
@@ -255,11 +263,25 @@ public class CredentialPDFGeneratorService {
                         .filter(Objects::nonNull)
                         .map(item -> (Map<?, ?>) item)
                         .filter(m -> {
-                            Object lang = m.getOrDefault(LdpVcV2Constants.LANGUAGE, m.get(LdpVcV1Constants.LANGUAGE));  // Safely get language
+                            Object lang = Stream.of(
+                                            m.get(LdpVcV2Constants.LANGUAGE),
+                                            m.get(LdpVcV1Constants.LANGUAGE),
+                                            m.get(SdJwtVcConstants.LANGUAGE)
+                                    ).filter(Objects::nonNull)
+                                    .findFirst()
+                                    .orElse(null);
+
                             return lang != null && LocaleUtils.matchesLocale(lang.toString(), locale);
                         })
                         .map(m -> {
-                            Object value = m.getOrDefault(LdpVcV2Constants.VALUE, m.get(LdpVcV1Constants.VALUE)); // Safely get value
+                            Object value = Stream.of(
+                                            m.get(LdpVcV2Constants.VALUE),
+                                            m.get(LdpVcV1Constants.VALUE),
+                                            m.get(SdJwtVcConstants.VALUE)
+                                    ).filter(Objects::nonNull)
+                                    .findFirst()
+                                    .orElse(null);
+
                             return value != null ? value.toString() : null;
                         })
                         .filter(Objects::nonNull)

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -252,11 +252,11 @@ public class CredentialPDFGeneratorService {
                         .filter(Objects::nonNull)
                         .map(item -> (Map<?, ?>) item)
                         .filter(m -> {
-                            Object lang = m.get("language");  // Safely get language
+                            Object lang = m.getOrDefault("@language", m.get("lang"));  // Safely get language
                             return lang != null && LocaleUtils.matchesLocale(lang.toString(), locale);
                         })
                         .map(m -> {
-                            Object value = m.get("value");  // Safely get value
+                            Object value = m.getOrDefault("@value", m.get("value")); // Safely get value
                             return value != null ? value.toString() : null;
                         })
                         .filter(Objects::nonNull)

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -339,8 +339,8 @@ class CredentialPDFGeneratorServiceTest {
         // Setup credential with locale-specific map list
         Map<String, Object> subjectWithLocaleMap = new HashMap<>();
         List<Map<String, Object>> localeData = List.of(
-                Map.of("@language", "en", "@value", "English Name"),
-                Map.of("@language", "fr", "@value", "French Name")
+                Map.of(LdpVcV2Constants.LANGUAGE, "en", LdpVcV2Constants.VALUE, "English Name"),
+                Map.of(LdpVcV2Constants.LANGUAGE, "fr", LdpVcV2Constants.VALUE, "French Name")
         );
         subjectWithLocaleMap.put("localizedName", localeData);
         ((VCCredentialProperties)vcCredentialResponse.getCredential()).setCredentialSubject(subjectWithLocaleMap);
@@ -821,8 +821,8 @@ class CredentialPDFGeneratorServiceTest {
 
         // Setup credential with locale-specific list
         List<Map<String, Object>> localeData = List.of(
-                Map.of("@language", "en", "@value", "English Name"),
-                Map.of("@language", "fr", "@value", "French Name")
+                Map.of(LdpVcV2Constants.LANGUAGE, "en", LdpVcV2Constants.VALUE, "English Name"),
+                Map.of(LdpVcV2Constants.LANGUAGE, "fr", LdpVcV2Constants.VALUE, "French Name")
         );
         Map<String, Object> subject = Map.of("name", localeData);
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(subject);

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -5,6 +5,8 @@ import com.authlete.sd.Disclosure;
 import com.authlete.sd.SDJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.injivcrenderer.InjiVcRenderer;
+import io.mosip.mimoto.constant.LdpVcV1Constants;
+import io.mosip.mimoto.constant.LdpVcV2Constants;
 import io.mosip.mimoto.dto.BackgroundImageDTO;
 import io.mosip.mimoto.dto.DisplayDTO;
 import io.mosip.mimoto.dto.IssuerDTO;
@@ -896,22 +898,50 @@ class CredentialPDFGeneratorServiceTest {
     }
 
     @Test
+    void testFormatValueWithMap_AtValue() throws Exception {
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
+        formatValueMethod.setAccessible(true);
+
+        Map<String, Object> value = new HashMap<>();
+        value.put(LdpVcV2Constants.VALUE, "Green Valley Farm");
+
+        String result = (String) formatValueMethod.invoke(service, value, "en");
+
+        assertEquals("Green Valley Farm", result);
+    }
+
+    @Test
+    void testFormatValueWithMap_Value() throws Exception {
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
+        formatValueMethod.setAccessible(true);
+
+        Map<String, Object> value = new HashMap<>();
+        value.put(LdpVcV1Constants.VALUE, "Green Valley Farm");
+
+        String result = (String) formatValueMethod.invoke(service, value, "en");
+
+        assertEquals("Green Valley Farm", result);
+    }
+
+    @Test
     void testFormatValueWithListOfMaps_LanguageAndValue() throws Exception {
         CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
         Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
         formatValueMethod.setAccessible(true);
 
         Map<String, String> mapEn = new HashMap<>();
-        mapEn.put("@value", "Green Valley Farm");
-        mapEn.put("@language", "en");
+        mapEn.put(LdpVcV2Constants.VALUE, "Green Valley Farm");
+        mapEn.put(LdpVcV2Constants.LANGUAGE, "en");
 
         Map<String, String> mapFr = new HashMap<>();
-        mapFr.put("@value", "Ferme Vallée Verte");
-        mapFr.put("@language", "fr");
+        mapFr.put(LdpVcV2Constants.VALUE, "Ferme Vallée Verte");
+        mapFr.put(LdpVcV2Constants.LANGUAGE, "fr");
 
         Map<String, String> mapFil = new HashMap<>();
-        mapFil.put("@value", "Bukid sa Luntiang Lambak");
-        mapFil.put("@language", "fil");
+        mapFil.put(LdpVcV2Constants.VALUE, "Bukid sa Luntiang Lambak");
+        mapFil.put(LdpVcV2Constants.LANGUAGE, "fil");
 
         List<Map<String, String>> value = Arrays.asList(mapEn, mapFr, mapFil);
 
@@ -935,16 +965,16 @@ class CredentialPDFGeneratorServiceTest {
         formatValueMethod.setAccessible(true);
 
         Map<String, String> mapEn = new HashMap<>();
-        mapEn.put("value", "Green Valley Farm");
-        mapEn.put("lang", "en");
+        mapEn.put(LdpVcV1Constants.VALUE, "Green Valley Farm");
+        mapEn.put(LdpVcV1Constants.LANGUAGE, "en");
 
         Map<String, String> mapFr = new HashMap<>();
-        mapFr.put("value", "Ferme Vallée Verte");
-        mapFr.put("lang", "fr");
+        mapFr.put(LdpVcV1Constants.VALUE, "Ferme Vallée Verte");
+        mapFr.put(LdpVcV1Constants.LANGUAGE, "fr");
 
         Map<String, String> mapFil = new HashMap<>();
-        mapFil.put("value", "Bukid sa Luntiang Lambak");
-        mapFil.put("lang", "fil");
+        mapFil.put(LdpVcV1Constants.VALUE, "Bukid sa Luntiang Lambak");
+        mapFil.put(LdpVcV1Constants.LANGUAGE, "fil");
 
         List<Map<String, String>> value = Arrays.asList(mapEn, mapFr, mapFil);
 

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayInputStream;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -892,6 +893,72 @@ class CredentialPDFGeneratorServiceTest {
                 "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse, "", "", "en");
 
         assertNotNull(result);  // Verifies formatValue converted 25 to "25"
+    }
+
+    @Test
+    void testFormatValueWithListOfMaps_LanguageAndValue() throws Exception {
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
+        formatValueMethod.setAccessible(true);
+
+        Map<String, String> mapEn = new HashMap<>();
+        mapEn.put("@value", "Green Valley Farm");
+        mapEn.put("@language", "en");
+
+        Map<String, String> mapFr = new HashMap<>();
+        mapFr.put("@value", "Ferme Vallée Verte");
+        mapFr.put("@language", "fr");
+
+        Map<String, String> mapFil = new HashMap<>();
+        mapFil.put("@value", "Bukid sa Luntiang Lambak");
+        mapFil.put("@language", "fil");
+
+        List<Map<String, String>> value = Arrays.asList(mapEn, mapFr, mapFil);
+
+        String resultEn = (String) formatValueMethod.invoke(service, value, "en");
+        String resultFr = (String) formatValueMethod.invoke(service, value, "fr");
+        String resultFil = (String) formatValueMethod.invoke(service, value, "fil");
+        String resultNoMatchingLang = (String) formatValueMethod.invoke(service, value, "hi"); // matching language not present, should return empty string
+        String resultNullLang = (String) formatValueMethod.invoke(service, value, null); // null language, should return empty string
+
+        assertEquals("Green Valley Farm", resultEn);
+        assertEquals("Ferme Vallée Verte", resultFr);
+        assertEquals("Bukid sa Luntiang Lambak", resultFil);
+        assertEquals("", resultNoMatchingLang);
+        assertEquals("", resultNullLang);
+    }
+
+    @Test
+    void testFormatValueWithListOfMaps_langAndValue() throws Exception {
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
+        formatValueMethod.setAccessible(true);
+
+        Map<String, String> mapEn = new HashMap<>();
+        mapEn.put("value", "Green Valley Farm");
+        mapEn.put("lang", "en");
+
+        Map<String, String> mapFr = new HashMap<>();
+        mapFr.put("value", "Ferme Vallée Verte");
+        mapFr.put("lang", "fr");
+
+        Map<String, String> mapFil = new HashMap<>();
+        mapFil.put("value", "Bukid sa Luntiang Lambak");
+        mapFil.put("lang", "fil");
+
+        List<Map<String, String>> value = Arrays.asList(mapEn, mapFr, mapFil);
+
+        String resultEn = (String) formatValueMethod.invoke(service, value, "en");
+        String resultFr = (String) formatValueMethod.invoke(service, value, "fr");
+        String resultFil = (String) formatValueMethod.invoke(service, value, "fil");
+        String resultNoMatchingLang = (String) formatValueMethod.invoke(service, value, "hi"); // matching language not present, should return empty string
+        String resultNullLang = (String) formatValueMethod.invoke(service, value, null); // null language, should return empty string
+
+        assertEquals("Green Valley Farm", resultEn);
+        assertEquals("Ferme Vallée Verte", resultFr);
+        assertEquals("Bukid sa Luntiang Lambak", resultFil);
+        assertEquals("", resultNoMatchingLang);
+        assertEquals("", resultNullLang);
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.LdpVcV1Constants;
 import io.mosip.mimoto.constant.LdpVcV2Constants;
+import io.mosip.mimoto.constant.SdJwtVcConstants;
 import io.mosip.mimoto.dto.BackgroundImageDTO;
 import io.mosip.mimoto.dto.DisplayDTO;
 import io.mosip.mimoto.dto.IssuerDTO;
@@ -926,7 +927,7 @@ class CredentialPDFGeneratorServiceTest {
     }
 
     @Test
-    void testFormatValueWithListOfMaps_LanguageAndValue() throws Exception {
+    void testFormatValueWithListOfMaps_AtLanguageAndAtValue() throws Exception {
         CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
         Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
         formatValueMethod.setAccessible(true);
@@ -942,6 +943,39 @@ class CredentialPDFGeneratorServiceTest {
         Map<String, String> mapFil = new HashMap<>();
         mapFil.put(LdpVcV2Constants.VALUE, "Bukid sa Luntiang Lambak");
         mapFil.put(LdpVcV2Constants.LANGUAGE, "fil");
+
+        List<Map<String, String>> value = Arrays.asList(mapEn, mapFr, mapFil);
+
+        String resultEn = (String) formatValueMethod.invoke(service, value, "en");
+        String resultFr = (String) formatValueMethod.invoke(service, value, "fr");
+        String resultFil = (String) formatValueMethod.invoke(service, value, "fil");
+        String resultNoMatchingLang = (String) formatValueMethod.invoke(service, value, "hi"); // matching language not present, should return empty string
+        String resultNullLang = (String) formatValueMethod.invoke(service, value, null); // null language, should return empty string
+
+        assertEquals("Green Valley Farm", resultEn);
+        assertEquals("Ferme Vallée Verte", resultFr);
+        assertEquals("Bukid sa Luntiang Lambak", resultFil);
+        assertEquals("", resultNoMatchingLang);
+        assertEquals("", resultNullLang);
+    }
+
+    @Test
+    void testFormatValueWithListOfMaps_LanguageAndValue() throws Exception {
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
+        formatValueMethod.setAccessible(true);
+
+        Map<String, String> mapEn = new HashMap<>();
+        mapEn.put(SdJwtVcConstants.VALUE, "Green Valley Farm");
+        mapEn.put(SdJwtVcConstants.LANGUAGE, "en");
+
+        Map<String, String> mapFr = new HashMap<>();
+        mapFr.put(SdJwtVcConstants.VALUE, "Ferme Vallée Verte");
+        mapFr.put(SdJwtVcConstants.LANGUAGE, "fr");
+
+        Map<String, String> mapFil = new HashMap<>();
+        mapFil.put(SdJwtVcConstants.VALUE, "Bukid sa Luntiang Lambak");
+        mapFil.put(SdJwtVcConstants.LANGUAGE, "fil");
 
         List<Map<String, String>> value = Arrays.asList(mapEn, mapFr, mapFil);
 

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -337,8 +337,8 @@ class CredentialPDFGeneratorServiceTest {
         // Setup credential with locale-specific map list
         Map<String, Object> subjectWithLocaleMap = new HashMap<>();
         List<Map<String, Object>> localeData = List.of(
-                Map.of("language", "en", "value", "English Name"),
-                Map.of("language", "fr", "value", "French Name")
+                Map.of("@language", "en", "@value", "English Name"),
+                Map.of("@language", "fr", "@value", "French Name")
         );
         subjectWithLocaleMap.put("localizedName", localeData);
         ((VCCredentialProperties)vcCredentialResponse.getCredential()).setCredentialSubject(subjectWithLocaleMap);
@@ -819,8 +819,8 @@ class CredentialPDFGeneratorServiceTest {
 
         // Setup credential with locale-specific list
         List<Map<String, Object>> localeData = List.of(
-                Map.of("language", "en", "value", "English Name"),
-                Map.of("language", "fr", "value", "French Name")
+                Map.of("@language", "en", "@value", "English Name"),
+                Map.of("@language", "fr", "@value", "French Name")
         );
         Map<String, Object> subject = Map.of("name", localeData);
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(subject);


### PR DESCRIPTION
 Modified the formatValue function to enable Multilang support
 Added the test cases for the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential PDF generation now reliably recognizes multiple language/value field variants and falls back between formats, improving localization and compatibility with varied credential inputs.
* **Tests**
  * Expanded unit tests covering many language/value key variants, list/map formatting scenarios, locale-specific selection, and handling of missing or unmatched language entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->