### PR TITLE
[INJIWEB-1861] Fixing SonarCloud reliability issues in mimoto 

### DIFF
--- a/docker-compose/config/credential-template.html
+++ b/docker-compose/config/credential-template.html
@@ -41,7 +41,7 @@
                     $nestedEntry.key
                 </div>  <!-- Use nested entry key as label -->
                 #if($nestedEntry.value.startsWith("data:image/"))
-                <img src="$nestedEntry.value" alt="Embedded Image"
+                <img src="$nestedEntry.value" alt="$nestedEntry.key"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 #else
                 <div style="font-family: 'Inter', sans-serif; font-weight: 600; font-size: 18px; word-wrap: break-word;">
@@ -58,7 +58,7 @@
                     $entry.key
                 </div> <!-- Outer key -->
                 #if($entry.value.startsWith("data:image/"))
-                <img src="$entry.value" alt="Embedded Image"
+                <img src="$entry.value" alt="$entry.key"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 <!-- Outer value -->
                 #else

--- a/docker-compose/config/credential-template.html
+++ b/docker-compose/config/credential-template.html
@@ -41,7 +41,7 @@
                     $nestedEntry.key
                 </div>  <!-- Use nested entry key as label -->
                 #if($nestedEntry.value.startsWith("data:image/"))
-                <img src="$nestedEntry.value" alt="$nestedEntry.key"
+                <img src="$nestedEntry.value" alt="Embedded Visual"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 #else
                 <div style="font-family: 'Inter', sans-serif; font-weight: 600; font-size: 18px; word-wrap: break-word;">
@@ -58,7 +58,7 @@
                     $entry.key
                 </div> <!-- Outer key -->
                 #if($entry.value.startsWith("data:image/"))
-                <img src="$entry.value" alt="$entry.key"
+                <img src="$entry.value" alt="Embedded Visual"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 <!-- Outer value -->
                 #else

--- a/src/main/java/io/mosip/mimoto/controller/AttestationServiceController.java
+++ b/src/main/java/io/mosip/mimoto/controller/AttestationServiceController.java
@@ -7,7 +7,6 @@ import io.mosip.mimoto.util.AttestationOfflineVerify;
 import io.mosip.mimoto.util.AttestationOnlineVerify;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/io/mosip/mimoto/controller/CommonInjiController.java
+++ b/src/main/java/io/mosip/mimoto/controller/CommonInjiController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/io/mosip/mimoto/controller/CredentialsController.java
+++ b/src/main/java/io/mosip/mimoto/controller/CredentialsController.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -39,11 +38,14 @@ import static io.mosip.mimoto.exception.PlatformErrorMessages.MIMOTO_PDF_SIGN_EX
 @Tag(name = SwaggerLiteralConstants.CREDENTIALS_NAME, description = SwaggerLiteralConstants.CREDENTIALS_DESCRIPTION)
 public class CredentialsController {
 
-    @Autowired
-    CredentialService credentialService;
+    private final CredentialService credentialService;
 
-    @Autowired
-    IdpService idpService;
+    private final IdpService idpService;
+
+    public CredentialsController(CredentialService credentialService, IdpService idpService) {
+        this.credentialService = credentialService;
+        this.idpService = idpService;
+    }
 
     @Operation(summary = SwaggerLiteralConstants.CREDENTIALS_DOWNLOAD_VC_SUMMARY, description = SwaggerLiteralConstants.CREDENTIALS_DOWNLOAD_VC_DESCRIPTION)
     @ApiResponses({

--- a/src/main/java/io/mosip/mimoto/controller/IdpController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IdpController.java
@@ -1,6 +1,5 @@
 package io.mosip.mimoto.controller;
 
-import io.mosip.kernel.core.util.JsonUtils;
 import io.mosip.mimoto.constant.ApiName;
 import io.mosip.mimoto.constant.SwaggerLiteralConstants;
 import io.mosip.mimoto.core.http.ResponseWrapper;
@@ -21,7 +20,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -38,17 +36,20 @@ import java.util.Map;
 public class IdpController {
     private static final boolean USE_BEARER_TOKEN = true;
 
-    @Autowired
-    private RestClientService<Object> restClientService;
+    private final RestClientService<Object> restClientService;
 
-    @Autowired
-    private JoseUtil joseUtil;
+    private final JoseUtil joseUtil;
 
-    @Autowired
-    IdpService idpService;
+    private final IdpService idpService;
 
-    @Autowired
-    RequestValidator requestValidator;
+    private final RequestValidator requestValidator;
+
+    public IdpController(RestClientService<Object> restClientService, JoseUtil joseUtil, IdpService idpService, RequestValidator requestValidator) {
+        this.restClientService = restClientService;
+        this.joseUtil = joseUtil;
+        this.idpService = idpService;
+        this.requestValidator = requestValidator;
+    }
 
     @Operation(summary = SwaggerLiteralConstants.IDP_BINDING_OTP_SUMMARY, description = SwaggerLiteralConstants.IDP_BINDING_OTP_DESCRIPTION)
     @PostMapping(value = "/binding-otp", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/io/mosip/mimoto/controller/IssuersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/IssuersController.java
@@ -13,7 +13,6 @@ import io.mosip.mimoto.util.Utilities;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -32,8 +31,11 @@ import static io.mosip.mimoto.exception.PlatformErrorMessages.*;
 @Tag(name = SwaggerLiteralConstants.ISSUERS_NAME, description = SwaggerLiteralConstants.ISSUERS_DESCRIPTION)
 public class IssuersController {
 
-    @Autowired
-    IssuersService issuersService;
+    private final IssuersService issuersService;
+
+    public IssuersController(IssuersService issuersService) {
+        this.issuersService = issuersService;
+    }
 
     @Operation(summary = SwaggerLiteralConstants.ISSUERS_GET_ISSUERS_SUMMARY, description = SwaggerLiteralConstants.ISSUERS_GET_ISSUERS_DESCRIPTION)
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/io/mosip/mimoto/controller/PresentationController.java
+++ b/src/main/java/io/mosip/mimoto/controller/PresentationController.java
@@ -18,9 +18,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -36,8 +33,7 @@ import java.util.Arrays;
 @Tag(name = SwaggerLiteralConstants.PRESENTATION_NAME, description = SwaggerLiteralConstants.PRESENTATION_DESCRIPTION)
 public class PresentationController {
 
-    @Autowired
-    PresentationService presentationService;
+    private final PresentationService presentationService;
 
     @Value("${mosip.inji.ovp.error.redirect.url.pattern}")
     String injiOvpErrorRedirectUrlPattern;
@@ -45,11 +41,15 @@ public class PresentationController {
     @Value("${mosip.inji.web.redirect.url}")
     String injiWebRedirectUrl;
 
-    @Autowired
-    VerifierService verifierService;
+    private final VerifierService verifierService;
 
-    @Autowired
-    ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+
+    public PresentationController(PresentationService presentationService, VerifierService verifierService, ObjectMapper objectMapper) {
+        this.presentationService = presentationService;
+        this.verifierService = verifierService;
+        this.objectMapper = objectMapper;
+    }
 
     @Operation( summary = SwaggerLiteralConstants.PRESENTATION_AUTHORIZE_SUMMARY, description = SwaggerLiteralConstants.PRESENTATION_AUTHORIZE_DESCRIPTION)
     @ApiResponses({ @ApiResponse(responseCode = "302", content = { @Content(mediaType = "application/text") }) })

--- a/src/main/java/io/mosip/mimoto/controller/ResidentServiceController.java
+++ b/src/main/java/io/mosip/mimoto/controller/ResidentServiceController.java
@@ -26,11 +26,11 @@ import jakarta.validation.Valid;
 @Tag(name = SwaggerLiteralConstants.RESIDENT_NAME, description = SwaggerLiteralConstants.RESIDENT_DESCRIPTION)
 public class ResidentServiceController {
 
-    public final RestClientService<Object> restClientService;
+    private final RestClientService<Object> restClientService;
 
     private final RequestValidator requestValidator;
 
-    private  final Environment env;
+    private final Environment env;
 
     public ResidentServiceController(RestClientService<Object> restClientService, RequestValidator requestValidator, Environment env) {
         this.restClientService = restClientService;

--- a/src/main/java/io/mosip/mimoto/controller/ResidentServiceController.java
+++ b/src/main/java/io/mosip/mimoto/controller/ResidentServiceController.java
@@ -11,7 +11,6 @@ import io.mosip.mimoto.util.DateUtils;
 import io.mosip.mimoto.util.RequestValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,14 +26,17 @@ import jakarta.validation.Valid;
 @Tag(name = SwaggerLiteralConstants.RESIDENT_NAME, description = SwaggerLiteralConstants.RESIDENT_DESCRIPTION)
 public class ResidentServiceController {
 
-    @Autowired
-    public RestClientService<Object> restClientService;
+    public final RestClientService<Object> restClientService;
 
-    @Autowired
-    RequestValidator requestValidator;
+    private final RequestValidator requestValidator;
 
-    @Autowired
-    Environment env;
+    private  final Environment env;
+
+    public ResidentServiceController(RestClientService<Object> restClientService, RequestValidator requestValidator, Environment env) {
+        this.restClientService = restClientService;
+        this.requestValidator = requestValidator;
+        this.env = env;
+    }
 
     /**
      * Request a new OTP for OTP required API.

--- a/src/main/java/io/mosip/mimoto/controller/UsersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/UsersController.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -35,11 +34,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/users/me")
 @Tag(name = SwaggerLiteralConstants.USERS_NAME, description = SwaggerLiteralConstants.USERS_DESCRIPTION)
 public class UsersController {
-    @Autowired
-    private UserMetadataRepository userMetadataRepository;
+    private final UserMetadataRepository userMetadataRepository;
 
-    @Autowired
-    private EncryptionService encryptionService;
+    private final EncryptionService encryptionService;
+
+    public UsersController(UserMetadataRepository userMetadataRepository, EncryptionService encryptionService) {
+        this.userMetadataRepository = userMetadataRepository;
+        this.encryptionService = encryptionService;
+    }
 
     /**
      * Retrieves user profile information, first checking the cache and then the database if needed

--- a/src/main/java/io/mosip/mimoto/controller/VerifiersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/VerifiersController.java
@@ -8,7 +8,6 @@ import io.mosip.mimoto.service.VerifierService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -26,8 +25,11 @@ import java.util.Collections;
 @Tag(name = SwaggerLiteralConstants.VERIFIERS_NAME, description = SwaggerLiteralConstants.VERIFIERS_DESCRIPTION)
 public class VerifiersController {
 
-    @Autowired
-    VerifierService verifierService;
+    private final VerifierService verifierService;
+
+    public VerifiersController(VerifierService verifierService) {
+        this.verifierService = verifierService;
+    }
 
     @Operation(summary = SwaggerLiteralConstants.VERIFIERS_GET_VERIFIERS_SUMMARY, description = SwaggerLiteralConstants.VERIFIERS_GET_VERIFIERS_DESCRIPTION)
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/io/mosip/mimoto/controller/WalletPresentationsController.java
+++ b/src/main/java/io/mosip/mimoto/controller/WalletPresentationsController.java
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -45,11 +44,14 @@ import static io.mosip.mimoto.exception.ErrorConstants.*;
 @RequestMapping("/wallets/{walletId}/presentations")
 public class WalletPresentationsController {
 
-    @Autowired
-    private WalletPresentationService walletPresentationService;
+    private final WalletPresentationService walletPresentationService;
 
-    @Autowired
-    private SessionManager sessionManager;
+    private final SessionManager sessionManager;
+
+    public WalletPresentationsController(WalletPresentationService walletPresentationService, SessionManager sessionManager) {
+        this.walletPresentationService = walletPresentationService;
+        this.sessionManager = sessionManager;
+    }
 
     /**
      * Processes the Verifiable Presentation Authorization Request for a specific wallet.

--- a/src/main/java/io/mosip/mimoto/controller/WalletTrustedVerifiersController.java
+++ b/src/main/java/io/mosip/mimoto/controller/WalletTrustedVerifiersController.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -32,8 +31,11 @@ import static io.mosip.mimoto.exception.ErrorConstants.ERROR_ADDING_TRUSTED_VERI
 @RequestMapping("/wallets/{walletId}/trusted-verifiers")
 public class WalletTrustedVerifiersController {
 
-    @Autowired
-    TrustedVerifierService trustedVerifierService;
+    private final TrustedVerifierService trustedVerifierService;
+
+    public WalletTrustedVerifiersController(TrustedVerifierService trustedVerifierService) {
+        this.trustedVerifierService = trustedVerifierService;
+    }
 
     /**
      * Adds a trusted verifier for the specified wallet.

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -35,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.Velocity;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -56,26 +55,29 @@ public class CredentialPDFGeneratorService {
 
     private record SelectedFace(String key, String face) {}
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private PresentationServiceImpl presentationService;
+    private final PresentationServiceImpl presentationService;
 
-    @Autowired
-    private Utilities utilities;
+    private final Utilities utilities;
 
-    @Autowired
-    private PixelPass pixelPass;
+    private final PixelPass pixelPass;
 
-    @Autowired
-    private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
+    private final CredentialFormatHandlerFactory credentialFormatHandlerFactory;
 
-    @Autowired
-    private InjiVcRenderer injiVcRenderer;
+    private final InjiVcRenderer injiVcRenderer;
 
-    @Autowired
-    private SvgFixerUtil svgFixerUtil;
+    private final SvgFixerUtil svgFixerUtil;
+
+    public CredentialPDFGeneratorService(ObjectMapper objectMapper, PresentationServiceImpl presentationService, Utilities utilities, PixelPass pixelPass, CredentialFormatHandlerFactory credentialFormatHandlerFactory, InjiVcRenderer injiVcRenderer, SvgFixerUtil svgFixerUtil) {
+        this.objectMapper = objectMapper;
+        this.presentationService = presentationService;
+        this.utilities = utilities;
+        this.pixelPass = pixelPass;
+        this.credentialFormatHandlerFactory = credentialFormatHandlerFactory;
+        this.injiVcRenderer = injiVcRenderer;
+        this.svgFixerUtil = svgFixerUtil;
+    }
 
     @Value("${mosip.inji.ovp.qrdata.pattern}")
     private String ovpQRDataPattern;

--- a/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
+++ b/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
@@ -33,8 +33,8 @@ import static io.mosip.mimoto.exception.ErrorConstants.ENCRYPTION_FAILED;
 public class DataProtectionService {
     private static final String AES_ALGORITHM = "AES/GCM/NoPadding";
     private static final int NONCE_LENGTH = 12; // Recommended nonce length for GCM
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final int TAG_LENGTH = 128; // Authentication tag length in bits (16 bytes)
-    public static final String USER_PII_KEY_REFERENCE_ID = "user_pii";
 
     private final CryptomanagerService cryptomanagerService;
 
@@ -121,8 +121,7 @@ public class DataProtectionService {
         try {
             // Generate a random nonce
             byte[] nonce = new byte[NONCE_LENGTH];
-            SecureRandom secureRandom = new SecureRandom();
-            secureRandom.nextBytes(nonce);
+            SECURE_RANDOM.nextBytes(nonce);
             GCMParameterSpec gcmSpec = new GCMParameterSpec(TAG_LENGTH, nonce);
 
             // Initialize cipher

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
@@ -22,7 +22,6 @@ import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.service.WalletCredentialService;
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.*;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -36,21 +35,23 @@ import java.util.stream.Stream;
 public class CredentialMatchingServiceImpl implements CredentialMatchingService {
 
     private static final String JSON_PATH_PREFIX = "$.";
-    private static final String TYPE_PATH = "$.type";
     private static final String LDP_VC_FORMAT = "ldp_vc";
     private static final String PROOF_TYPE_KEY = "proof_type";
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private IssuersService issuersService;
+    private final IssuersService issuersService;
 
-    @Autowired
-    private OpenID4VPService openID4VPService;
+    private final OpenID4VPService openID4VPService;
 
-    @Autowired
-    private WalletCredentialService walletCredentialService;
+    private final WalletCredentialService walletCredentialService;
+
+    public CredentialMatchingServiceImpl(ObjectMapper objectMapper, IssuersService issuersService, OpenID4VPService openID4VPService, WalletCredentialService walletCredentialService) {
+        this.objectMapper = objectMapper;
+        this.issuersService = issuersService;
+        this.openID4VPService = openID4VPService;
+        this.walletCredentialService = walletCredentialService;
+    }
 
     @Override
     public MatchingCredentialsDTO getMatchingCredentials(VerifiablePresentationSessionData sessionData, String walletId, String base64Key) throws ApiNotAccessibleException, IOException {

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialRequestServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialRequestServiceImpl.java
@@ -9,7 +9,6 @@ import io.mosip.mimoto.service.CredentialRequestService;
 import io.mosip.mimoto.service.KeyPairRetrievalService;
 import io.mosip.mimoto.util.SigningKeyUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -27,17 +26,20 @@ public class CredentialRequestServiceImpl implements CredentialRequestService {
 
     private static final SigningAlgorithm FALLBACK_SIGNING_ALG = SigningAlgorithm.ED25519;
 
+    public CredentialRequestServiceImpl(CredentialFormatHandlerFactory credentialFormatHandlerFactory, KeyPairRetrievalService keyPairService) {
+        this.credentialFormatHandlerFactory = credentialFormatHandlerFactory;
+        this.keyPairService = keyPairService;
+    }
+
     public Set<String> getSigningAlgorithmsPriorityOrder() {
         return Arrays.stream(signingAlgorithmsPriorityOrder.split(","))
                 .map(String::trim).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
 
-    @Autowired
-    private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
+    private final CredentialFormatHandlerFactory credentialFormatHandlerFactory;
 
-    @Autowired
-    private KeyPairRetrievalService keyPairService;
+    private final KeyPairRetrievalService keyPairService;
 
     @Override
     public VCCredentialRequest buildRequest(IssuerDTO issuerDTO,

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialRequestServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialRequestServiceImpl.java
@@ -20,11 +20,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public class CredentialRequestServiceImpl implements CredentialRequestService {
 
-
     @Value("${signing.algorithms.priority.order:ED25519,ES256K,ES256,RS256}")
     private String signingAlgorithmsPriorityOrder;
 
     private static final SigningAlgorithm FALLBACK_SIGNING_ALG = SigningAlgorithm.ED25519;
+
+    private final CredentialFormatHandlerFactory credentialFormatHandlerFactory;
+
+    private final KeyPairRetrievalService keyPairService;
 
     public CredentialRequestServiceImpl(CredentialFormatHandlerFactory credentialFormatHandlerFactory, KeyPairRetrievalService keyPairService) {
         this.credentialFormatHandlerFactory = credentialFormatHandlerFactory;
@@ -35,11 +38,6 @@ public class CredentialRequestServiceImpl implements CredentialRequestService {
         return Arrays.stream(signingAlgorithmsPriorityOrder.split(","))
                 .map(String::trim).collect(Collectors.toCollection(LinkedHashSet::new));
     }
-
-
-    private final CredentialFormatHandlerFactory credentialFormatHandlerFactory;
-
-    private final KeyPairRetrievalService keyPairService;
 
     @Override
     public VCCredentialRequest buildRequest(IssuerDTO issuerDTO,

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialShareServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialShareServiceImpl.java
@@ -21,7 +21,6 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
@@ -51,62 +50,62 @@ public class CredentialShareServiceImpl implements CredentialShareService {
     public static final String CARD_JSON_FILE_NAME = "%s_VCD.json";
 
     /** The Constant FINGER. */
-    public static final String FINGER = "Finger";
     public static final String DATA_IMAGE_JPG_BASE_64 = "data:image/jpg;base64,";
     public static final String DATA_BINARY_BASE_64 = "data:binary;base64,";
 
     private Gson gson = new Gson();
 
-    public String topic = "CREDENTIAL_STATUS_UPDATE";
+    private final WebSubSubscriptionHelper webSubSubscriptionHelper;
 
-    @Autowired
-    public WebSubSubscriptionHelper webSubSubscriptionHelper;
+    private final DataShareUtil dataShareUtil;
 
-    @Autowired
-    public DataShareUtil dataShareUtil;
+    private final DerivedKeyCryptoUtil derivedKeyCryptoUtil;
 
-    @Autowired
-    DerivedKeyCryptoUtil derivedKeyCryptoUtil;
+    private final RestApiClient restApiClient;
 
-    @Autowired
-    public RestApiClient restApiClient;
+    private final P12KeyStoreManager p12KeyStoreManager;
 
-    @Autowired
-    public P12KeyStoreManager p12KeyStoreManager;
-
-    @Autowired
-    CbeffToBiometricUtil util;
+    private final CbeffToBiometricUtil util;
 
     /** The Constant VALUE. */
     public static final String VALUE = "value";
 
     /** The Constant UIN_TEXT_FILE. */
-    public static final String UIN_TEXT_FILE = "textFile";
+    private static final String UIN_TEXT_FILE = "textFile";
 
     @Value("${vercred.type.vid:PCN}")
     private String vid;
 
     /** The core audit request builder. */
-    @Autowired
-    private AuditLogRequestBuilder auditLogRequestBuilder;
+    private final AuditLogRequestBuilder auditLogRequestBuilder;
 
     /** The utilities. */
-    @Autowired
-    private Utilities utilities;
+    private final Utilities utilities;
 
     /** The rest client service. */
-    @Autowired
-    private RestClientService<Object> restClientService;
+    private final RestClientService<Object> restClientService;
 
     /** The env. */
-    @Autowired
-    private Environment env;
+    private final Environment env;
 
-    @Autowired
-    private PublisherClient<String, Object, HttpHeaders> pb;
+    private final PublisherClient<String, Object, HttpHeaders> pb;
 
     @Value("#{'${mosip.mandatory-languages:}'.concat('${mosip.optional-languages:}')}")
     private String supportedLang;
+
+    public CredentialShareServiceImpl(RestApiClient restApiClient, WebSubSubscriptionHelper webSubSubscriptionHelper, DataShareUtil dataShareUtil, DerivedKeyCryptoUtil derivedKeyCryptoUtil, P12KeyStoreManager p12KeyStoreManager, CbeffToBiometricUtil util, AuditLogRequestBuilder auditLogRequestBuilder, Utilities utilities, RestClientService<Object> restClientService, Environment env, PublisherClient<String, Object, HttpHeaders> pb) {
+        this.restApiClient = restApiClient;
+        this.webSubSubscriptionHelper = webSubSubscriptionHelper;
+        this.dataShareUtil = dataShareUtil;
+        this.derivedKeyCryptoUtil = derivedKeyCryptoUtil;
+        this.p12KeyStoreManager = p12KeyStoreManager;
+        this.util = util;
+        this.auditLogRequestBuilder = auditLogRequestBuilder;
+        this.utilities = utilities;
+        this.restClientService = restClientService;
+        this.env = env;
+        this.pb = pb;
+    }
 
     public boolean generateDocuments(EventModel eventModel) throws Exception {
         Path eventFilePath = Path.of(utilities.getDataPath(),

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialVerifierServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialVerifierServiceImpl.java
@@ -8,7 +8,6 @@ import io.mosip.mimoto.service.CredentialVerifierService;
 import io.mosip.vercred.vcverifier.CredentialsVerifier;
 import io.mosip.vercred.vcverifier.constants.CredentialFormat;
 import io.mosip.vercred.vcverifier.data.VerificationResult;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
@@ -16,11 +15,14 @@ import java.util.Objects;
 @Service
 public class CredentialVerifierServiceImpl implements CredentialVerifierService {
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private CredentialsVerifier credentialsVerifier;
+    private final CredentialsVerifier credentialsVerifier;
+
+    public CredentialVerifierServiceImpl(ObjectMapper objectMapper, CredentialsVerifier credentialsVerifier) {
+        this.objectMapper = objectMapper;
+        this.credentialsVerifier = credentialsVerifier;
+    }
 
     public boolean verify(VCCredentialResponse response) throws JsonProcessingException, VCVerificationException {
         String credentialString = response.getCredential() instanceof String ? (String) response.getCredential() : objectMapper.writeValueAsString(response.getCredential());

--- a/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
@@ -12,7 +12,6 @@ import io.mosip.mimoto.util.RestApiClient;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpEntity;
@@ -33,8 +32,7 @@ public class DataShareServiceImpl {
 
     private static final Pattern SAFE_URL_SEGMENT_PATTERN = Pattern.compile("^[A-Za-z0-9._\\-]+$");
 
-    @Autowired
-    RestApiClient restApiClient;
+    private final RestApiClient restApiClient;
 
     @Value("${mosip.data.share.url}")
     String dataShareHostUrl;
@@ -48,10 +46,14 @@ public class DataShareServiceImpl {
     @Value("${mosip.data.share.create.retry.count}")
     Integer maxRetryCount;
 
-    @Autowired
-    ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     PathMatcher pathMatcher ;
+
+    public DataShareServiceImpl(RestApiClient restApiClient, ObjectMapper objectMapper) {
+        this.restApiClient = restApiClient;
+        this.objectMapper = objectMapper;
+    }
 
     @PostConstruct
     public void setUp(){

--- a/src/main/java/io/mosip/mimoto/service/impl/DcSdJwtCredentialFormatHandler.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/DcSdJwtCredentialFormatHandler.java
@@ -1,6 +1,7 @@
 package io.mosip.mimoto.service.impl;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.mimoto.constant.CredentialFormat;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -8,6 +9,10 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component("dc+sd-jwt")
 public class DcSdJwtCredentialFormatHandler extends VcSdJwtCredentialFormatHandler {
+    public DcSdJwtCredentialFormatHandler(ObjectMapper objectMapper) {
+        super(objectMapper);
+    }
+
     @Override
     public String getSupportedFormat() {
         return CredentialFormat.DC_SD_JWT.getFormat();

--- a/src/main/java/io/mosip/mimoto/service/impl/IdpServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IdpServiceImpl.java
@@ -8,7 +8,7 @@ import io.mosip.mimoto.exception.*;
 import io.mosip.mimoto.service.IdpService;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.JoseUtil;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -41,14 +41,17 @@ public class IdpServiceImpl implements IdpService {
     @Value("${mosip.oidc.p12.path}")
     String keyStorePath;
 
-    @Autowired
-    JoseUtil joseUtil;
+    private final JoseUtil joseUtil;
 
-    @Autowired
-    RestTemplate restTemplate;
+    private final RestTemplate restTemplate;
 
-    @Autowired
-    IssuersService issuersService;
+    private final IssuersService issuersService;
+
+    public IdpServiceImpl(JoseUtil joseUtil, @Qualifier("restTemplate") RestTemplate restTemplate, IssuersService issuersService) {
+        this.joseUtil = joseUtil;
+        this.restTemplate = restTemplate;
+        this.issuersService = issuersService;
+    }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> constructGetTokenRequest(Map<String, String> params, IssuerDTO issuerDTO, String authorizationAudience) throws IOException, IssuerOnboardingException {

--- a/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
@@ -13,7 +13,6 @@ import io.mosip.mimoto.util.Utilities;
 import jakarta.validation.constraints.NotBlank;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -28,14 +27,17 @@ import java.util.stream.Collectors;
 @Validated
 public class IssuersServiceImpl implements IssuersService {
 
-    @Autowired
-    private Utilities utilities;
+    private final Utilities utilities;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private IssuerConfigUtil issuersConfigUtil;
+    private final IssuerConfigUtil issuersConfigUtil;
+
+    public IssuersServiceImpl(Utilities utilities, ObjectMapper objectMapper, IssuerConfigUtil issuersConfigUtil) {
+        this.utilities = utilities;
+        this.objectMapper = objectMapper;
+        this.issuersConfigUtil = issuersConfigUtil;
+    }
 
     @Override
     @Cacheable(value = "issuersConfig", key = "#p0 ?: 'allIssuersConfig'")

--- a/src/main/java/io/mosip/mimoto/service/impl/KeyPairRetrievalServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/KeyPairRetrievalServiceImpl.java
@@ -9,7 +9,6 @@ import io.mosip.mimoto.service.DataProtectionService;
 import io.mosip.mimoto.service.KeyPairRetrievalService;
 import io.mosip.mimoto.util.SigningKeyUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -24,11 +23,14 @@ import java.util.Optional;
 @Service
 public class KeyPairRetrievalServiceImpl implements KeyPairRetrievalService {
 
-    @Autowired
-    private ProofSigningKeyRepository proofSigningKeyRepository;
+    private final ProofSigningKeyRepository proofSigningKeyRepository;
 
-    @Autowired
-    private DataProtectionService dataProtectionService;
+    private final DataProtectionService dataProtectionService;
+
+    public KeyPairRetrievalServiceImpl(ProofSigningKeyRepository proofSigningKeyRepository, DataProtectionService dataProtectionService) {
+        this.proofSigningKeyRepository = proofSigningKeyRepository;
+        this.dataProtectionService = dataProtectionService;
+    }
 
     @Override
     public KeyPair getKeyPairFromDB(String walletId, String base64EncodedWalletKey, SigningAlgorithm signingAlgorithm) throws KeyGenerationException, DecryptionException {

--- a/src/main/java/io/mosip/mimoto/service/impl/LdpVcCredentialFormatHandler.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/LdpVcCredentialFormatHandler.java
@@ -7,7 +7,6 @@ import io.mosip.mimoto.service.CredentialFormatHandler;
 import io.mosip.mimoto.util.LocaleUtils;
 import static io.mosip.mimoto.util.IssuerConfigUtil.camelToTitleCase;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -16,8 +15,11 @@ import java.util.*;
 @Component("ldp_vc")
 public class LdpVcCredentialFormatHandler implements CredentialFormatHandler {
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+
+    public LdpVcCredentialFormatHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public String getSupportedFormat() {

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -14,7 +14,6 @@ import io.mosip.openID4VP.constants.VPFormatType;
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions;
 import io.mosip.openID4VP.verifier.VerifierResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -26,8 +25,11 @@ import java.util.Map;
 @Slf4j
 public class OpenID4VPService {
 
-    @Autowired
-    private VerifierService verifierService;
+    private final VerifierService verifierService;
+
+    public OpenID4VPService(VerifierService verifierService) {
+        this.verifierService = verifierService;
+    }
 
     public OpenID4VP create(String presentationId) {
         WalletMetadata walletMetadata = new WalletMetadata();

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -13,7 +13,6 @@ import io.mosip.mimoto.exception.VPNotCreatedException;
 import io.mosip.mimoto.service.PresentationService;
 import io.mosip.mimoto.util.RestApiClient;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -34,20 +33,23 @@ import static io.mosip.mimoto.util.JwtUtils.parseJwtHeader;
 @Service
 public class PresentationServiceImpl implements PresentationService {
 
-    @Autowired
-    private DataShareServiceImpl dataShareService;
+    private final DataShareServiceImpl dataShareService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private RestApiClient restApiClient;
+    private final RestApiClient restApiClient;
 
     @Value("${mosip.inji.ovp.redirect.url.pattern}")
     private String injiOvpRedirectURLPattern;
 
     @Value("${server.tomcat.max-http-response-header-size:65536}")
     private Integer maximumResponseHeaderSize;
+
+    public PresentationServiceImpl(DataShareServiceImpl dataShareService, ObjectMapper objectMapper, RestApiClient restApiClient) {
+        this.dataShareService = dataShareService;
+        this.objectMapper = objectMapper;
+        this.restApiClient = restApiClient;
+    }
 
 
     @Override

--- a/src/main/java/io/mosip/mimoto/service/impl/RestClientServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/RestClientServiceImpl.java
@@ -7,7 +7,6 @@ import io.mosip.mimoto.exception.PlatformErrorMessages;
 import io.mosip.mimoto.service.RestClientService;
 import io.mosip.mimoto.util.RestApiClient;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -28,12 +27,15 @@ import java.util.List;
 public class RestClientServiceImpl implements RestClientService<Object> {
 
     /** The rest api client. */
-    @Autowired
-    private RestApiClient restApiClient;
+    private final RestApiClient restApiClient;
 
     /** The env. */
-    @Autowired
-    private Environment env;
+    private final Environment env;
+
+    public RestClientServiceImpl(RestApiClient restApiClient, Environment env) {
+        this.restApiClient = restApiClient;
+        this.env = env;
+    }
 
     /*
      * (non-Javadoc)

--- a/src/main/java/io/mosip/mimoto/service/impl/SessionManager.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/SessionManager.java
@@ -8,7 +8,6 @@ import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -19,8 +18,11 @@ import java.util.Map;
 @Slf4j
 public class SessionManager {
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+
+    public SessionManager(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     public void setupSession(HttpServletRequest request, String provider, UserMetadataDTO userMetadata, String userId) {
         HttpSession session = request.getSession(true);

--- a/src/main/java/io/mosip/mimoto/service/impl/TrustedVerifierServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/TrustedVerifierServiceImpl.java
@@ -6,7 +6,6 @@ import io.mosip.mimoto.exception.InvalidRequestException;
 import io.mosip.mimoto.model.TrustedVerifier;
 import io.mosip.mimoto.repository.VerifierRepository;
 import io.mosip.mimoto.service.TrustedVerifierService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -16,8 +15,11 @@ import static io.mosip.mimoto.exception.ErrorConstants.*;
 @Service
 public class TrustedVerifierServiceImpl implements TrustedVerifierService {
 
-    @Autowired
-    private VerifierRepository verifierRepository;
+    private final VerifierRepository verifierRepository;
+
+    public TrustedVerifierServiceImpl(VerifierRepository verifierRepository) {
+        this.verifierRepository = verifierRepository;
+    }
 
     @Override
     public TrustedVerifierResponseDTO addTrustedVerifier(String walletId, TrustedVerifierRequest trustedVerifierRequest) {

--- a/src/main/java/io/mosip/mimoto/service/impl/VcSdJwtCredentialFormatHandler.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/VcSdJwtCredentialFormatHandler.java
@@ -9,10 +9,8 @@ import io.mosip.mimoto.dto.mimoto.*;
 import io.mosip.mimoto.service.CredentialFormatHandler;
 import io.mosip.mimoto.util.LocaleUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -23,8 +21,11 @@ import static io.mosip.mimoto.util.JwtUtils.parseJwtPayload;
 @Component("vc+sd-jwt")
 public class VcSdJwtCredentialFormatHandler implements CredentialFormatHandler {
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+
+    public VcSdJwtCredentialFormatHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public String getSupportedFormat() {

--- a/src/main/java/io/mosip/mimoto/service/impl/VerifierServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/VerifierServiceImpl.java
@@ -15,7 +15,6 @@ import io.mosip.mimoto.util.Utilities;
 import io.mosip.openID4VP.authorizationRequest.Verifier;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.validator.routines.UrlValidator;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -32,14 +31,11 @@ import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URL
 @Service
 public class VerifierServiceImpl implements VerifierService {
 
-    @Autowired
-    Utilities utilities;
+    private final Utilities utilities;
 
-    @Autowired
-    ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private VerifierRepository verifierRepository;
+    private final VerifierRepository verifierRepository;
 
     private static final PathMatcher pathMatcher;
     private static final UrlValidator urlValidator;
@@ -47,6 +43,12 @@ public class VerifierServiceImpl implements VerifierService {
     static {
         pathMatcher = new AntPathMatcher();
         urlValidator = new UrlValidator(ALLOW_ALL_SCHEMES+ALLOW_LOCAL_URLS);
+    }
+
+    public VerifierServiceImpl(Utilities utilities, ObjectMapper objectMapper, VerifierRepository verifierRepository) {
+        this.utilities = utilities;
+        this.objectMapper = objectMapper;
+        this.verifierRepository = verifierRepository;
     }
 
     @Cacheable(value = "preRegisteredTrustedVerifiersCache", key = "'preRegisteredTrustedVerifiers'")

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
@@ -38,7 +38,6 @@ import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.L
 import io.mosip.openID4VP.constants.FormatType;
 import io.mosip.openID4VP.verifier.VerifierResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -67,26 +66,29 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     private static final String EMPTY_JSON = "{}";
     private static final String DEFAULT_SIGNING_ALGORITHM_NAME = "ED25519";
 
-    @Autowired
-    private VerifierService verifierService;
+    private final VerifierService verifierService;
 
-    @Autowired
-    private OpenID4VPService openID4VPService;
+    private final OpenID4VPService openID4VPService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
-    @Autowired
-    private KeyPairRetrievalService keyPairService;
+    private final KeyPairRetrievalService keyPairService;
 
-    @Autowired
-    private CredentialMatchingService credentialMatchingService;
+    private final CredentialMatchingService credentialMatchingService;
 
-    @Autowired
-    private VerifiablePresentationsRepository verifiablePresentationsRepository;
+    private final VerifiablePresentationsRepository verifiablePresentationsRepository;
 
-    @Autowired
-    private DataProtectionService dataProtectionService;
+    private final DataProtectionService dataProtectionService;
+
+    public WalletPresentationServiceImpl(VerifierService verifierService, OpenID4VPService openID4VPService, ObjectMapper objectMapper, KeyPairRetrievalService keyPairService, CredentialMatchingService credentialMatchingService, VerifiablePresentationsRepository verifiablePresentationsRepository, DataProtectionService dataProtectionService) {
+        this.verifierService = verifierService;
+        this.openID4VPService = openID4VPService;
+        this.objectMapper = objectMapper;
+        this.keyPairService = keyPairService;
+        this.credentialMatchingService = credentialMatchingService;
+        this.verifiablePresentationsRepository = verifiablePresentationsRepository;
+        this.dataProtectionService = dataProtectionService;
+    }
 
     @Override
     public VPResponseDTO handleVPAuthorizationRequest(String urlEncodedVPAuthorizationRequest, String walletId) throws ApiNotAccessibleException, IOException, URISyntaxException {

--- a/src/main/resources/templates/credential-template.html
+++ b/src/main/resources/templates/credential-template.html
@@ -41,7 +41,7 @@
                     $nestedEntry.key
                 </div>  <!-- Use nested entry key as label -->
                 #if($nestedEntry.value.startsWith("data:image/"))
-                <img src="$nestedEntry.value" alt="Embedded Image"
+                <img src="$nestedEntry.value" alt="$nestedEntry.key"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 #else
                 <div style="font-family: 'Inter', sans-serif; font-weight: 600; font-size: 18px; word-wrap: break-word;">
@@ -58,7 +58,7 @@
                     $entry.key
                 </div> <!-- Outer key -->
                 #if($entry.value.startsWith("data:image/"))
-                <img src="$entry.value" alt="Embedded Image"
+                <img src="$entry.value" alt="$entry.key"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 <!-- Outer value -->
                 #else

--- a/src/main/resources/templates/credential-template.html
+++ b/src/main/resources/templates/credential-template.html
@@ -41,7 +41,7 @@
                     $nestedEntry.key
                 </div>  <!-- Use nested entry key as label -->
                 #if($nestedEntry.value.startsWith("data:image/"))
-                <img src="$nestedEntry.value" alt="$nestedEntry.key"
+                <img src="$nestedEntry.value" alt="Embedded Visual"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 #else
                 <div style="font-family: 'Inter', sans-serif; font-weight: 600; font-size: 18px; word-wrap: break-word;">
@@ -58,7 +58,7 @@
                     $entry.key
                 </div> <!-- Outer key -->
                 #if($entry.value.startsWith("data:image/"))
-                <img src="$entry.value" alt="$entry.key"
+                <img src="$entry.value" alt="Embedded Visual"
                      style="height:100px; width:100px; border: 1px solid #ccc; border-radius: 8px;"/>
                 <!-- Outer value -->
                 #else

--- a/src/test/java/io/mosip/mimoto/controller/IdpControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/IdpControllerTest.java
@@ -8,7 +8,6 @@ import io.mosip.mimoto.exception.BaseUncheckedException;
 import io.mosip.mimoto.exception.IdpException;
 import io.mosip.mimoto.service.RestClientService;
 import io.mosip.mimoto.service.impl.IdpServiceImpl;
-import io.mosip.mimoto.service.impl.IssuersServiceImpl;
 import io.mosip.mimoto.util.*;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.message.BasicNameValuePair;

--- a/src/test/java/io/mosip/mimoto/controller/WalletPresentationsControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/WalletPresentationsControllerTest.java
@@ -50,9 +50,6 @@ public class WalletPresentationsControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private ObjectMapper objectMapper;
-
-    @MockBean
     private WalletPresentationService walletPresentationService;
 
     @Mock

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -18,7 +18,6 @@ import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.service.impl.LdpVcCredentialFormatHandler;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
 import io.mosip.mimoto.service.impl.VcSdJwtCredentialFormatHandler;
-import io.mosip.mimoto.util.LocaleUtils;
 import io.mosip.mimoto.util.SvgFixerUtil;
 import io.mosip.mimoto.util.Utilities;
 import io.mosip.pixelpass.PixelPass;
@@ -901,7 +900,7 @@ class CredentialPDFGeneratorServiceTest {
 
     @Test
     void testFormatValueWithMap_AtValue() throws Exception {
-        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService(objectMapper, presentationService, utilities, pixelPass, credentialFormatHandlerFactory, injiVcRenderer, svgFixerUtil );
         Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
         formatValueMethod.setAccessible(true);
 
@@ -915,7 +914,7 @@ class CredentialPDFGeneratorServiceTest {
 
     @Test
     void testFormatValueWithMap_Value() throws Exception {
-        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService(objectMapper, presentationService, utilities, pixelPass, credentialFormatHandlerFactory, injiVcRenderer, svgFixerUtil );
         Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
         formatValueMethod.setAccessible(true);
 
@@ -929,7 +928,7 @@ class CredentialPDFGeneratorServiceTest {
 
     @Test
     void testFormatValueWithListOfMaps_AtLanguageAndAtValue() throws Exception {
-        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService(objectMapper, presentationService, utilities, pixelPass, credentialFormatHandlerFactory, injiVcRenderer, svgFixerUtil );
         Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
         formatValueMethod.setAccessible(true);
 
@@ -962,7 +961,7 @@ class CredentialPDFGeneratorServiceTest {
 
     @Test
     void testFormatValueWithListOfMaps_LanguageAndValue() throws Exception {
-        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService(objectMapper, presentationService, utilities, pixelPass, credentialFormatHandlerFactory, injiVcRenderer, svgFixerUtil );
         Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
         formatValueMethod.setAccessible(true);
 
@@ -995,7 +994,7 @@ class CredentialPDFGeneratorServiceTest {
 
     @Test
     void testFormatValueWithListOfMaps_langAndValue() throws Exception {
-        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService();
+        CredentialPDFGeneratorService service = new CredentialPDFGeneratorService(objectMapper, presentationService, utilities, pixelPass, credentialFormatHandlerFactory, injiVcRenderer, svgFixerUtil );
         Method formatValueMethod = CredentialPDFGeneratorService.class.getDeclaredMethod("formatValue", Object.class, String.class);
         formatValueMethod.setAccessible(true);
 

--- a/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
@@ -12,7 +12,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +33,7 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(classes = {CredentialRequestServiceImpl.class})
 @TestPropertySource(locations = "classpath:application-test.properties")
 public class CredentialRequestServiceTest {
-    @Mock
+    @MockBean
     private ObjectMapper objectMapper;
 
     @Autowired

--- a/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
@@ -1,5 +1,6 @@
 package io.mosip.mimoto.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.mimoto.constant.SigningAlgorithm;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.mimoto.*;
@@ -11,6 +12,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +34,9 @@ import static org.mockito.Mockito.when;
 @SpringBootTest(classes = {CredentialRequestServiceImpl.class})
 @TestPropertySource(locations = "classpath:application-test.properties")
 public class CredentialRequestServiceTest {
+    @Mock
+    private ObjectMapper objectMapper;
+
     @Autowired
     private CredentialRequestServiceImpl credentialRequestServiceImpl;
 
@@ -53,7 +58,7 @@ public class CredentialRequestServiceTest {
     public void setUp() {
         issuerId = "issuer1";
         issuerDTO = getIssuerConfigDTO(issuerId);
-        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(new LdpVcCredentialFormatHandler());
+        when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(new LdpVcCredentialFormatHandler(objectMapper));
     }
 
     @After

--- a/src/test/java/io/mosip/mimoto/service/CredentialShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialShareServiceTest.java
@@ -16,10 +16,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
 
 import java.net.URI;
 import java.security.InvalidKeyException;
@@ -33,8 +33,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(MockitoJUnitRunner.class)
 public class CredentialShareServiceTest {
 
-    @InjectMocks
-    private CredentialShareService service = new CredentialShareServiceImpl();
+    private CredentialShareService service;
 
     @Mock
     public RestApiClient restApiClient;
@@ -51,10 +50,25 @@ public class CredentialShareServiceTest {
     @Mock
     private Utilities utilities;
 
-    private EventModel eventModel = null;
+    @Mock
+    private WebSubSubscriptionHelper webSubSubscriptionHelper;
+
+    @Mock
+    private DataShareUtil dataShareUtil;
+
+    @Mock
+    private RestClientService<Object> restClientService;
+
+    @Mock
+    private org.springframework.core.env.Environment env;
+
+    @Mock
+    private io.mosip.kernel.core.websub.spi.PublisherClient<String, Object, HttpHeaders> pb;
 
     @Mock
     private CbeffToBiometricUtil util;
+
+    private EventModel eventModel = null;
 
     @Before
     public void setup() throws Exception {
@@ -98,6 +112,10 @@ public class CredentialShareServiceTest {
         List<BIR> birs = Lists.newArrayList(bir);
         Mockito.when(util.getBIRTypeList(Mockito.anyString())).thenReturn(birs);
         Mockito.when(util.getPhotoByTypeAndSubType(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn("face image strring".getBytes());
+
+        service = new CredentialShareServiceImpl(restApiClient, webSubSubscriptionHelper, dataShareUtil,
+                derivedKeyCryptoUtil, p12KeyStoreManager, util, auditLogRequestBuilder, utilities,
+                restClientService, env, pb);
 
     }
 

--- a/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
@@ -47,6 +47,7 @@ public class DataShareServiceTest {
         ReflectionTestUtils.setField(dataShareService, "dataShareGetUrlPattern", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*");
         ReflectionTestUtils.setField(dataShareService, "maxRetryCount", 1);
         presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
+        ReflectionTestUtils.setField(dataShareService, "pathMatcher", pathMatcher);
         Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test")).thenReturn(true);
     }
 

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -3,8 +3,6 @@ package io.mosip.mimoto.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.mimoto.constant.CredentialFormat;
-import io.mosip.mimoto.dto.ErrorDTO;
-import io.mosip.mimoto.dto.VPResponseDTO;
 import io.mosip.mimoto.dto.mimoto.VCCredentialProperties;
 import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
 import io.mosip.mimoto.dto.mimoto.VCCredentialResponseProof;
@@ -15,18 +13,13 @@ import io.mosip.mimoto.dto.openid.presentation.InputDescriptorDTO;
 import io.mosip.mimoto.dto.openid.presentation.PresentationDefinitionDTO;
 import io.mosip.mimoto.dto.openid.presentation.PresentationRequestDTO;
 import io.mosip.mimoto.exception.ErrorConstants;
-import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
-import io.mosip.mimoto.exception.VPErrorNotSentException;
 import io.mosip.mimoto.exception.VPNotCreatedException;
 import io.mosip.mimoto.service.impl.DataShareServiceImpl;
-import io.mosip.mimoto.service.impl.OpenID4VPService;
 import io.mosip.mimoto.service.impl.PresentationServiceImpl;
 import io.mosip.mimoto.util.JwtUtils;
 import io.mosip.mimoto.util.RestApiClient;
 import io.mosip.mimoto.util.TestUtilities;
-import io.mosip.openID4VP.OpenID4VP;
 import io.mosip.openID4VP.authorizationRequest.Verifier;
-import io.mosip.openID4VP.verifier.VerifierResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,13 +28,11 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
-import io.mosip.mimoto.dto.SubmitPresentationResponseDTO;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
 
-import static io.mosip.mimoto.exception.ErrorConstants.REJECTED_VERIFIER;
 import static io.mosip.mimoto.util.JwtUtils.parseJwtHeader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -49,20 +40,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static io.mosip.mimoto.util.TestUtilities.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PresentationServiceTest {
-    @Mock
-    VerifierService verifierService;
     @Mock
     DataShareServiceImpl dataShareService;
 
     @Mock
     ObjectMapper objectMapper;
-
-    @Mock
-    private OpenID4VPService openID4VPService;
 
     @Mock
     RestApiClient restApiClient;

--- a/src/test/java/io/mosip/mimoto/service/RestClientServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/RestClientServiceTest.java
@@ -16,7 +16,6 @@ import io.mosip.mimoto.exception.ApisResourceAccessException;
 import io.mosip.mimoto.service.impl.RestClientServiceImpl;
 import io.mosip.mimoto.util.RestApiClient;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
@@ -35,7 +34,7 @@ public class RestClientServiceTest {
     private static final String API_NAME = "AUDIT";
 
     @InjectMocks
-    RestClientService<Object> registrationProcessorRestClientService = new RestClientServiceImpl();
+    private RestClientServiceImpl registrationProcessorRestClientService;
     /** The rest api client. */
     @Mock
     private RestApiClient restApiClient;

--- a/src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
+++ b/src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
@@ -35,7 +35,7 @@ public class SessionManagerTest {
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        sessionManager = new SessionManager();
+        sessionManager = new SessionManager(objectMapper);
         ReflectionTestUtils.setField(sessionManager, "objectMapper", objectMapper);
         userMetadataDTO = new UserMetadataDTO("Test user", "https://test.com/pic.jpg", "test@example.com", "wallet123");
     }

--- a/src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
+++ b/src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 import java.util.*;
@@ -36,7 +35,6 @@ public class SessionManagerTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         sessionManager = new SessionManager(objectMapper);
-        ReflectionTestUtils.setField(sessionManager, "objectMapper", objectMapper);
         userMetadataDTO = new UserMetadataDTO("Test user", "https://test.com/pic.jpg", "test@example.com", "wallet123");
     }
 

--- a/src/test/java/io/mosip/mimoto/service/TrustedVerifierServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/TrustedVerifierServiceTest.java
@@ -11,10 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.UUID;
 
 import static io.mosip.mimoto.exception.ErrorConstants.DUPLICATE_VERIFIER;
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
Replaced the Field injection with constructor injection in the Controller and Service files

Reused the SecureRandom as private static final field in DataProtectionService

Removed the redundant use of "Image" in the alt attribute in credential template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated alt text for embedded images from "Embedded Image" to "Embedded Visual" to improve accessibility labels.

* **Refactor**
  * Migrated many components to constructor-based dependency wiring and made dependencies immutable; no changes to external behavior or public endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->