### PR TITLE
[INJIWEB-1861] Refactored reflection tests to use mocking

### DIFF
--- a/src/main/java/io/mosip/mimoto/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/io/mosip/mimoto/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -20,8 +20,11 @@ import java.io.IOException;
 @Slf4j
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    @Value("${mosip.inji.web.authentication.success.redirect.url}")
-    private String authenticationSuccessRedirectUrl;
+    private final String authenticationSuccessRedirectUrl;
+
+    public OAuth2AuthenticationSuccessHandler(@Value("${mosip.inji.web.authentication.success.redirect.url}") String authenticationSuccessRedirectUrl) {
+        this.authenticationSuccessRedirectUrl = authenticationSuccessRedirectUrl;
+    }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {

--- a/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
+++ b/src/main/java/io/mosip/mimoto/service/DataProtectionService.java
@@ -38,11 +38,12 @@ public class DataProtectionService {
 
     private final CryptomanagerService cryptomanagerService;
 
-    @Value("${mosip.inji.app.id:MIMOTO}")
-    private String appId;
+    private final String appId;
 
-    public DataProtectionService(CryptomanagerService cryptomanagerService) {
+    public DataProtectionService(CryptomanagerService cryptomanagerService,
+                                 @Value("${mosip.inji.app.id:MIMOTO}") String appId) {
         this.cryptomanagerService = cryptomanagerService;
+        this.appId = appId;
     }
 
     /**

--- a/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/DataShareServiceImpl.java
@@ -9,7 +9,6 @@ import io.mosip.mimoto.dto.openid.presentation.PresentationRequestDTO;
 import io.mosip.mimoto.exception.ErrorConstants;
 import io.mosip.mimoto.exception.InvalidCredentialResourceException;
 import io.mosip.mimoto.util.RestApiClient;
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,30 +33,32 @@ public class DataShareServiceImpl {
 
     private final RestApiClient restApiClient;
 
-    @Value("${mosip.data.share.url}")
-    String dataShareHostUrl;
+    private final String dataShareHostUrl;
 
-    @Value("${mosip.data.share.create.url}")
-    String dataShareCreateUrl;
+    private final String dataShareCreateUrl;
 
-    @Value("${mosip.data.share.get.url.pattern}")
-    String dataShareGetUrlPattern;
+    private final String dataShareGetUrlPattern;
 
-    @Value("${mosip.data.share.create.retry.count}")
-    Integer maxRetryCount;
+    private final Integer maxRetryCount;
 
     private final ObjectMapper objectMapper;
 
-    PathMatcher pathMatcher ;
+    private final PathMatcher pathMatcher = new AntPathMatcher();
 
-    public DataShareServiceImpl(RestApiClient restApiClient, ObjectMapper objectMapper) {
+    public DataShareServiceImpl(
+            RestApiClient restApiClient,
+            ObjectMapper objectMapper,
+            @Value("${mosip.data.share.url}") String dataShareHostUrl,
+            @Value("${mosip.data.share.create.url}") String dataShareCreateUrl,
+            @Value("${mosip.data.share.get.url.pattern}") String dataShareGetUrlPattern,
+            @Value("${mosip.data.share.create.retry.count}") Integer maxRetryCount) {
+
         this.restApiClient = restApiClient;
         this.objectMapper = objectMapper;
-    }
-
-    @PostConstruct
-    public void setUp(){
-        pathMatcher = new AntPathMatcher();
+        this.dataShareHostUrl = dataShareHostUrl;
+        this.dataShareCreateUrl = dataShareCreateUrl;
+        this.dataShareGetUrlPattern = dataShareGetUrlPattern;
+        this.maxRetryCount = maxRetryCount;
     }
 
     public String storeDataInDataShare(String data, String credentialValidity) throws InvalidCredentialResourceException {

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -39,16 +39,22 @@ public class PresentationServiceImpl implements PresentationService {
 
     private final RestApiClient restApiClient;
 
-    @Value("${mosip.inji.ovp.redirect.url.pattern}")
-    private String injiOvpRedirectURLPattern;
+    private final String injiOvpRedirectURLPattern;
 
-    @Value("${server.tomcat.max-http-response-header-size:65536}")
-    private Integer maximumResponseHeaderSize;
+    private final Integer maximumResponseHeaderSize;
 
-    public PresentationServiceImpl(DataShareServiceImpl dataShareService, ObjectMapper objectMapper, RestApiClient restApiClient) {
+    public PresentationServiceImpl(
+            DataShareServiceImpl dataShareService,
+            ObjectMapper objectMapper,
+            RestApiClient restApiClient,
+            @Value("${mosip.inji.ovp.redirect.url.pattern}") String injiOvpRedirectURLPattern,
+            @Value("${server.tomcat.max-http-response-header-size:65536}") Integer maximumResponseHeaderSize
+    ) {
         this.dataShareService = dataShareService;
         this.objectMapper = objectMapper;
         this.restApiClient = restApiClient;
+        this.injiOvpRedirectURLPattern = injiOvpRedirectURLPattern;
+        this.maximumResponseHeaderSize = maximumResponseHeaderSize;
     }
 
 

--- a/src/main/java/io/mosip/mimoto/util/DerivedKeyCryptoUtil.java
+++ b/src/main/java/io/mosip/mimoto/util/DerivedKeyCryptoUtil.java
@@ -35,14 +35,20 @@ public class DerivedKeyCryptoUtil {
 
     private static final String AES_KEY_TYPE = "AES";
 
-    @Value("${mosip.kernel.crypto.hash-symmetric-key-length:256}")
-    private int symmetricKeyLength;
+    private final int symmetricKeyLength;
 
-    @Value("${mosip.kernel.crypto.hash-iteration:100000}")
-    private int iterations;
+    private final int iterations;
 
-    @Value("${mosip.kernel.crypto.hash-algorithm-name:PBKDF2WithHmacSHA512}")
-    private String passwordAlgorithm;
+    private final String passwordAlgorithm;
+
+    public DerivedKeyCryptoUtil(
+            @Value("${mosip.kernel.crypto.hash-symmetric-key-length:256}") int symmetricKeyLength,
+            @Value("${mosip.kernel.crypto.hash-iteration:100000}") int iterations,
+            @Value("${mosip.kernel.crypto.hash-algorithm-name:PBKDF2WithHmacSHA512}") String passwordAlgorithm) {
+        this.symmetricKeyLength = symmetricKeyLength;
+        this.iterations = iterations;
+        this.passwordAlgorithm = passwordAlgorithm;
+    }
 
     public CryptoWithPinResponseDto decryptWithPin(CryptoWithPinRequestDto requestDto)
             throws NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException,

--- a/src/test/java/io/mosip/mimoto/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/io/mosip/mimoto/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -10,12 +10,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 
@@ -25,7 +23,6 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class OAuth2AuthenticationSuccessHandlerTest {
 
-    @InjectMocks
     private OAuth2AuthenticationSuccessHandler successHandler;
 
     @Mock
@@ -52,8 +49,7 @@ public class OAuth2AuthenticationSuccessHandlerTest {
 
     @Before
     public void setUp() throws Exception {
-        ReflectionTestUtils.setField(successHandler, "authenticationSuccessRedirectUrl", AUTH_SUCCESS_REDIRECT_URL);
-
+        successHandler = new OAuth2AuthenticationSuccessHandler(AUTH_SUCCESS_REDIRECT_URL);
         when(request.getSession(false)).thenReturn(session);
     }
 

--- a/src/test/java/io/mosip/mimoto/service/DataProtectionServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataProtectionServiceTest.java
@@ -35,7 +35,6 @@ public class DataProtectionServiceTest {
     @Mock
     private CryptomanagerService cryptomanagerService;
 
-    @InjectMocks
     private DataProtectionService dataProtectionService;
 
     private final String refId = "ref123";
@@ -50,7 +49,7 @@ public class DataProtectionServiceTest {
     @Before
     public void setUp() throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, NoSuchProviderException {
         String appId = "MIMOTO";
-        ReflectionTestUtils.setField(dataProtectionService, "appId", appId);
+        dataProtectionService = new DataProtectionService(cryptomanagerService, appId);
         encryptionKey = SigningKeyUtil.generateEncryptionKey("AES", 256);
         keyPair = SigningKeyUtil.generateKeyPair(SigningAlgorithm.ED25519);
     }

--- a/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
@@ -14,14 +14,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.PathMatcher;
 import static io.mosip.mimoto.util.TestUtilities.getDataShareResponseDTO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -34,21 +31,22 @@ public class DataShareServiceTest {
     RestApiClient restApiClient;
     @Mock
     ObjectMapper objectMapper;
-    @Mock
-    PathMatcher pathMatcher;
-    @InjectMocks
+
     DataShareServiceImpl dataShareService;
     PresentationRequestDTO presentationRequestDTO;
 
     @Before
     public void setUp() {
-        ReflectionTestUtils.setField(dataShareService, "dataShareHostUrl", "https://test-url");
-        ReflectionTestUtils.setField(dataShareService, "dataShareCreateUrl", "https://test-url");
-        ReflectionTestUtils.setField(dataShareService, "dataShareGetUrlPattern", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*");
-        ReflectionTestUtils.setField(dataShareService, "maxRetryCount", 1);
         presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
-        ReflectionTestUtils.setField(dataShareService, "pathMatcher", pathMatcher);
-        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test")).thenReturn(true);
+
+        dataShareService = new DataShareServiceImpl(
+                restApiClient,
+                objectMapper,
+                "https://test-url",
+                "https://test-url",
+                "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*",
+                1
+        );
     }
 
     @Test
@@ -63,13 +61,13 @@ public class DataShareServiceTest {
 
     @Test(expected = InvalidCredentialResourceException.class)
     public void throwRequestTimedOutExceptionWhenMaxCountIsReached() throws Exception {
-        ReflectionTestUtils.setField(dataShareService, "maxRetryCount", 0);
+        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, "https://test-url", "https://test-url", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", 0);
         dataShareService.storeDataInDataShare("SampleData", "3");
     }
 
     @Test(expected = InvalidCredentialResourceException.class)
     public void throwServiceUnavailableExceptionWhenCredentialPushIsNotDone() throws Exception {
-        ReflectionTestUtils.setField(dataShareService, "maxRetryCount", 1);
+        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, "https://test-url", "https://test-url", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", 1);
         Mockito.when(restApiClient.postApi(Mockito.anyString(), Mockito.eq(MediaType.MULTIPART_FORM_DATA), Mockito.any(), Mockito.eq(DataShareResponseWrapperDTO.class)))
                 .thenThrow(InvalidCredentialResourceException.class);
         dataShareService.storeDataInDataShare("SampleData", "3");
@@ -145,7 +143,6 @@ public class DataShareServiceTest {
     @Test
     public void throwResourceInvalidRequestExceptionWhenCredentialURLHasIllegalDirectoryCharacter() {
         String expectedExceptionMsg = "invalid_resource --> Invalid path structure in resource URL";
-        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/te..st")).thenReturn(true);
 
         presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/te..st");
 
@@ -157,7 +154,6 @@ public class DataShareServiceTest {
     @Test
     public void throwResourceInvalidRequestExceptionWhenCredentialURLHasIllegalForwardSlashCharacter() {
         String expectedExceptionMsg = "invalid_resource --> Invalid path structure in resource URL";
-        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid//test")).thenReturn(true);
 
         presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid//test");
 
@@ -169,8 +165,7 @@ public class DataShareServiceTest {
     @Test
     public void throwResourceInvalidRequestExceptionWhenCredentialURLIsMisconfiguredAndHasNoWildcard() {
         String expectedExceptionMsg = "invalid_resource --> Invalid resource identifier in URL";
-        ReflectionTestUtils.setField(dataShareService, "dataShareGetUrlPattern", "http://datashare.datashare/*");
-        Mockito.when(pathMatcher.match("http://datashare.datashare/*", "http://datashare.datashare/")).thenReturn(true);
+        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, "https://test-url", "https://test-url", "http://datashare.datashare/*", 1);
 
         presentationRequestDTO.setResource("http://datashare.datashare/");
 
@@ -184,8 +179,6 @@ public class DataShareServiceTest {
         String expectedExceptionMsg = "invalid_resource --> Invalid characters in wildcard segment";
         presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test$");
 
-        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/test$")).thenReturn(true);
-
         InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
@@ -196,8 +189,6 @@ public class DataShareServiceTest {
         String expectedExceptionMsg = "invalid_resource --> Malformed resource URL";
         presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%%illegal");
 
-        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%%illegal")).thenReturn(true);
-
         InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class, () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
@@ -207,9 +198,6 @@ public class DataShareServiceTest {
     public void throwResourceInvalidRequestExceptionWhenCredentialURLHasDoubleEncodedPathTraversal() {
         String expectedExceptionMsg = "invalid_resource --> Invalid characters in wildcard segment";
         presentationRequestDTO.setResource("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%252e%252e");
-
-        Mockito.when(pathMatcher.match("http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*",
-                "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/%252e%252e")).thenReturn(true);
 
         InvalidCredentialResourceException actualException = assertThrows(InvalidCredentialResourceException.class,
                 () -> dataShareService.downloadCredentialFromDataShare(presentationRequestDTO));

--- a/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/DataShareServiceTest.java
@@ -35,6 +35,12 @@ public class DataShareServiceTest {
     DataShareServiceImpl dataShareService;
     PresentationRequestDTO presentationRequestDTO;
 
+    private static final String TEST_HOST_URL = "https://test-url";
+    private static final String TEST_CREATE_URL = "https://test-url";
+    private static final String TEST_GET_URL_PATTERN = "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*";
+    private static final String MISCONFIGURED_GET_URL_PATTERN = "http://datashare.datashare/*";
+    private static final int DEFAULT_MAX_RETRY_COUNT = 1;
+
     @Before
     public void setUp() {
         presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
@@ -42,10 +48,10 @@ public class DataShareServiceTest {
         dataShareService = new DataShareServiceImpl(
                 restApiClient,
                 objectMapper,
-                "https://test-url",
-                "https://test-url",
-                "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*",
-                1
+                TEST_HOST_URL,
+                TEST_CREATE_URL,
+                TEST_GET_URL_PATTERN,
+                DEFAULT_MAX_RETRY_COUNT
         );
     }
 
@@ -61,13 +67,12 @@ public class DataShareServiceTest {
 
     @Test(expected = InvalidCredentialResourceException.class)
     public void throwRequestTimedOutExceptionWhenMaxCountIsReached() throws Exception {
-        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, "https://test-url", "https://test-url", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", 0);
+        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, TEST_HOST_URL, TEST_CREATE_URL, TEST_GET_URL_PATTERN, 0);
         dataShareService.storeDataInDataShare("SampleData", "3");
     }
 
     @Test(expected = InvalidCredentialResourceException.class)
     public void throwServiceUnavailableExceptionWhenCredentialPushIsNotDone() throws Exception {
-        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, "https://test-url", "https://test-url", "http://datashare.datashare/v1/datashare/get/static-policyid/static-subscriberid/*", 1);
         Mockito.when(restApiClient.postApi(Mockito.anyString(), Mockito.eq(MediaType.MULTIPART_FORM_DATA), Mockito.any(), Mockito.eq(DataShareResponseWrapperDTO.class)))
                 .thenThrow(InvalidCredentialResourceException.class);
         dataShareService.storeDataInDataShare("SampleData", "3");
@@ -165,7 +170,7 @@ public class DataShareServiceTest {
     @Test
     public void throwResourceInvalidRequestExceptionWhenCredentialURLIsMisconfiguredAndHasNoWildcard() {
         String expectedExceptionMsg = "invalid_resource --> Invalid resource identifier in URL";
-        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, "https://test-url", "https://test-url", "http://datashare.datashare/*", 1);
+        dataShareService = new DataShareServiceImpl(restApiClient, objectMapper, TEST_HOST_URL, TEST_CREATE_URL, MISCONFIGURED_GET_URL_PATTERN, DEFAULT_MAX_RETRY_COUNT);
 
         presentationRequestDTO.setResource("http://datashare.datashare/");
 

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -23,11 +23,9 @@ import io.mosip.openID4VP.authorizationRequest.Verifier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -52,7 +50,6 @@ public class PresentationServiceTest {
     @Mock
     RestApiClient restApiClient;
 
-    @InjectMocks
     PresentationServiceImpl presentationService;
 
     String walletId, clientId, urlEncodedVPAuthorizationRequest;
@@ -64,8 +61,7 @@ public class PresentationServiceTest {
 
     @Before
     public void setup() throws JsonProcessingException {
-        ReflectionTestUtils.setField(presentationService, "injiOvpRedirectURLPattern", "%s#vp_token=%s&presentation_submission=%s");
-        ReflectionTestUtils.setField(presentationService, "maximumResponseHeaderSize", 65536);
+        presentationService = new PresentationServiceImpl(dataShareService, objectMapper, restApiClient, "%s#vp_token=%s&presentation_submission=%s", 65536);
         when(objectMapper.writeValueAsString(any())).thenReturn("test-data");
 
         // Setup for Wallet presentation tests
@@ -149,7 +145,7 @@ public class PresentationServiceTest {
 
     @Test(expected = VPNotCreatedException.class)
     public void uriTooLongWithVPRequest() throws IOException {
-        ReflectionTestUtils.setField(presentationService, "maximumResponseHeaderSize", 10); // Very small limit
+        presentationService = new PresentationServiceImpl(dataShareService, objectMapper, restApiClient, "%s#vp_token=%s&presentation_submission=%s", 10);
 
         VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
         PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();

--- a/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
@@ -19,11 +19,9 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.mimoto.dto.CryptoWithPinRequestDto;
 import io.mosip.mimoto.dto.CryptoWithPinResponseDto;
@@ -33,7 +31,6 @@ import io.mosip.mimoto.exception.ParseException;
 @ExtendWith(MockitoExtension.class)
 class DerivedKeyCryptoUtilTest {
 
-    @InjectMocks
     private DerivedKeyCryptoUtil derivedKeyCryptoUtil;
 
     private static final String AES_KEY_TYPE = "AES";
@@ -44,9 +41,7 @@ class DerivedKeyCryptoUtilTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "symmetricKeyLength", 256);
-        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "iterations", 100000);
-        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "passwordAlgorithm", "PBKDF2WithHmacSHA512");
+        derivedKeyCryptoUtil = new DerivedKeyCryptoUtil(256, 100000, "PBKDF2WithHmacSHA512");
     }
 
     private byte[] encrypt(String data, SecretKey key, byte[] nonce, byte[] aad) throws Exception {
@@ -192,7 +187,7 @@ class DerivedKeyCryptoUtilTest {
 
     @Test
     void testHashThrowsCryptoManagerException() {
-        ReflectionTestUtils.setField(derivedKeyCryptoUtil, "passwordAlgorithm", "InvalidAlgo");
+        derivedKeyCryptoUtil = new DerivedKeyCryptoUtil(256, 100000, "InvalidAlgo");
         InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
             invokeHash(USER_PIN.getBytes(), SALT);
         });

--- a/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
+++ b/src/test/java/io/mosip/mimoto/util/DerivedKeyCryptoUtilTest.java
@@ -38,10 +38,13 @@ class DerivedKeyCryptoUtilTest {
     private static final String USER_PIN = "12345";
     private static final byte[] SALT = "testsalt123456789012345678901234".getBytes();
     private static final byte[] NONCE = "testnonce123".getBytes();
+    private static final int DEFAULT_KEY_SIZE = 256;
+    private static final int DEFAULT_ITERATIONS = 100000;
+    private static final String DEFAULT_ALGORITHM = "PBKDF2WithHmacSHA512";
 
     @BeforeEach
     void setUp() {
-        derivedKeyCryptoUtil = new DerivedKeyCryptoUtil(256, 100000, "PBKDF2WithHmacSHA512");
+        derivedKeyCryptoUtil = new DerivedKeyCryptoUtil(DEFAULT_KEY_SIZE, DEFAULT_ITERATIONS, DEFAULT_ALGORITHM);
     }
 
     private byte[] encrypt(String data, SecretKey key, byte[] nonce, byte[] aad) throws Exception {
@@ -187,7 +190,7 @@ class DerivedKeyCryptoUtilTest {
 
     @Test
     void testHashThrowsCryptoManagerException() {
-        derivedKeyCryptoUtil = new DerivedKeyCryptoUtil(256, 100000, "InvalidAlgo");
+        derivedKeyCryptoUtil = new DerivedKeyCryptoUtil(DEFAULT_KEY_SIZE, DEFAULT_ITERATIONS, "InvalidAlgo");
         InvocationTargetException exception = assertThrows(InvocationTargetException.class, () -> {
             invokeHash(USER_PIN.getBytes(), SALT);
         });


### PR DESCRIPTION
Used constructor injection and replaced the reflection tests with mockito tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal services converted to constructor-provided configuration; no change to user-facing behavior.
* **Tests**
  * Test suite updated to instantiate components explicitly (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->