### PR TITLE
[INJIWEB-1435] - Add fallback logic to use Credential issuer host as authorization server

### DIFF
--- a/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
@@ -92,8 +92,13 @@ public class IssuersServiceImpl implements IssuersService {
 
     @Override
     public CredentialIssuerConfiguration getIssuerConfiguration(String issuerId) throws ApiNotAccessibleException, IOException, AuthorizationServerWellknownResponseException, InvalidWellknownResponseException {
-        CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = issuersConfigUtil.getIssuerWellknown(getIssuerDetails(issuerId).getCredential_issuer_host());
-        AuthorizationServerWellKnownResponse authorizationServerWellKnownResponse = issuersConfigUtil.getAuthServerWellknown(credentialIssuerWellKnownResponse.getAuthorizationServers().get(0));
+        String credentialIssuerHost = getIssuerDetails(issuerId).getCredential_issuer_host();
+        CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = issuersConfigUtil.getIssuerWellknown(credentialIssuerHost);
+
+        if(credentialIssuerWellKnownResponse.getAuthorizationServers() == null || credentialIssuerWellKnownResponse.getAuthorizationServers().isEmpty()) {
+            credentialIssuerWellKnownResponse.setAuthorizationServers(List.of(credentialIssuerHost));
+        }
+        AuthorizationServerWellKnownResponse authorizationServerWellKnownResponse = issuersConfigUtil.getAuthServerWellknown(credentialIssuerWellKnownResponse.getAuthorizationServers().getFirst());
 
         return new CredentialIssuerConfiguration(
                 credentialIssuerWellKnownResponse.getCredentialIssuer(),

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -171,6 +172,50 @@ public class IssuersServiceTest {
         CredentialIssuerConfiguration actualCredentialIssuerConfiguration = issuersService.getIssuerConfiguration("Issuer3id");
 
         assertEquals(expectedCredentialIssuerConfiguration, actualCredentialIssuerConfiguration);
+    }
+
+    @Test
+    public void shouldSetAuthorizationServersToCredentialIssuerHostWhenNull() throws AuthorizationServerWellknownResponseException, ApiNotAccessibleException, IOException, InvalidWellknownResponseException {
+        expectedCredentialIssuerWellKnownResponse.setAuthorizationServers(null);
+        Mockito.when(issuersConfigUtil.getIssuerWellknown(credentialIssuerHostUrl))
+                .thenReturn(expectedCredentialIssuerWellKnownResponse);
+        Mockito.when(issuersConfigUtil.getAuthServerWellknown(credentialIssuerHostUrl))
+                .thenReturn(expectedCredentialIssuerConfiguration.getAuthorizationServerWellKnownResponse());
+
+        CredentialIssuerConfiguration actual = issuersService.getIssuerConfiguration(issuerId);
+
+        CredentialIssuerConfiguration expected = new CredentialIssuerConfiguration(
+                expectedCredentialIssuerWellKnownResponse.getCredentialIssuer(),
+                List.of(credentialIssuerHostUrl),
+                expectedCredentialIssuerWellKnownResponse.getCredentialEndPoint(),
+                expectedCredentialIssuerWellKnownResponse.getCredentialConfigurationsSupported(),
+                expectedCredentialIssuerConfiguration.getAuthorizationServerWellKnownResponse()
+        );
+        assertEquals(expected, actual);
+        verify(issuersConfigUtil, times(1)).getAuthServerWellknown(credentialIssuerHostUrl);
+        verify(issuersConfigUtil, never()).getAuthServerWellknown(authServerWellknownUrl);
+    }
+
+    @Test
+    public void shouldSetAuthorizationServersToCredentialIssuerHostWhenEmpty() throws AuthorizationServerWellknownResponseException, ApiNotAccessibleException, IOException, InvalidWellknownResponseException {
+        expectedCredentialIssuerWellKnownResponse.setAuthorizationServers(Collections.emptyList());
+        Mockito.when(issuersConfigUtil.getIssuerWellknown(credentialIssuerHostUrl))
+                .thenReturn(expectedCredentialIssuerWellKnownResponse);
+        Mockito.when(issuersConfigUtil.getAuthServerWellknown(credentialIssuerHostUrl))
+                .thenReturn(expectedCredentialIssuerConfiguration.getAuthorizationServerWellKnownResponse());
+
+        CredentialIssuerConfiguration actual = issuersService.getIssuerConfiguration(issuerId);
+
+        CredentialIssuerConfiguration expected = new CredentialIssuerConfiguration(
+                expectedCredentialIssuerWellKnownResponse.getCredentialIssuer(),
+                List.of(credentialIssuerHostUrl),
+                expectedCredentialIssuerWellKnownResponse.getCredentialEndPoint(),
+                expectedCredentialIssuerWellKnownResponse.getCredentialConfigurationsSupported(),
+                expectedCredentialIssuerConfiguration.getAuthorizationServerWellKnownResponse()
+        );
+        assertEquals(expected, actual);
+        verify(issuersConfigUtil, times(1)).getAuthServerWellknown(credentialIssuerHostUrl);
+        verify(issuersConfigUtil, never()).getAuthServerWellknown(authServerWellknownUrl);
     }
 
     @Test


### PR DESCRIPTION
Align OpenID4VCI issuer metadata with draft-style behavior 
Resolve as candidates from authorization_servers or credential_issuer 
Update tests and issuer config doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of issuer configuration retrieval by handling cases where authorization server information is unavailable in the well-known response.

* **Tests**
  * Added test coverage for issuer configuration retrieval edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->