### PR TITLE
[INJIWEB-1873] - Add Conditional Validation for verifier, bring back fall back redirect logic in case of response_mode is not direct_post

### DIFF
--- a/src/main/java/io/mosip/mimoto/controller/PresentationController.java
+++ b/src/main/java/io/mosip/mimoto/controller/PresentationController.java
@@ -67,7 +67,7 @@ public class PresentationController {
 
         try {
             log.info("Started Presentation Authorization in the controller.");
-            verifierService.validateVerifier(clientId, responseUri);
+            verifierService.validateVerifier(clientId, responseUri, redirectUri);
             PresentationDefinitionDTO presentationDefinitionDTO = objectMapper.readValue(presentationDefinition, PresentationDefinitionDTO.class);
             PresentationRequestDTO presentationRequestDTO = PresentationRequestDTO.builder()
                     .responseType(responseType)

--- a/src/main/java/io/mosip/mimoto/service/VerifierService.java
+++ b/src/main/java/io/mosip/mimoto/service/VerifierService.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public interface VerifierService {
     Optional<VerifierDTO> getVerifierByClientId(String clientId) throws ApiNotAccessibleException, IOException;
-    void validateVerifier(String clientId, String redirectUri) throws ApiNotAccessibleException, JsonProcessingException;
+    void validateVerifier(String clientId, String responseUri, String redirectUri) throws ApiNotAccessibleException, JsonProcessingException;
     VerifiersDTO getTrustedVerifiers() throws ApiNotAccessibleException, IOException;
     boolean isVerifierTrustedByWallet(String verifierId, String walletId);
     boolean isVerifierClientPreregistered(List<Verifier> preRegisteredVerifiers, String urlEncodedVPAuthorizationRequest) throws URISyntaxException;

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -181,7 +181,37 @@ public class PresentationServiceImpl implements PresentationService {
         // Create PresentationSubmission
         String presentationSubmission = constructPresentationSubmission(format, vpDTO, presentationDefinitionDTO, inputDescriptorDTO);
 
-        return postVpToResponseUri(presentationRequestDTO.getResponseUri(), presentationRequestDTO.getRedirectUri(), vpToken, presentationSubmission, presentationRequestDTO.getState(), presentationRequestDTO.getNonce());
+        // If response_uri is present, POST the response
+        if (presentationRequestDTO.getResponseMode() != null && "direct_post".equals(presentationRequestDTO.getResponseMode())) {
+            return postVpToResponseUri(
+                    presentationRequestDTO.getResponseUri(),
+                    presentationRequestDTO.getRedirectUri(),
+                    vpToken,
+                    presentationSubmission,
+                    presentationRequestDTO.getState(),
+                    presentationRequestDTO.getNonce()
+            );
+        }
+
+        // Otherwise, do redirect
+        String redirectString = buildRedirectString(
+                vpToken,
+                presentationRequestDTO.getRedirectUri(),
+                presentationSubmission
+        );
+
+        if (redirectString.length() > maximumResponseHeaderSize) {
+            throw new VPNotCreatedException(ErrorConstants.URI_TOO_LONG.getErrorCode(), ErrorConstants.URI_TOO_LONG.getErrorMessage());
+        }
+
+        return redirectString;
+    }
+
+    private String buildRedirectString(String vpToken, String redirectUri, String presentationSubmission) {
+        return String.format(injiOvpRedirectURLPattern,
+                redirectUri,
+                Base64.getUrlEncoder().encodeToString(vpToken.getBytes(StandardCharsets.UTF_8)),
+                URLEncoder.encode(presentationSubmission, StandardCharsets.UTF_8));
     }
 
     private String createVpToken(VerifiablePresentationDTO vpDTO) throws JsonProcessingException {

--- a/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/PresentationServiceImpl.java
@@ -181,22 +181,7 @@ public class PresentationServiceImpl implements PresentationService {
         // Create PresentationSubmission
         String presentationSubmission = constructPresentationSubmission(format, vpDTO, presentationDefinitionDTO, inputDescriptorDTO);
 
-        // If response_uri is present, POST the response
-        if (presentationRequestDTO.getResponseMode() != null && "direct_post".equals(presentationRequestDTO.getResponseMode())) {
-            return postVpToResponseUri(
-                    presentationRequestDTO.getResponseUri(),
-                    presentationRequestDTO.getRedirectUri(),
-                    vpToken,
-                    presentationSubmission,
-                    presentationRequestDTO.getState(),
-                    presentationRequestDTO.getNonce()
-            );
-        }
-
-        //throw exception if the response_mode is not direct_post
-        else {
-            throw new VPNotCreatedException(ErrorConstants.INVALID_RESPONSE_MODE.getErrorCode(), ErrorConstants.INVALID_RESPONSE_MODE.getErrorMessage());
-        }
+        return postVpToResponseUri(presentationRequestDTO.getResponseUri(), presentationRequestDTO.getRedirectUri(), vpToken, presentationSubmission, presentationRequestDTO.getState(), presentationRequestDTO.getNonce());
     }
 
     private String createVpToken(VerifiablePresentationDTO vpDTO) throws JsonProcessingException {

--- a/src/main/java/io/mosip/mimoto/service/impl/VerifierServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/VerifierServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.util.PathMatcher;
 import org.springframework.cache.annotation.Cacheable;
 
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -71,7 +72,9 @@ public class VerifierServiceImpl implements VerifierService {
         if (responseUri != null && !responseUri.trim().isEmpty()) {
             getVerifierByClientId(clientId).ifPresentOrElse(
                     (verifierDTO) -> {
-                        boolean isValidVerifier = verifierDTO.getResponseUris().stream().anyMatch(registeredResponseUri ->
+                        List<String> registeredResponseUris = Optional.ofNullable(verifierDTO.getResponseUris())
+                                .orElseGet(Collections::emptyList);
+                        boolean isValidVerifier = registeredResponseUris.stream().anyMatch(registeredResponseUri ->
                                 urlValidator.isValid(registeredResponseUri) &&
                                         urlValidator.isValid(responseUri) &&
                                         pathMatcher.match(registeredResponseUri, responseUri));
@@ -90,7 +93,9 @@ public class VerifierServiceImpl implements VerifierService {
         } else {
             getVerifierByClientId(clientId).ifPresentOrElse(
                     (verifierDTO) -> {
-                        boolean isValidVerifier = verifierDTO.getRedirectUris().stream().anyMatch(registeredRedirectUri ->
+                        List<String> registeredRedirectUris = Optional.ofNullable(verifierDTO.getRedirectUris())
+                                .orElseGet(Collections::emptyList);
+                        boolean isValidVerifier = registeredRedirectUris.stream().anyMatch(registeredRedirectUri ->
                                 urlValidator.isValid(registeredRedirectUri) &&
                                         urlValidator.isValid(redirectUri) &&
                                         pathMatcher.match(registeredRedirectUri, redirectUri));

--- a/src/main/java/io/mosip/mimoto/service/impl/VerifierServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/VerifierServiceImpl.java
@@ -66,26 +66,47 @@ public class VerifierServiceImpl implements VerifierService {
     }
 
     @Override
-    public void validateVerifier(String clientId, String responseUri) throws ApiNotAccessibleException, JsonProcessingException {
+    public void validateVerifier(String clientId, String responseUri, String redirectUri) throws ApiNotAccessibleException, JsonProcessingException {
         log.info("Started the presentation Validation");
-        getVerifierByClientId(clientId).ifPresentOrElse(
-            (verifierDTO) -> {
-                boolean isValidVerifier = verifierDTO.getResponseUris().stream().anyMatch(registeredResponseUri ->
-                        urlValidator.isValid(registeredResponseUri) &&
-                        urlValidator.isValid(responseUri) &&
-                        pathMatcher.match(registeredResponseUri, responseUri));
-                if(!isValidVerifier){
-                    throw new InvalidVerifierException(
-                            ErrorConstants.INVALID_RESPONSE_URI.getErrorCode(),
-                            ErrorConstants.INVALID_RESPONSE_URI.getErrorMessage());
-                }
-            },
-            () -> {
-                throw new InvalidVerifierException(
-                        ErrorConstants.INVALID_CLIENT.getErrorCode(),
-                        ErrorConstants.INVALID_CLIENT.getErrorMessage());
-            }
-        );
+        if (responseUri != null && !responseUri.trim().isEmpty()) {
+            getVerifierByClientId(clientId).ifPresentOrElse(
+                    (verifierDTO) -> {
+                        boolean isValidVerifier = verifierDTO.getResponseUris().stream().anyMatch(registeredResponseUri ->
+                                urlValidator.isValid(registeredResponseUri) &&
+                                        urlValidator.isValid(responseUri) &&
+                                        pathMatcher.match(registeredResponseUri, responseUri));
+                        if (!isValidVerifier) {
+                            throw new InvalidVerifierException(
+                                    ErrorConstants.INVALID_RESPONSE_URI.getErrorCode(),
+                                    ErrorConstants.INVALID_RESPONSE_URI.getErrorMessage());
+                        }
+                    },
+                    () -> {
+                        throw new InvalidVerifierException(
+                                ErrorConstants.INVALID_CLIENT.getErrorCode(),
+                                ErrorConstants.INVALID_CLIENT.getErrorMessage());
+                    }
+            );
+        } else {
+            getVerifierByClientId(clientId).ifPresentOrElse(
+                    (verifierDTO) -> {
+                        boolean isValidVerifier = verifierDTO.getRedirectUris().stream().anyMatch(registeredRedirectUri ->
+                                urlValidator.isValid(registeredRedirectUri) &&
+                                        urlValidator.isValid(redirectUri) &&
+                                        pathMatcher.match(registeredRedirectUri, redirectUri));
+                        if (!isValidVerifier) {
+                            throw new InvalidVerifierException(
+                                    ErrorConstants.INVALID_REDIRECT_URI.getErrorCode(),
+                                    ErrorConstants.INVALID_REDIRECT_URI.getErrorMessage());
+                        }
+                    },
+                    () -> {
+                        throw new InvalidVerifierException(
+                                ErrorConstants.INVALID_CLIENT.getErrorCode(),
+                                ErrorConstants.INVALID_CLIENT.getErrorMessage());
+                    }
+            );
+        }
     }
 
     @Override

--- a/src/test/java/io/mosip/mimoto/controller/PresentationControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/PresentationControllerTest.java
@@ -78,7 +78,7 @@ public class PresentationControllerTest {
                 .thenReturn(mockPresentationDefinitionDTO);
         when(presentationService.authorizePresentation(any(PresentationRequestDTO.class)))
                 .thenReturn(SUCCESS_REDIRECT_URL);
-        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
 
         // Act & Assert
         mockMvc.perform(get("/authorize")
@@ -92,7 +92,7 @@ public class PresentationControllerTest {
                 .andExpect(redirectedUrl(SUCCESS_REDIRECT_URL));
 
         // Verify service calls
-        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         verify(objectMapper).readValue(PRESENTATION_DEFINITION_JSON, PresentationDefinitionDTO.class);
 
         ArgumentCaptor<PresentationRequestDTO> captor = ArgumentCaptor.forClass(PresentationRequestDTO.class);
@@ -113,7 +113,7 @@ public class PresentationControllerTest {
         String errorMessage = "Invalid verifier provided";
         InvalidVerifierException exception = new InvalidVerifierException(errorCode, errorMessage);
 
-        doThrow(exception).when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doThrow(exception).when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
 
         String expectedRedirectUrl = String.format(
                 "https://inji.web.redirect.url?error_code=%s&error_message=%s",
@@ -132,7 +132,7 @@ public class PresentationControllerTest {
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl(expectedRedirectUrl));
 
-        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         verify(presentationService, never()).authorizePresentation(any());
     }
 
@@ -146,7 +146,7 @@ public class PresentationControllerTest {
         PresentationDefinitionDTO mockPresentationDefinitionDTO = new PresentationDefinitionDTO();
         when(objectMapper.readValue(PRESENTATION_DEFINITION_JSON, PresentationDefinitionDTO.class))
                 .thenReturn(mockPresentationDefinitionDTO);
-        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         when(presentationService.authorizePresentation(any(PresentationRequestDTO.class)))
                 .thenThrow(exception);
 
@@ -168,7 +168,7 @@ public class PresentationControllerTest {
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl(expectedRedirectUrl));
 
-        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         verify(presentationService).authorizePresentation(any(PresentationRequestDTO.class));
     }
 
@@ -182,7 +182,7 @@ public class PresentationControllerTest {
         PresentationDefinitionDTO mockPresentationDefinitionDTO = new PresentationDefinitionDTO();
         when(objectMapper.readValue(PRESENTATION_DEFINITION_JSON, PresentationDefinitionDTO.class))
                 .thenReturn(mockPresentationDefinitionDTO);
-        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         when(presentationService.authorizePresentation(any(PresentationRequestDTO.class)))
                 .thenThrow(exception);
 
@@ -204,7 +204,7 @@ public class PresentationControllerTest {
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl(expectedRedirectUrl));
 
-        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         verify(presentationService).authorizePresentation(any(PresentationRequestDTO.class));
     }
 
@@ -216,7 +216,7 @@ public class PresentationControllerTest {
         PresentationDefinitionDTO mockPresentationDefinitionDTO = new PresentationDefinitionDTO();
         when(objectMapper.readValue(PRESENTATION_DEFINITION_JSON, PresentationDefinitionDTO.class))
                 .thenReturn(mockPresentationDefinitionDTO);
-        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         when(presentationService.authorizePresentation(any(PresentationRequestDTO.class)))
                 .thenThrow(exception);
 
@@ -238,7 +238,7 @@ public class PresentationControllerTest {
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl(expectedRedirectUrl));
 
-        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         verify(presentationService).authorizePresentation(any(PresentationRequestDTO.class));
     }
 
@@ -247,7 +247,7 @@ public class PresentationControllerTest {
         // Arrange
         when(objectMapper.readValue(PRESENTATION_DEFINITION_JSON, PresentationDefinitionDTO.class))
                 .thenThrow(new RuntimeException("JSON parsing failed"));
-        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
 
         String expectedRedirectUrl = String.format(
                 "%s?error_code=%s&error_message=%s",
@@ -267,7 +267,7 @@ public class PresentationControllerTest {
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl(expectedRedirectUrl));
 
-        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        verify(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
         verify(presentationService, never()).authorizePresentation(any());
     }
 
@@ -306,7 +306,7 @@ public class PresentationControllerTest {
                 .andExpect(status().isBadRequest());
 
         // Verify no service calls were made
-        verify(verifierService, never()).validateVerifier(anyString(), anyString());
+        verify(verifierService, never()).validateVerifier(anyString(), anyString(), anyString());
         verify(presentationService, never()).authorizePresentation(any());
     }
 
@@ -314,7 +314,7 @@ public class PresentationControllerTest {
     public void testPerformAuthorizationEmptyParameters() throws Exception {
         // Arrange
         doThrow(new InvalidVerifierException("EMPTY_CLIENT_ID", "Client ID cannot be empty"))
-                .when(verifierService).validateVerifier("", "");
+                .when(verifierService).validateVerifier("", "", "");
 
         String expectedRedirectUrl = String.format(
                 "https://inji.web.redirect.url?error_code=%s&error_message=%s",
@@ -347,7 +347,7 @@ public class PresentationControllerTest {
         String specialResponseUri = "https://example.com/v0/verify/vp-submission/direct-post?session=abc";
         when(presentationService.authorizePresentation(any(PresentationRequestDTO.class)))
                 .thenReturn(SUCCESS_REDIRECT_URL);
-        doNothing().when(verifierService).validateVerifier(specialClientId, specialResponseUri);
+        doNothing().when(verifierService).validateVerifier(specialClientId, specialResponseUri, specialRedirectUri);
 
         // Act & Assert
         mockMvc.perform(get("/authorize")
@@ -360,7 +360,7 @@ public class PresentationControllerTest {
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl(SUCCESS_REDIRECT_URL));
 
-        verify(verifierService).validateVerifier(specialClientId, specialResponseUri);
+        verify(verifierService).validateVerifier(specialClientId, specialResponseUri, specialRedirectUri);
         verify(presentationService).authorizePresentation(any(PresentationRequestDTO.class));
     }
 
@@ -385,7 +385,7 @@ public class PresentationControllerTest {
                 .thenReturn(mockPresentationDefinitionDTO);
         when(presentationService.authorizePresentation(any(PresentationRequestDTO.class)))
                 .thenReturn(SUCCESS_REDIRECT_URL);
-        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
 
         mockMvc.perform(get("/authorize")
                         .param("response_type", RESPONSE_TYPE)
@@ -404,7 +404,7 @@ public class PresentationControllerTest {
         String malformedJson = "{invalid_json}";
         when(objectMapper.readValue(malformedJson, PresentationDefinitionDTO.class))
                 .thenThrow(new RuntimeException("Malformed JSON"));
-        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI);
+        doNothing().when(verifierService).validateVerifier(CLIENT_ID, RESPONSE_URI, REDIRECT_URI);
 
         String expectedRedirectUrl = String.format(
                 "%s?error_code=%s&error_message=%s",
@@ -434,7 +434,7 @@ public class PresentationControllerTest {
                         .param("redirect_uri", (String) null))
                 .andExpect(status().isBadRequest());
 
-        verify(verifierService, never()).validateVerifier(anyString(), anyString());
+        verify(verifierService, never()).validateVerifier(anyString(), anyString(), anyString());
         verify(presentationService, never()).authorizePresentation(any());
     }
 

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -28,6 +28,8 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 
@@ -105,6 +107,59 @@ public class PresentationServiceTest {
 
         assertEquals("https://verifier.example.com/success", actualRedirectUrl);
         verify(restApiClient).postApi(eq("https://verifier.example.com/response"), any(), any(), eq(Map.class));
+    }
+
+    @Test
+    public void authorizePresentation_redirectMode_returnsRedirectUrlWithVpTokenAndPresentationSubmission() throws Exception {
+        VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
+        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
+        presentationRequestDTO.setResponseMode(null);
+
+        doReturn(vcCredentialResponse).when(dataShareService).downloadCredentialFromDataShare(eq(presentationRequestDTO));
+        doReturn((VCCredentialProperties) vcCredentialResponse.getCredential()).when(objectMapper)
+                .convertValue(eq(vcCredentialResponse.getCredential()), eq(VCCredentialProperties.class));
+        doReturn("test-data").when(objectMapper).writeValueAsString(any());
+
+        String vpToken = "test-data";
+        String presentationSubmission = "test-data";
+        String redirectUri = presentationRequestDTO.getRedirectUri();
+        String expected = String.format("%s#vp_token=%s&presentation_submission=%s",
+                redirectUri,
+                Base64.getUrlEncoder().encodeToString(vpToken.getBytes(StandardCharsets.UTF_8)),
+                URLEncoder.encode(presentationSubmission, StandardCharsets.UTF_8));
+
+        String actual = presentationService.authorizePresentation(presentationRequestDTO);
+
+        assertEquals(expected, actual);
+        verify(restApiClient, never()).postApi(anyString(), any(), any(), eq(Map.class));
+    }
+
+    @Test
+    public void authorizePresentation_redirectMode_throwsWhenRedirectUrlExceedsMaxHeaderSize() throws Exception {
+        PresentationServiceImpl serviceWithSmallHeaderLimit = new PresentationServiceImpl(
+                dataShareService,
+                objectMapper,
+                restApiClient,
+                "%s#vp_token=%s&presentation_submission=%s",
+                200
+        );
+
+        VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
+        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
+        presentationRequestDTO.setResponseMode(null);
+
+        doReturn(vcCredentialResponse).when(dataShareService).downloadCredentialFromDataShare(eq(presentationRequestDTO));
+        doReturn((VCCredentialProperties) vcCredentialResponse.getCredential()).when(objectMapper)
+                .convertValue(eq(vcCredentialResponse.getCredential()), eq(VCCredentialProperties.class));
+        doReturn("p".repeat(500)).when(objectMapper).writeValueAsString(any());
+
+        VPNotCreatedException ex = assertThrows(VPNotCreatedException.class,
+                () -> serviceWithSmallHeaderLimit.authorizePresentation(presentationRequestDTO));
+
+        assertEquals(
+                ErrorConstants.URI_TOO_LONG.getErrorCode() + " --> " + ErrorConstants.URI_TOO_LONG.getErrorMessage(),
+                ex.getMessage());
+        verify(restApiClient, never()).postApi(anyString(), any(), any(), eq(Map.class));
     }
 
     @Test(expected = VPNotCreatedException.class)

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -151,21 +151,6 @@ public class PresentationServiceTest {
         presentationService.authorizePresentation(presentationRequestDTO);
     }
 
-    @Test(expected = VPNotCreatedException.class)
-    public void uriTooLongWithVPRequest() throws IOException {
-        presentationService = new PresentationServiceImpl(dataShareService, objectMapper, restApiClient, "%s#vp_token=%s&presentation_submission=%s", 10);
-
-        VCCredentialResponse vcCredentialResponse = TestUtilities.getVCCredentialResponseDTO("Ed25519Signature2020");
-        PresentationRequestDTO presentationRequestDTO = TestUtilities.getPresentationRequestDTO();
-
-        when(dataShareService.downloadCredentialFromDataShare(eq(presentationRequestDTO))).thenReturn(vcCredentialResponse);
-        when(objectMapper.convertValue(eq(vcCredentialResponse.getCredential()), eq(VCCredentialProperties.class)))
-                .thenReturn((VCCredentialProperties) vcCredentialResponse.getCredential());
-        when(objectMapper.writeValueAsString(any())).thenReturn("very-long-test-data-that-exceeds-limit");
-
-        presentationService.authorizePresentation(presentationRequestDTO);
-    }
-
     @Test
     public void constructPresentationDefinitionForLdpVcCredential() {
         VCCredentialResponse vcCredentialResponse = createLdpVcCredentialResponse();

--- a/src/test/java/io/mosip/mimoto/service/VerifierServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/VerifierServiceTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -85,6 +86,14 @@ public class VerifierServiceTest {
     }
 
     @Test
+    public void getVerifierByClientIdReturnsRegisteredRedirectUrisForClient() throws ApiNotAccessibleException, IOException {
+        Optional<VerifierDTO> verifier = verifiersService.getVerifierByClientId("test-clientId");
+
+        assertTrue(verifier.isPresent());
+        assertEquals(Collections.singletonList("https://test-redirectUri"), verifier.get().getRedirectUris());
+    }
+
+    @Test
     public void shouldThrowApiNotAccessibleExceptionOnFetchingTrustedVerifiersListFailure() {
         when(utilities.getTrustedVerifiersJsonValue()).thenReturn(null);
         String expectedExceptionMsg = "RESIDENT-APP-026 --> Api not accessible failure";
@@ -98,21 +107,103 @@ public class VerifierServiceTest {
 
     @Test
     public void validateTrustedVerifiersAndDoNothing() throws ApiNotAccessibleException, IOException {
-        PresentationRequestDTO presentationRequestDTO = PresentationRequestDTO.builder().clientId("test-clientId").responseUri("https://test-responseUri").build();
-        verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri());
+        PresentationRequestDTO presentationRequestDTO = PresentationRequestDTO.builder().clientId("test-clientId").responseUri("https://test-responseUri").redirectUri("https://test-redirectUri").build();
+        verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri(), presentationRequestDTO.getRedirectUri());
+    }
+
+    @Test
+    public void validateVerifier_succeedsWhenResponseUriNullAndRedirectUriMatches() throws ApiNotAccessibleException, IOException {
+        verifiersService.validateVerifier("test-clientId", null, "https://test-redirectUri");
+    }
+
+    @Test
+    public void validateVerifierSucceedsWhenResponseUriEmptyAndRedirectUriMatches() throws ApiNotAccessibleException, IOException {
+        verifiersService.validateVerifier("test-clientId", "", "https://test-redirectUri");
+    }
+
+    @Test
+    public void validateVerifierThrowsInvalidRedirectUriWhenRedirectDoesNotMatchRegistered() throws ApiNotAccessibleException, IOException {
+        String expectedMsg = "invalid_redirect_uri --> The requested redirect uri doesn’t match.";
+
+        InvalidVerifierException ex = assertThrows(InvalidVerifierException.class,
+                () -> verifiersService.validateVerifier("test-clientId", null, "https://other-app.example/callback"));
+
+        assertEquals(expectedMsg, ex.getMessage());
+    }
+
+    @Test
+    public void validateVerifierThrowsInvalidRedirectUriWhenRedirectUriIsNotAValidUrl() throws ApiNotAccessibleException, IOException {
+        String expectedMsg = "invalid_redirect_uri --> The requested redirect uri doesn’t match.";
+
+        InvalidVerifierException ex = assertThrows(InvalidVerifierException.class,
+                () -> verifiersService.validateVerifier("test-clientId", null, "not-a-valid-url"));
+
+        assertEquals(expectedMsg, ex.getMessage());
+    }
+
+    @Test
+    public void validateVerifierThrowsInvalidRedirectUriWhenRedirectUriNull() throws ApiNotAccessibleException, IOException {
+        String expectedMsg = "invalid_redirect_uri --> The requested redirect uri doesn’t match.";
+
+        InvalidVerifierException ex = assertThrows(InvalidVerifierException.class,
+                () -> verifiersService.validateVerifier("test-clientId", null, null));
+
+        assertEquals(expectedMsg, ex.getMessage());
+    }
+
+    @Test
+    public void validateVerifierThrowsInvalidClientWhenClientNotFoundAndResponseUriSkippedForRedirectValidation() throws ApiNotAccessibleException, IOException {
+        String expectedMsg = "invalid_client --> The requested client doesn’t match.";
+
+        InvalidVerifierException ex = assertThrows(InvalidVerifierException.class,
+                () -> verifiersService.validateVerifier("unknown-client-id", null, "https://test-redirectUri"));
+
+        assertEquals(expectedMsg, ex.getMessage());
+    }
+
+    @Test
+    public void validateVerifierThrowsInvalidRedirectUriWhenRegisteredRedirectUriIsNotAValidUrl() throws Exception {
+        VerifierDTO verifier = VerifierDTO.builder()
+                .clientId("client-with-bad-registered-redirect")
+                .redirectUris(Collections.singletonList("not-a-valid-registered-redirect-uri"))
+                .responseUris(Collections.singletonList("https://cb.example/resp"))
+                .build();
+        VerifiersDTO dto = VerifiersDTO.builder().verifiers(Collections.singletonList(verifier)).build();
+        String json = new ObjectMapper().writeValueAsString(dto);
+        when(utilities.getTrustedVerifiersJsonValue()).thenReturn(json);
+        when(objectMapper.readValue(anyString(), eq(VerifiersDTO.class))).thenReturn(dto);
+
+        String expectedMsg = "invalid_redirect_uri --> The requested redirect uri doesn’t match.";
+
+        InvalidVerifierException ex = assertThrows(InvalidVerifierException.class,
+                () -> verifiersService.validateVerifier("client-with-bad-registered-redirect", null,
+                        "https://valid-redirect.example/callback"));
+
+        assertEquals(expectedMsg, ex.getMessage());
+    }
+
+    @Test
+    public void validateVerifierThrowsInvalidRedirectUriWhenRegisteredRedirectValidButPathDoesNotMatch() throws ApiNotAccessibleException, IOException {
+        String expectedMsg = "invalid_redirect_uri --> The requested redirect uri doesn’t match.";
+
+        InvalidVerifierException ex = assertThrows(InvalidVerifierException.class,
+                () -> verifiersService.validateVerifier("test-clientId", null,
+                        "https://test-redirectUri/extra-path"));
+
+        assertEquals(expectedMsg, ex.getMessage());
     }
 
     @Test(expected = InvalidVerifierException.class)
     public void validateTrustedVerifiersAndThrowInvalidVerifierExceptionWhenClientIdIsIncorrect() throws ApiNotAccessibleException, IOException {
         PresentationRequestDTO presentationRequestDTO = PresentationRequestDTO.builder().clientId("test-clientId2").responseUri("https://test-responseUri").build();
-        verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri());
+        verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri(), presentationRequestDTO.getRedirectUri());
     }
 
     @Test
     public void validateTrustedVerifiersAndThrowInvalidVerifiersExceptionForAInvalidClientId() throws ApiNotAccessibleException, IOException {
         PresentationRequestDTO presentationRequestDTO = PresentationRequestDTO.builder().clientId("test-clientId2").responseUri("https://test-responseUri").build();
         String expectedExceptionMsg = "invalid_client --> The requested client doesn’t match.";
-        InvalidVerifierException actualException = assertThrows(InvalidVerifierException.class, () -> verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri()));
+        InvalidVerifierException actualException = assertThrows(InvalidVerifierException.class, () -> verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri(), presentationRequestDTO.getRedirectUri()));
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
     }
@@ -122,7 +213,7 @@ public class VerifierServiceTest {
         PresentationRequestDTO presentationRequestDTO = PresentationRequestDTO.builder().clientId("test-clientId").responseUri("https://test-reponseUri/invalid-uri").build();
         String expectedExceptionMsg = "invalid_response_uri --> The requested response uri doesn’t match.";
 
-        InvalidVerifierException actualException = assertThrows(InvalidVerifierException.class, () -> verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri()));
+        InvalidVerifierException actualException = assertThrows(InvalidVerifierException.class, () -> verifiersService.validateVerifier(presentationRequestDTO.getClientId(), presentationRequestDTO.getResponseUri(), presentationRequestDTO.getRedirectUri()));
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
     }
@@ -132,7 +223,7 @@ public class VerifierServiceTest {
         String expectedExceptionMsg = "invalid_response_uri --> The requested response uri doesn’t match.";
 
         InvalidVerifierException actualException = assertThrows(InvalidVerifierException.class,
-                () -> verifiersService.validateVerifier("test-clientId", "not-a-valid-url"));
+                () -> verifiersService.validateVerifier("test-clientId", "not-a-valid-url", ""));
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
     }
@@ -153,7 +244,7 @@ public class VerifierServiceTest {
         String expectedExceptionMsg = "invalid_response_uri --> The requested response uri doesn’t match.";
 
         InvalidVerifierException actualException = assertThrows(InvalidVerifierException.class,
-                () -> verifiersService.validateVerifier("test-clientId", "https://test-responseUri"));
+                () -> verifiersService.validateVerifier("test-clientId", "https://test-responseUri", ""));
 
         assertEquals(expectedExceptionMsg, actualException.getMessage());
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verifier validation now accepts an explicit response URI and falls back to validating redirect URIs, supporting both response modes.
  * Presentation flow always performs redirect-based responses when applicable, embedding an encoded token and presentation submission in the redirect.

* **Bug Fixes**
  * Improved URI matching and null-safety for verifier URIs.
  * Added explicit error when redirect payloads exceed allowed header size.

* **Tests**
  * Expanded unit tests covering response-vs-redirect validation and redirect-length error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->