### PR TITLE
[INJIWEB-1891] - Removed unused config from issuers config

### DIFF
--- a/docker-compose/config/mimoto-issuers-config.json
+++ b/docker-compose/config/mimoto-issuers-config.json
@@ -2,7 +2,6 @@
   "issuers": [
     {
       "issuer_id": "StayProtected",
-      "credential_issuer": "StayProtected",
       "display": [
         {
           "name": "StayProtected Insurance",
@@ -18,11 +17,7 @@
       "protocol": "OpenId4VCI",
       "client_id": "wallet-demo",
       "client_alias": "wallet-demo-client",
-      "wellknown_endpoint": "https://injicertify-insurance.collab.mosip.net/v1/certify/issuance/.well-known/openid-credential-issuer",
-      "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
-      "authorization_audience": "https://esignet-insurance.collab.mosip.net/v1/esignet/oauth/v2/token",
       "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/StayProtected",
-      "proxy_token_endpoint": "https://esignet-insurance.collab.mosip.net/v1/esignet/oauth/v2/token",
       "qr_code_type": "OnlineSharing",
       "credential_issuer_host": "https://injicertify-insurance.collab.mosip.net",
       "enabled": "true"

--- a/docker-compose/config/mimoto-issuers-config.json
+++ b/docker-compose/config/mimoto-issuers-config.json
@@ -17,7 +17,7 @@
       "protocol": "OpenId4VCI",
       "client_id": "wallet-demo",
       "client_alias": "wallet-demo-client",
-      "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
+      "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/Mock",
       "qr_code_type": "OnlineSharing",
       "credential_issuer_host": "https://injicertify-mock.collab.mosip.net",
       "enabled": "true"

--- a/docker-compose/config/mimoto-issuers-config.json
+++ b/docker-compose/config/mimoto-issuers-config.json
@@ -1,25 +1,25 @@
 {
   "issuers": [
     {
-      "issuer_id": "StayProtected",
+      "issuer_id": "Mock",
       "display": [
         {
-          "name": "StayProtected Insurance",
+          "name": "Mock Identity",
           "logo": {
-            "url": "https://raw.githubusercontent.com/tw-mosip/file-server/master/StayProtectedInsurance.png",
-            "alt_text": "a square logo of a Sunbird"
+            "url": "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+            "alt_text": "mosip-logo"
           },
-          "language": "en",
-          "title": "Download StayProtected Insurance Credentials",
-          "description": "Download insurance credential"
+          "title": "Mock Identity",
+          "description": "Download Mock Identity Credential",
+          "language": "en"
         }
       ],
       "protocol": "OpenId4VCI",
       "client_id": "wallet-demo",
       "client_alias": "wallet-demo-client",
-      "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/StayProtected",
+      "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
       "qr_code_type": "OnlineSharing",
-      "credential_issuer_host": "https://injicertify-insurance.collab.mosip.net",
+      "credential_issuer_host": "https://injicertify-mock.collab.mosip.net",
       "enabled": "true"
     }
   ]

--- a/src/main/resources/mimoto-issuers-config.json
+++ b/src/main/resources/mimoto-issuers-config.json
@@ -2,7 +2,6 @@
   "issuers": [
     {
       "issuer_id": "StayProtected",
-      "credential_issuer": "StayProtected",
       "display": [
         {
           "name": "StayProtected Insurance",
@@ -18,11 +17,7 @@
       "protocol": "OpenId4VCI",
       "client_id": "wallet-demo",
       "client_alias": "wallet-demo-client",
-      "wellknown_endpoint": "https://injicertify-insurance.collab.mosip.net/v1/certify/issuance/.well-known/openid-credential-issuer",
-      "redirect_uri": "io.mosip.residentapp.inji://oauthredirect",
-      "authorization_audience": "https://esignet-insurance.collab.mosip.net/v1/esignet/oauth/v2/token",
       "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/StayProtected",
-      "proxy_token_endpoint": "https://esignet-insurance.collab.mosip.net/v1/esignet/oauth/v2/token",
       "qr_code_type": "OnlineSharing",
       "credential_issuer_host": "https://injicertify-insurance.collab.mosip.net",
       "enabled": "true"

--- a/src/main/resources/mimoto-issuers-config.json
+++ b/src/main/resources/mimoto-issuers-config.json
@@ -17,7 +17,7 @@
       "protocol": "OpenId4VCI",
       "client_id": "wallet-demo",
       "client_alias": "wallet-demo-client",
-      "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
+      "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/Mock",
       "qr_code_type": "OnlineSharing",
       "credential_issuer_host": "https://injicertify-mock.collab.mosip.net",
       "enabled": "true"

--- a/src/main/resources/mimoto-issuers-config.json
+++ b/src/main/resources/mimoto-issuers-config.json
@@ -1,25 +1,25 @@
 {
   "issuers": [
     {
-      "issuer_id": "StayProtected",
+      "issuer_id": "Mock",
       "display": [
         {
-          "name": "StayProtected Insurance",
+          "name": "Mock Identity",
           "logo": {
-            "url": "https://raw.githubusercontent.com/tw-mosip/file-server/master/StayProtectedInsurance.png",
-            "alt_text": "a square logo of a Sunbird"
+            "url": "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+            "alt_text": "mosip-logo"
           },
-          "language": "en",
-          "title": "Download StayProtected Insurance Credentials",
-          "description": "Download insurance credential"
+          "title": "Mock Identity",
+          "description": "Download Mock Identity Credential",
+          "language": "en"
         }
       ],
       "protocol": "OpenId4VCI",
       "client_id": "wallet-demo",
       "client_alias": "wallet-demo-client",
-      "token_endpoint": "https://localhost:8099/v1/mimoto/get-token/StayProtected",
+      "token_endpoint": "https://api.collab.mosip.net/v1/mimoto/get-token/Mock",
       "qr_code_type": "OnlineSharing",
-      "credential_issuer_host": "https://injicertify-insurance.collab.mosip.net",
+      "credential_issuer_host": "https://injicertify-mock.collab.mosip.net",
       "enabled": "true"
     }
   ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced an issuer entry with a "Mock Identity" issuer, updating visible name, title, description and logo.

* **Chores**
  * Simplified issuer configuration by removing legacy OAuth/OpenID connection fields and updating token and credential-issuer endpoints to point to the mock environment; enabled status remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->