### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/api-test/src/main/java/io/inji/testrig/apirig/mimoto/testrunner/InjiTestRunner.java
+++ b/api-test/src/main/java/io/inji/testrig/apirig/mimoto/testrunner/InjiTestRunner.java
@@ -86,7 +86,7 @@ public class InjiTestRunner {
 			MimotoConfigManager.getEsignetBaseUrl();
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.MIMOTO);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 			


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.MIMOTO), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to properly track the current running module in the health checker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->