### PR TITLE
[INJIWEB-1883] Update the deployment variables used to fetch database hostname and port

### DIFF
--- a/deploy/mimoto/keygen-mimoto.yaml
+++ b/deploy/mimoto/keygen-mimoto.yaml
@@ -4,7 +4,7 @@ extraEnvVars:
       secretKeyRef:
         name: db-common-secrets
         key: db-dbuser-password
-  - name: MOSIP_MIMOTO_DATABASE_HOSTNAME
+  - name: INJI_MIMOTO_DATABASE_HOSTNAME
     value: postgres-postresql.postgres
-  - name: MOSIP_MIMOTO_DATABASE_PORT
+  - name: INJI_MIMOTO_DATABASE_PORT
     value: "5432"

--- a/deploy/mimoto/values.yaml
+++ b/deploy/mimoto/values.yaml
@@ -19,7 +19,7 @@ extraEnvVars:
       secretKeyRef:
         name: db-common-secrets
         key: db-dbuser-password
-  - name: MOSIP_MIMOTO_DATABASE_HOSTNAME
+  - name: INJI_MIMOTO_DATABASE_HOSTNAME
     value: postgres-postgresql.postgres
-  - name: MOSIP_MIMOTO_DATABASE_PORT
+  - name: INJI_MIMOTO_DATABASE_PORT
     value: "5432"

--- a/src/main/resources/application-default.properties
+++ b/src/main/resources/application-default.properties
@@ -66,7 +66,7 @@ mosip.kernel.keymanager.certificate.default.country=IN
 # Specifies the driver class name for the PostgreSQL database, required for the application to interact with the database
 keymanager.persistence.jdbc.driver=org.postgresql.Driver
 # Specifies the JDBC URL for connecting to the PostgreSQL database, required to establish a connection to the inji_mimoto database
-keymanager_database_url = jdbc:postgresql://${mosip.mimoto.database.hostname}:${mosip.mimoto.database.port}/inji_mimoto
+keymanager_database_url = jdbc:postgresql://${inji.mimoto.database.hostname}:${inji.mimoto.database.port}/inji_mimoto
 # Defines the password for accessing the PostgreSQL database, required for authentication
 keymanager_database_password=${db.dbuser.password}
 # Defines the username for accessing the PostgreSQL database, required for authentication
@@ -141,7 +141,7 @@ spring.security.oauth2.client.provider.google.phoneNumberAttribute=phone_number
 
 #Database configuration
 # Specifies the JDBC URL for connecting to the PostgreSQL database, required to establish a connection to the inji_mimoto database
-spring.datasource.url=jdbc:postgresql://${mosip.mimoto.database.hostname}:${mosip.mimoto.database.port}/inji_mimoto
+spring.datasource.url=jdbc:postgresql://${inji.mimoto.database.hostname}:${inji.mimoto.database.port}/inji_mimoto
 # Defines the username for accessing the PostgreSQL database, required for authentication
 spring.datasource.username=mimotouser
 # Defines the password for accessing the PostgreSQL database, required for authentication

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -258,9 +258,9 @@ spring.cache.type=caffeine
 spring.session.store-type=caffeine
 
 # Defines the hostname where the database is hosted
-mosip.mimoto.database.hostname=localhost
+inji.mimoto.database.hostname=localhost
 # Defines the port number on which database is running and available
-mosip.mimoto.database.port=5432
+inji.mimoto.database.port=5432
 
 # Database configuration
 # Defines the username for accessing the PostgreSQL database, required for authentication


### PR DESCRIPTION
Update the deployment variables used to fetch database hostname and port. The updates are done in both keygen job and mimoto service configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration property names across deployment files and application configuration to align with system naming standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->