### PR TITLE
fix(inji-web): add error handling for invalid transaction data in OpenID4VP

### DIFF
--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -100,17 +100,17 @@ public class OpenID4VPService {
         }
         String message = payload.getErrorMessage() != null ? payload.getErrorMessage() : "";
         String code = payload.getErrorCode();
-        String className = OpenID4VPService.class.getSimpleName();
 
         if (code == null || code.isBlank()) {
-            return new OpenID4VPExceptions.AccessDenied(message, className);
+            return new OpenID4VPExceptions.AccessDenied(message, "OpenID4VPService");
         }
         if (OpenID4VPErrorCodes.ACCESS_DENIED.equals(code)) {
-            return new OpenID4VPExceptions.AccessDenied(message, className);
+            return new OpenID4VPExceptions.AccessDenied(message, "OpenID4VPService");
         }
         if (OpenID4VPErrorCodes.INVALID_TRANSACTION_DATA.equals(code)) {
-            return new OpenID4VPExceptions.InvalidTransactionData(message, className);
+            return new OpenID4VPExceptions.InvalidTransactionData(message, "OpenID4VPService");
         }
-        return new OpenID4VPExceptions.InvalidData(message, className, code);
+        // Default to AccessDenied for any unrecognized error codes
+        return new OpenID4VPExceptions.AccessDenied(message, "OpenID4VPService");
     }
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -95,6 +95,9 @@ public class OpenID4VPService {
      * matches (e.g. {@link OpenID4VPErrorCodes#INVALID_TRANSACTION_DATA} vs {@link OpenID4VPErrorCodes#ACCESS_DENIED}).
      */
     static Exception toOpenId4VpException(ErrorDTO payload) {
+        if (payload == null) {
+            throw new IllegalArgumentException("Invalid error payload");
+        }
         String message = payload.getErrorMessage() != null ? payload.getErrorMessage() : "";
         String code = payload.getErrorCode();
         String className = OpenID4VPService.class.getSimpleName();

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -84,17 +84,17 @@ public class OpenID4VPService {
         // authenticateVerifier to populate internal state in OpenID4VP before sending error
         openID4VP.authenticateVerifier(sessionData.getAuthorizationRequest(), preRegisteredVerifiers, sessionData.isVerifierClientPreregistered());
 
-        Exception errorForVerifier = toOpenId4VpException(payload);
+        Exception errorForVerifier = openId4VPErrorException(payload);
         VerifierResponse verifierResponse = openID4VP.sendErrorInfoToVerifier(errorForVerifier);
         log.info("Sent rejection to verifier for presentationId {}. Response: {}", sessionData.getPresentationId(), verifierResponse);
         return verifierResponse;
     }
 
     /**
-     * Maps wallet {@link ErrorDTO#errorCode} to inji-openid4vp exceptions so the verifier OAuth {@code error}
+     * Maps wallet {@link ErrorDTO#errorCode} to inji-openid4vp exceptions {@code error}
      * matches (e.g. {@link OpenID4VPErrorCodes#INVALID_TRANSACTION_DATA} vs {@link OpenID4VPErrorCodes#ACCESS_DENIED}).
      */
-    static Exception toOpenId4VpException(ErrorDTO payload) {
+    private Exception openId4VPErrorException(ErrorDTO payload) {
         if (payload == null) {
             throw new IllegalArgumentException("Invalid error payload");
         }

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -10,6 +10,7 @@ import io.mosip.openID4VP.authorizationRequest.VPFormatSupported;
 import io.mosip.openID4VP.authorizationRequest.Verifier;
 import io.mosip.openID4VP.authorizationRequest.WalletMetadata;
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition;
+import io.mosip.openID4VP.common.OpenID4VPErrorCodes;
 import io.mosip.openID4VP.constants.VPFormatType;
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions;
 import io.mosip.openID4VP.verifier.VerifierResponse;
@@ -81,11 +82,32 @@ public class OpenID4VPService {
                 .toList();
 
         // authenticateVerifier to populate internal state in OpenID4VP before sending error
-        AuthorizationRequest authorizationRequest = openID4VP.authenticateVerifier(sessionData.getAuthorizationRequest(), preRegisteredVerifiers, sessionData.isVerifierClientPreregistered());
+        openID4VP.authenticateVerifier(sessionData.getAuthorizationRequest(), preRegisteredVerifiers, sessionData.isVerifierClientPreregistered());
 
-        OpenID4VPExceptions.AccessDenied accessDeniedException = new OpenID4VPExceptions.AccessDenied(payload.getErrorMessage(), "OpenID4VPService");
-        VerifierResponse verifierResponse = openID4VP.sendErrorInfoToVerifier(accessDeniedException);
+        Exception errorForVerifier = toOpenId4VpException(payload);
+        VerifierResponse verifierResponse = openID4VP.sendErrorInfoToVerifier(errorForVerifier);
         log.info("Sent rejection to verifier for presentationId {}. Response: {}", sessionData.getPresentationId(), verifierResponse);
         return verifierResponse;
+    }
+
+    /**
+     * Maps wallet {@link ErrorDTO#errorCode} to inji-openid4vp exceptions so the verifier OAuth {@code error}
+     * matches (e.g. {@link OpenID4VPErrorCodes#INVALID_TRANSACTION_DATA} vs {@link OpenID4VPErrorCodes#ACCESS_DENIED}).
+     */
+    static Exception toOpenId4VpException(ErrorDTO payload) {
+        String message = payload.getErrorMessage() != null ? payload.getErrorMessage() : "";
+        String code = payload.getErrorCode();
+        String className = OpenID4VPService.class.getSimpleName();
+
+        if (code == null || code.isBlank()) {
+            return new OpenID4VPExceptions.AccessDenied(message, className);
+        }
+        if (OpenID4VPErrorCodes.ACCESS_DENIED.equals(code)) {
+            return new OpenID4VPExceptions.AccessDenied(message, className);
+        }
+        if (OpenID4VPErrorCodes.INVALID_TRANSACTION_DATA.equals(code)) {
+            return new OpenID4VPExceptions.InvalidTransactionData(message, className);
+        }
+        return new OpenID4VPExceptions.InvalidData(message, className, code);
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/OpenID4VPServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/OpenID4VPServiceTest.java
@@ -10,11 +10,14 @@ import io.mosip.mimoto.service.impl.OpenID4VPService;
 import io.mosip.openID4VP.OpenID4VP;
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest;
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.PresentationDefinition;
+import io.mosip.openID4VP.common.OpenID4VPErrorCodes;
+import io.mosip.openID4VP.exceptions.OpenID4VPExceptions;
 import io.mosip.openID4VP.verifier.VerifierResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -357,6 +360,40 @@ public class OpenID4VPServiceTest {
         verify(verifierService).getTrustedVerifiers();
         verify(mockOpenID4VP).authenticateVerifier(eq("authorization-request"), anyList(), eq(true));
         verify(mockOpenID4VP).sendErrorInfoToVerifier(any());
+    }
+
+    @Test
+    public void testSendErrorToVerifierUsesInvalidTransactionDataWhenErrorCodeSet() throws Exception {
+        when(verifierService.getTrustedVerifiers()).thenReturn(mockVerifiersDTO);
+
+        OpenID4VP mockOpenID4VP = mock(OpenID4VP.class);
+        VerifierResponse mockResponse = mock(VerifierResponse.class);
+
+        when(mockOpenID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(mockAuthorizationRequest);
+        when(mockOpenID4VP.sendErrorInfoToVerifier(any())).thenReturn(mockResponse);
+
+        OpenID4VPService spyService = spy(openID4VPService);
+        doReturn(mockOpenID4VP).when(spyService).create(anyString());
+
+        VerifiablePresentationSessionData sessionData = mock(VerifiablePresentationSessionData.class);
+        when(sessionData.getPresentationId()).thenReturn("presentation-123");
+        when(sessionData.getAuthorizationRequest()).thenReturn("authorization-request");
+        when(sessionData.isVerifierClientPreregistered()).thenReturn(true);
+
+        ErrorDTO payload = mock(ErrorDTO.class);
+        when(payload.getErrorCode()).thenReturn(OpenID4VPErrorCodes.INVALID_TRANSACTION_DATA);
+        when(payload.getErrorMessage()).thenReturn("No matching credentials");
+
+        VerifierResponse response = spyService.sendErrorToVerifier(sessionData, payload);
+
+        assertNotNull(response);
+        assertEquals(mockResponse, response);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(mockOpenID4VP).sendErrorInfoToVerifier(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenID4VPExceptions.InvalidTransactionData);
+        assertEquals(OpenID4VPErrorCodes.INVALID_TRANSACTION_DATA,
+                ((OpenID4VPExceptions) captor.getValue()).getErrorCode());
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/OpenID4VPServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/OpenID4VPServiceTest.java
@@ -359,7 +359,11 @@ public class OpenID4VPServiceTest {
         assertEquals(mockResponse, response);
         verify(verifierService).getTrustedVerifiers();
         verify(mockOpenID4VP).authenticateVerifier(eq("authorization-request"), anyList(), eq(true));
-        verify(mockOpenID4VP).sendErrorInfoToVerifier(any());
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(mockOpenID4VP).sendErrorInfoToVerifier(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue() instanceof OpenID4VPExceptions.AccessDenied);
+        assertEquals(OpenID4VPErrorCodes.ACCESS_DENIED,
+                ((OpenID4VPExceptions) errorCaptor.getValue()).getErrorCode());
     }
 
     @Test
@@ -394,6 +398,143 @@ public class OpenID4VPServiceTest {
         assertTrue(captor.getValue() instanceof OpenID4VPExceptions.InvalidTransactionData);
         assertEquals(OpenID4VPErrorCodes.INVALID_TRANSACTION_DATA,
                 ((OpenID4VPExceptions) captor.getValue()).getErrorCode());
+    }
+
+    @Test
+    public void testSendErrorToVerifierWithNullErrorPayload() throws Exception {
+        when(verifierService.getTrustedVerifiers()).thenReturn(mockVerifiersDTO);
+
+        OpenID4VP mockOpenID4VP = mock(OpenID4VP.class);
+        when(mockOpenID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(mockAuthorizationRequest);
+
+        OpenID4VPService spyService = spy(openID4VPService);
+        doReturn(mockOpenID4VP).when(spyService).create(anyString());
+
+        VerifiablePresentationSessionData sessionData = mock(VerifiablePresentationSessionData.class);
+        when(sessionData.getPresentationId()).thenReturn("presentation-123");
+        when(sessionData.getAuthorizationRequest()).thenReturn("authorization-request");
+        when(sessionData.isVerifierClientPreregistered()).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () -> spyService.sendErrorToVerifier(sessionData, null));
+        verify(mockOpenID4VP, never()).sendErrorInfoToVerifier(any());
+    }
+
+    @Test
+    public void testSendErrorToVerifierMapsBlankErrorCodeToAccessDenied() throws Exception {
+        when(verifierService.getTrustedVerifiers()).thenReturn(mockVerifiersDTO);
+
+        OpenID4VP mockOpenID4VP = mock(OpenID4VP.class);
+        VerifierResponse mockResponse = mock(VerifierResponse.class);
+        when(mockOpenID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(mockAuthorizationRequest);
+        when(mockOpenID4VP.sendErrorInfoToVerifier(any())).thenReturn(mockResponse);
+
+        OpenID4VPService spyService = spy(openID4VPService);
+        doReturn(mockOpenID4VP).when(spyService).create(anyString());
+
+        VerifiablePresentationSessionData sessionData = mock(VerifiablePresentationSessionData.class);
+        when(sessionData.getPresentationId()).thenReturn("presentation-123");
+        when(sessionData.getAuthorizationRequest()).thenReturn("authorization-request");
+        when(sessionData.isVerifierClientPreregistered()).thenReturn(true);
+
+        ErrorDTO payload = mock(ErrorDTO.class);
+        when(payload.getErrorCode()).thenReturn("   ");
+        when(payload.getErrorMessage()).thenReturn("msg");
+
+        spyService.sendErrorToVerifier(sessionData, payload);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(mockOpenID4VP).sendErrorInfoToVerifier(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenID4VPExceptions.AccessDenied);
+        assertEquals(OpenID4VPErrorCodes.ACCESS_DENIED,
+                ((OpenID4VPExceptions) captor.getValue()).getErrorCode());
+    }
+
+    @Test
+    public void testSendErrorToVerifierMapsAccessDeniedCodeToAccessDenied() throws Exception {
+        when(verifierService.getTrustedVerifiers()).thenReturn(mockVerifiersDTO);
+
+        OpenID4VP mockOpenID4VP = mock(OpenID4VP.class);
+        VerifierResponse mockResponse = mock(VerifierResponse.class);
+        when(mockOpenID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(mockAuthorizationRequest);
+        when(mockOpenID4VP.sendErrorInfoToVerifier(any())).thenReturn(mockResponse);
+
+        OpenID4VPService spyService = spy(openID4VPService);
+        doReturn(mockOpenID4VP).when(spyService).create(anyString());
+
+        VerifiablePresentationSessionData sessionData = mock(VerifiablePresentationSessionData.class);
+        when(sessionData.getPresentationId()).thenReturn("presentation-123");
+        when(sessionData.getAuthorizationRequest()).thenReturn("authorization-request");
+        when(sessionData.isVerifierClientPreregistered()).thenReturn(true);
+
+        ErrorDTO payload = mock(ErrorDTO.class);
+        when(payload.getErrorCode()).thenReturn(OpenID4VPErrorCodes.ACCESS_DENIED);
+        when(payload.getErrorMessage()).thenReturn("user denied");
+
+        spyService.sendErrorToVerifier(sessionData, payload);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(mockOpenID4VP).sendErrorInfoToVerifier(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenID4VPExceptions.AccessDenied);
+        assertEquals(OpenID4VPErrorCodes.ACCESS_DENIED,
+                ((OpenID4VPExceptions) captor.getValue()).getErrorCode());
+    }
+
+    @Test
+    public void testSendErrorToVerifierMapsUnknownErrorCodeToAccessDenied() throws Exception {
+        when(verifierService.getTrustedVerifiers()).thenReturn(mockVerifiersDTO);
+
+        OpenID4VP mockOpenID4VP = mock(OpenID4VP.class);
+        VerifierResponse mockResponse = mock(VerifierResponse.class);
+        when(mockOpenID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(mockAuthorizationRequest);
+        when(mockOpenID4VP.sendErrorInfoToVerifier(any())).thenReturn(mockResponse);
+
+        OpenID4VPService spyService = spy(openID4VPService);
+        doReturn(mockOpenID4VP).when(spyService).create(anyString());
+
+        VerifiablePresentationSessionData sessionData = mock(VerifiablePresentationSessionData.class);
+        when(sessionData.getPresentationId()).thenReturn("presentation-123");
+        when(sessionData.getAuthorizationRequest()).thenReturn("authorization-request");
+        when(sessionData.isVerifierClientPreregistered()).thenReturn(true);
+
+        ErrorDTO payload = mock(ErrorDTO.class);
+        when(payload.getErrorCode()).thenReturn("invalid_request");
+        when(payload.getErrorMessage()).thenReturn("bad");
+
+        spyService.sendErrorToVerifier(sessionData, payload);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(mockOpenID4VP).sendErrorInfoToVerifier(captor.capture());
+        assertTrue(captor.getValue() instanceof OpenID4VPExceptions.AccessDenied);
+        assertEquals(OpenID4VPErrorCodes.ACCESS_DENIED,
+                ((OpenID4VPExceptions) captor.getValue()).getErrorCode());
+    }
+
+    @Test
+    public void testSendErrorToVerifierUsesEmptyMessageWhenErrorMessageNull() throws Exception {
+        when(verifierService.getTrustedVerifiers()).thenReturn(mockVerifiersDTO);
+
+        OpenID4VP mockOpenID4VP = mock(OpenID4VP.class);
+        VerifierResponse mockResponse = mock(VerifierResponse.class);
+        when(mockOpenID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(mockAuthorizationRequest);
+        when(mockOpenID4VP.sendErrorInfoToVerifier(any())).thenReturn(mockResponse);
+
+        OpenID4VPService spyService = spy(openID4VPService);
+        doReturn(mockOpenID4VP).when(spyService).create(anyString());
+
+        VerifiablePresentationSessionData sessionData = mock(VerifiablePresentationSessionData.class);
+        when(sessionData.getPresentationId()).thenReturn("presentation-123");
+        when(sessionData.getAuthorizationRequest()).thenReturn("authorization-request");
+        when(sessionData.isVerifierClientPreregistered()).thenReturn(true);
+
+        ErrorDTO payload = mock(ErrorDTO.class);
+        when(payload.getErrorCode()).thenReturn(OpenID4VPErrorCodes.ACCESS_DENIED);
+        when(payload.getErrorMessage()).thenReturn(null);
+
+        spyService.sendErrorToVerifier(sessionData, payload);
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(mockOpenID4VP).sendErrorInfoToVerifier(captor.capture());
+        assertEquals("", captor.getValue().getMessage());
     }
 
     @Test


### PR DESCRIPTION
Part of #558
Map INVALID_TRANSACTION_DATA from the rejection ErrorDTO to OpenID4VPExceptions.InvalidTransactionData for OpenID4VP error dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error forwarding to verifiers now maps incoming error codes to specific error types (unrecognized/blank codes default to access-denied). Null error payloads are rejected (IllegalArgumentException) and null error messages are treated as empty strings to ensure consistent error content.

* **Tests**
  * Added unit tests validating error-code-to-error-type mapping, null-payload handling, and the exact error messages sent to verifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->