### PR TITLE
refactor: Use IssuerV2DTO instead of IssuerDTO

### DIFF
--- a/src/main/java/io/mosip/mimoto/config/IssuersValidationConfig.java
+++ b/src/main/java/io/mosip/mimoto/config/IssuersValidationConfig.java
@@ -1,7 +1,7 @@
 package io.mosip.mimoto.config;
 
-import io.mosip.mimoto.dto.IssuerDTO;
-import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
+import io.mosip.mimoto.dto.IssuersV2DTO;
 import io.mosip.mimoto.exception.ApiNotAccessibleException;
 import io.mosip.mimoto.exception.AuthorizationServerWellknownResponseException;
 import io.mosip.mimoto.exception.InvalidWellknownResponseException;
@@ -15,6 +15,7 @@ import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.Validator;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,7 +35,7 @@ public class IssuersValidationConfig implements ApplicationRunner {
         List<String> allErrors = new ArrayList<>();
         AtomicReference<Set<String>> credentialIssuers = new AtomicReference<>(new HashSet<>());
 
-        IssuersDTO issuerDTOList = null;
+        IssuersV2DTO issuerDTOList = null;
         try {
             issuerDTOList = issuersService.getAllIssuers();
         } catch (Exception e) {
@@ -44,11 +45,11 @@ public class IssuersValidationConfig implements ApplicationRunner {
 
         if (issuerDTOList != null) {
             for (int index = 0; index < issuerDTOList.getIssuers().size(); index++) {
-                IssuerDTO issuerDTO = issuerDTOList.getIssuers().get(index);
+                IssuerV2DTO issuerDTO = issuerDTOList.getIssuers().get(index);
                 if (!issuerDTO.getProtocol().equals("OTP")) {
                     Errors errors = new BeanPropertyBindingResult(issuerDTO, "issuerV2DTO");
                     validator.validate(issuerDTO, errors);
-                    String issuerId = issuerDTO.getIssuer_id();
+                    String issuerId = issuerDTO.getIssuerId();
                     boolean issuerHasErrors = false;
 
                     StringBuilder issuerErrors = new StringBuilder();
@@ -62,7 +63,7 @@ public class IssuersValidationConfig implements ApplicationRunner {
 
                     }
 
-                    String[] tokenEndpointArray = issuerDTO.getToken_endpoint().split("/");
+                    String[] tokenEndpointArray = issuerDTO.getTokenEndpoint().split("/");
                     Set<String> currentIssuers = credentialIssuers.get();
 
                     if (!currentIssuers.add(issuerId)) {

--- a/src/main/java/io/mosip/mimoto/dto/IssuerDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/IssuerDTO.java
@@ -66,4 +66,19 @@ public class IssuerDTO {
     @NotBlank
     @Schema(description = "Credential Issuer Host")
     String credential_issuer_host;
+
+
+    public IssuerDTO mapFromIssuerV2DTO(IssuerV2DTO issuerV2DTO) {
+        this.issuer_id = issuerV2DTO.getIssuerId();
+        this.protocol = issuerV2DTO.getProtocol();
+        this.display = issuerV2DTO.getDisplay();
+        this.client_id = issuerV2DTO.getClientId();
+        this.client_alias = issuerV2DTO.getClientAlias();
+        this.token_endpoint = issuerV2DTO.getTokenEndpoint();
+        this.qr_code_type = issuerV2DTO.getQrCodeType();
+        this.enabled = issuerV2DTO.getEnabled();
+        this.credential_issuer_host = issuerV2DTO.getCredentialIssuerHost();
+
+        return this;
+    }
 }

--- a/src/main/java/io/mosip/mimoto/dto/IssuersV2DTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/IssuersV2DTO.java
@@ -7,8 +7,9 @@ import jakarta.validation.Valid;
 
 import java.util.List;
 
+@NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@Data
 public class IssuersV2DTO {
 
     @Valid

--- a/src/main/java/io/mosip/mimoto/dto/mimoto/IssuerConfig.java
+++ b/src/main/java/io/mosip/mimoto/dto/mimoto/IssuerConfig.java
@@ -1,11 +1,11 @@
 package io.mosip.mimoto.dto.mimoto;
 
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import lombok.Data;
 
 @Data
 public class IssuerConfig {
-    private final IssuerDTO issuerDTO;
+    private final IssuerV2DTO issuerDTO;
     private final CredentialIssuerWellKnownResponse wellKnownResponse;
     private final CredentialsSupportedResponse credentialsSupportedResponse;
 }

--- a/src/main/java/io/mosip/mimoto/dto/mimoto/VerifiableCredentialResponseDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/mimoto/VerifiableCredentialResponseDTO.java
@@ -1,7 +1,7 @@
 package io.mosip.mimoto.dto.mimoto;
 
 import io.mosip.mimoto.dto.DisplayDTO;
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -42,7 +42,7 @@ public class VerifiableCredentialResponseDTO {
         DisplayDTO issuerDisplayDTO;
         CredentialSupportedDisplayResponse credentialTypeDisplayDTO;
         if (null != issuerConfig) {
-            IssuerDTO issuerDTO = issuerConfig.getIssuerDTO();
+            IssuerV2DTO issuerDTO = issuerConfig.getIssuerDTO();
             CredentialsSupportedResponse credentialsSupportedResponse = issuerConfig.getCredentialsSupportedResponse();
             if (issuerDTO != null) {
                 issuerDisplayDTO = getIssuerDisplayDTOBasedOnLocale(issuerDTO.getDisplay(), locale);

--- a/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialPDFGeneratorService.java
@@ -19,7 +19,7 @@ import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.constant.LdpVcV1Constants;
 import io.mosip.mimoto.constant.LdpVcV2Constants;
 import io.mosip.mimoto.constant.SdJwtVcConstants;
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerDisplayResponse;
 import io.mosip.mimoto.dto.mimoto.CredentialSupportedDisplayResponse;
 import io.mosip.mimoto.dto.mimoto.CredentialsSupportedResponse;
@@ -99,7 +99,7 @@ public class CredentialPDFGeneratorService {
 
     private static final String CLAIM_169_KEY = "claim169";
     
-    public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
+    public ByteArrayInputStream generatePdfForVerifiableCredential(String credentialConfigurationId, VCCredentialResponse vcCredentialResponse, IssuerV2DTO issuerDTO, CredentialsSupportedResponse credentialsSupportedResponse, String dataShareUrl, String credentialValidity, String locale) throws Exception {
         // Check if the credential can support SVG based rendering
         if (isSvgBasedRenderingSupported(vcCredentialResponse)) {
             log.info("Detected LDP VC v2 credential with svg template, using InjiVcRenderer for PDF generation");
@@ -119,7 +119,7 @@ public class CredentialPDFGeneratorService {
             Map<String, Object> data = getPdfResourceFromVcProperties(displayProperties, credentialsSupportedResponse,
                     vcCredentialResponse, issuerDTO, dataShareUrl, credentialValidity, locale);
 
-            return renderVCInCredentialTemplate(data, issuerDTO.getIssuer_id(), credentialConfigurationId);
+            return renderVCInCredentialTemplate(data, issuerDTO.getIssuerId(), credentialConfigurationId);
         }
     }
 
@@ -127,7 +127,7 @@ public class CredentialPDFGeneratorService {
             LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties,
             CredentialsSupportedResponse credentialsSupportedResponse,
             VCCredentialResponse vcCredentialResponse,
-            IssuerDTO issuerDTO,
+            IssuerV2DTO issuerDTO,
             String dataShareUrl,
             String credentialValidity,
             String userLocale) throws IOException, WriterException {
@@ -186,9 +186,9 @@ public class CredentialPDFGeneratorService {
         });
 
         String qrCodeImage = "";
-        if (QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type())) {
+        if (QRCodeType.OnlineSharing.equals(issuerDTO.getQrCodeType())) {
             qrCodeImage = constructQRCodeWithAuthorizeRequest(vcCredentialResponse, dataShareUrl);
-        } else if (QRCodeType.EmbeddedVC.equals(issuerDTO.getQr_code_type())) {
+        } else if (QRCodeType.EmbeddedVC.equals(issuerDTO.getQrCodeType())) {
             String claim169Qr = extractClaim169Qr(vcCredentialResponse);
             if(!claim169Qr.isEmpty()) {
                 qrCodeImage = constructQRCode(claim169Qr);
@@ -385,14 +385,14 @@ public class CredentialPDFGeneratorService {
         return false;
     }
 
-    private ByteArrayInputStream generatePdfUsingSvgTemplate(VCCredentialResponse vcCredentialResponse, IssuerDTO issuerDTO, String dataShareUrl) throws Exception {
+    private ByteArrayInputStream generatePdfUsingSvgTemplate(VCCredentialResponse vcCredentialResponse, IssuerV2DTO issuerDTO, String dataShareUrl) throws Exception {
         try {
             // Get the ldp_vc credential and convert to string
             String credentialJsonString = objectMapper.writeValueAsString(vcCredentialResponse.getCredential());
 
             // Generate the QR code data to embed into the svg for Online Sharing
             String qrCodeData = null;
-            if (QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type())) {
+            if (QRCodeType.OnlineSharing.equals(issuerDTO.getQrCodeType())) {
                 PresentationDefinitionDTO presentationDefinitionDTO = presentationService.constructPresentationDefinition(vcCredentialResponse);
                 String presentationString = objectMapper.writeValueAsString(presentationDefinitionDTO);
                 qrCodeData = String.format(ovpQRDataPattern, URLEncoder.encode(dataShareUrl, StandardCharsets.UTF_8), URLEncoder.encode(presentationString, StandardCharsets.UTF_8));

--- a/src/main/java/io/mosip/mimoto/service/CredentialRequestService.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialRequestService.java
@@ -1,12 +1,12 @@
 package io.mosip.mimoto.service;
 
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerWellKnownResponse;
 import io.mosip.mimoto.dto.mimoto.VCCredentialRequest;
 
 public interface CredentialRequestService {
     VCCredentialRequest buildRequest(
-            IssuerDTO issuerDTO,
+            IssuerV2DTO issuerDTO,
             String credentialConfigurationId,
             CredentialIssuerWellKnownResponse wellKnownResponse,
             String cNonce,

--- a/src/main/java/io/mosip/mimoto/service/IdpService.java
+++ b/src/main/java/io/mosip/mimoto/service/IdpService.java
@@ -1,6 +1,6 @@
 package io.mosip.mimoto.service;
 
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.VerifiableCredentialRequestDTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerConfiguration;
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.util.Map;
 
 public interface IdpService {
-    HttpEntity<MultiValueMap<String, String>> constructGetTokenRequest(Map<String, String> params, IssuerDTO issuerDTO, String authorizationAudience) throws IOException, IssuerOnboardingException;
+    HttpEntity<MultiValueMap<String, String>> constructGetTokenRequest(Map<String, String> params, IssuerV2DTO issuerDTO, String authorizationAudience) throws IOException, IssuerOnboardingException;
 
     String getTokenEndpoint(CredentialIssuerConfiguration credentialIssuerConfiguration);
 

--- a/src/main/java/io/mosip/mimoto/service/IssuersService.java
+++ b/src/main/java/io/mosip/mimoto/service/IssuersService.java
@@ -18,7 +18,7 @@ public interface IssuersService {
 
     IssuerDTO getIssuerDetails(String issuerId) throws ApiNotAccessibleException, IOException, InvalidIssuerIdException;
 
-    IssuersDTO getAllIssuers() throws ApiNotAccessibleException, IOException;
+    IssuersV2DTO getAllIssuers() throws ApiNotAccessibleException, IOException;
 
     CredentialIssuerConfiguration getIssuerConfiguration(String issuerId) throws ApiNotAccessibleException, IOException, AuthorizationServerWellknownResponseException, InvalidWellknownResponseException;
 

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialRequestServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialRequestServiceImpl.java
@@ -1,7 +1,7 @@
 package io.mosip.mimoto.service.impl;
 
 import io.mosip.mimoto.constant.SigningAlgorithm;
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.mimoto.*;
 import io.mosip.mimoto.service.CredentialFormatHandler;
 import io.mosip.mimoto.service.CredentialFormatHandlerFactory;
@@ -40,7 +40,7 @@ public class CredentialRequestServiceImpl implements CredentialRequestService {
     }
 
     @Override
-    public VCCredentialRequest buildRequest(IssuerDTO issuerDTO,
+    public VCCredentialRequest buildRequest(IssuerV2DTO issuerDTO,
                                             String credentialConfigurationId,
                                             CredentialIssuerWellKnownResponse wellKnownResponse,
                                             String cNonce,
@@ -57,7 +57,7 @@ public class CredentialRequestServiceImpl implements CredentialRequestService {
         } else {
             KeyPair keyPair = SigningKeyUtil.generateKeyPair(signingAlgorithm);
             log.debug("Generated KeyPair for signing signingAlgorithm: {}", signingAlgorithm);
-            jwt = SigningKeyUtil.generateJwt(signingAlgorithm, wellKnownResponse.getCredentialIssuer(), issuerDTO.getClient_id(), cNonce, keyPair);
+            jwt = SigningKeyUtil.generateJwt(signingAlgorithm, wellKnownResponse.getCredentialIssuer(), issuerDTO.getClientId(), cNonce, keyPair);
         }
 
         String format = credentialsSupportedResponse.getFormat();
@@ -105,14 +105,14 @@ public class CredentialRequestServiceImpl implements CredentialRequestService {
                                           String base64EncodedWalletKey,
                                           SigningAlgorithm signingAlgorithm,
                                           CredentialIssuerWellKnownResponse wellKnownResponse,
-                                          IssuerDTO issuerDTO,
+                                          IssuerV2DTO issuerDTO,
                                           String cNonce) throws Exception {
 
         KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64EncodedWalletKey, signingAlgorithm);
 
         return SigningKeyUtil.generateJwt(signingAlgorithm,
                 wellKnownResponse.getCredentialIssuer(),
-                issuerDTO.getClient_id(),
+                issuerDTO.getClientId(),
                 cNonce,
                 keyPair);
     }

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialServiceImpl.java
@@ -2,7 +2,7 @@ package io.mosip.mimoto.service.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.*;
 import io.mosip.mimoto.exception.*;
@@ -10,12 +10,7 @@ import io.mosip.mimoto.model.CredentialMetadata;
 import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.model.VerifiableCredential;
 import io.mosip.mimoto.repository.WalletCredentialsRepository;
-import io.mosip.mimoto.service.CredentialPDFGeneratorService;
-import io.mosip.mimoto.service.CredentialRequestService;
-import io.mosip.mimoto.service.CredentialService;
-import io.mosip.mimoto.service.CredentialVerifierService;
-import io.mosip.mimoto.service.IssuersService;
-import io.mosip.mimoto.service.DataProtectionService;
+import io.mosip.mimoto.service.*;
 import io.mosip.mimoto.util.RestApiClient;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
@@ -68,7 +63,7 @@ public class CredentialServiceImpl implements CredentialService {
 
     @Override
     public ByteArrayInputStream downloadCredentialAsPDF(String issuerId, String credentialConfigurationId, TokenResponseDTO response, String credentialValidity, String locale) throws Exception {
-        IssuerDTO issuerDTO = issuersService.getIssuerDetails(issuerId);
+        IssuerV2DTO issuerDTO = issuersService.getIssuerV2Details(issuerId);
         CredentialIssuerConfiguration credentialIssuerConfiguration = issuersService.getIssuerConfiguration(issuerId);
         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = new CredentialIssuerWellKnownResponse(
                 credentialIssuerConfiguration.getCredentialIssuer(),
@@ -82,7 +77,7 @@ public class CredentialServiceImpl implements CredentialService {
 
         boolean verificationStatus = verifyCredential(vcCredentialResponse, issuerId, credentialConfigurationId);
         if (verificationStatus) {
-            String dataShareUrl = QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type()) ? dataShareService.storeDataInDataShare(objectMapper.writeValueAsString(vcCredentialResponse), credentialValidity) : "";
+            String dataShareUrl = QRCodeType.OnlineSharing.equals(issuerDTO.getQrCodeType()) ? dataShareService.storeDataInDataShare(objectMapper.writeValueAsString(vcCredentialResponse), credentialValidity) : "";
             return credentialPDFGeneratorService.generatePdfForVerifiableCredential(credentialConfigurationId, vcCredentialResponse, issuerDTO, credentialsSupportedResponse, dataShareUrl, credentialValidity, locale);
         }
             throw new VCVerificationException(SIGNATURE_VERIFICATION_EXCEPTION.getErrorCode(),
@@ -200,7 +195,7 @@ public class CredentialServiceImpl implements CredentialService {
                     tokenResponse.getC_nonce(),
                     walletId, base64Key, true);
         } catch (Exception e) {
-            log.error("Failed to generate VC credential request for issuerId: {}", issuerConfig.getIssuerDTO().getIssuer_id(), e);
+            log.error("Failed to generate VC credential request for issuerId: {}", issuerConfig.getIssuerDTO().getIssuerId(), e);
             throw new CredentialProcessingException(
                     CREDENTIAL_DOWNLOAD_EXCEPTION.getErrorCode(),
                     "Unable to generate credential request", e);

--- a/src/main/java/io/mosip/mimoto/service/impl/IdpServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IdpServiceImpl.java
@@ -1,6 +1,6 @@
 package io.mosip.mimoto.service.impl;
 
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.VerifiableCredentialRequestDTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerConfiguration;
@@ -12,19 +12,19 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.http.HttpStatus;
-
-import static io.mosip.mimoto.exception.ErrorConstants.*;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static io.mosip.mimoto.exception.ErrorConstants.INVALID_REQUEST;
 
 @Service
 public class IdpServiceImpl implements IdpService {
@@ -54,14 +54,14 @@ public class IdpServiceImpl implements IdpService {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> constructGetTokenRequest(Map<String, String> params, IssuerDTO issuerDTO, String authorizationAudience) throws IOException, IssuerOnboardingException {
+    public HttpEntity<MultiValueMap<String, String>> constructGetTokenRequest(Map<String, String> params, IssuerV2DTO issuerDTO, String authorizationAudience) throws IOException, IssuerOnboardingException {
         HttpHeaders headers = new HttpHeaders();
         MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
 
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        String clientAssertion = joseUtil.getJWT(issuerDTO.getClient_id(), keyStorePath, fileName, issuerDTO.getClient_alias(), cyptoPassword, authorizationAudience);
+        String clientAssertion = joseUtil.getJWT(issuerDTO.getClientId(), keyStorePath, fileName, issuerDTO.getClientAlias(), cyptoPassword, authorizationAudience);
         map.add("code", params.get("code"));
-        map.add("client_id", issuerDTO.getClient_id());
+        map.add("client_id", issuerDTO.getClientId());
         map.add("grant_type", params.get("grant_type"));
         map.add("redirect_uri", params.get("redirect_uri"));
         map.add("client_assertion", clientAssertion.replace("[", "").replace("]", ""));
@@ -90,7 +90,7 @@ public class IdpServiceImpl implements IdpService {
                 throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Invalid code verifier.");
             }
 
-            IssuerDTO issuerDTO = issuersService.getIssuerDetails(issuerId);
+            IssuerV2DTO issuerDTO = issuersService.getIssuerV2Details(issuerId);
             CredentialIssuerConfiguration credentialIssuerConfiguration = issuersService.getIssuerConfiguration(issuerId);
             String tokenEndpoint = getTokenEndpoint(credentialIssuerConfiguration);
             HttpEntity<MultiValueMap<String, String>> request = constructGetTokenRequest(params, issuerDTO, tokenEndpoint);

--- a/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/IssuersServiceImpl.java
@@ -5,8 +5,14 @@ import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.IssuersDTO;
 import io.mosip.mimoto.dto.IssuersV2DTO;
-import io.mosip.mimoto.dto.mimoto.*;
-import io.mosip.mimoto.exception.*;
+import io.mosip.mimoto.dto.mimoto.AuthorizationServerWellKnownResponse;
+import io.mosip.mimoto.dto.mimoto.CredentialIssuerConfiguration;
+import io.mosip.mimoto.dto.mimoto.CredentialIssuerWellKnownResponse;
+import io.mosip.mimoto.dto.mimoto.IssuerConfig;
+import io.mosip.mimoto.exception.ApiNotAccessibleException;
+import io.mosip.mimoto.exception.AuthorizationServerWellknownResponseException;
+import io.mosip.mimoto.exception.InvalidIssuerIdException;
+import io.mosip.mimoto.exception.InvalidWellknownResponseException;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.util.IssuerConfigUtil;
 import io.mosip.mimoto.util.Utilities;
@@ -42,57 +48,74 @@ public class IssuersServiceImpl implements IssuersService {
     @Override
     @Cacheable(value = "issuersConfig", key = "#p0 ?: 'allIssuersConfig'")
     public IssuersDTO getIssuers(String search) throws ApiNotAccessibleException, IOException {
-        IssuersDTO issuersDTO = getAllIssuers();
-        issuersDTO = getAllEnabledIssuers(issuersDTO);
+        IssuersV2DTO issuersDTO = getAllEnabledIssuers();
         issuersDTO = getFilteredIssuers(issuersDTO, search);
 
-        return issuersDTO;
+        return new IssuersDTO(
+                issuersDTO.getIssuers().stream()
+                .map(issuer -> {
+                    try {
+                        return toIssuerDTO(issuer);
+                    } catch (AuthorizationServerWellknownResponseException | ApiNotAccessibleException | IOException |
+                             InvalidWellknownResponseException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList())
+        );
+
     }
 
     @Override
     public IssuerDTO getIssuerDetails(String issuerId) throws ApiNotAccessibleException, IOException {
-        IssuersDTO issuersDTO = getAllIssuers();
-        issuersDTO = getAllEnabledIssuers(issuersDTO);
+        IssuersV2DTO issuersDTO = getAllEnabledIssuers();
 
-        return issuersDTO.getIssuers().stream()
-                .filter(issuer -> issuer.getIssuer_id().equals(issuerId))
+        IssuerV2DTO issuerV2DTO = issuersDTO.getIssuers().stream()
+                .filter(issuer -> issuer.getIssuerId().equals(issuerId))
                 .findFirst()
                 .orElseThrow(InvalidIssuerIdException::new);
+        try {
+            return toIssuerDTO(issuerV2DTO);
+        } catch (AuthorizationServerWellknownResponseException | InvalidWellknownResponseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    private IssuersDTO getAllEnabledIssuers(IssuersDTO issuersDTO) {
-        return new IssuersDTO(issuersDTO.getIssuers().stream()
+    private IssuersV2DTO getAllEnabledIssuers() throws ApiNotAccessibleException, IOException {
+        IssuersV2DTO issuersDTO = getAllIssuers();
+
+        return new IssuersV2DTO(issuersDTO.getIssuers().stream()
                 .filter(issuer -> "true".equals(issuer.getEnabled()))
                 .collect(Collectors.toList()));
     }
 
-    private IssuersDTO getFilteredIssuers(IssuersDTO issuersDTO, String search) {
+    private IssuersV2DTO getFilteredIssuers(IssuersV2DTO issuersDTO, String search) {
         if (StringUtils.isEmpty(search)) {
             return issuersDTO;
         }
 
-        return new IssuersDTO(issuersDTO.getIssuers().stream()
+        return new IssuersV2DTO(issuersDTO.getIssuers().stream()
                 .filter(issuer -> issuer.getDisplay().stream()
                         .anyMatch(displayDTO -> displayDTO.getTitle().toLowerCase().contains(search.toLowerCase())))
                 .collect(Collectors.toList()));
     }
 
     @Override
-    public IssuersDTO getAllIssuers() throws ApiNotAccessibleException, IOException {
-        IssuersDTO issuersDTO;
+    public IssuersV2DTO getAllIssuers() throws ApiNotAccessibleException, IOException {
+        IssuersV2DTO issuersDTO;
         String issuersConfigJsonValue = utilities.getIssuersConfigJsonValue();
         if (issuersConfigJsonValue == null) {
             throw new ApiNotAccessibleException();
         }
 
-        issuersDTO = objectMapper.readValue(issuersConfigJsonValue, IssuersDTO.class);
+        issuersDTO = objectMapper.readValue(issuersConfigJsonValue, IssuersV2DTO.class);
 
         return issuersDTO;
     }
 
     @Override
     public CredentialIssuerConfiguration getIssuerConfiguration(String issuerId) throws ApiNotAccessibleException, IOException, AuthorizationServerWellknownResponseException, InvalidWellknownResponseException {
-        String credentialIssuerHost = getIssuerDetails(issuerId).getCredential_issuer_host();
+        String credentialIssuerHost = getIssuerV2Details(issuerId).getCredentialIssuerHost();
         CredentialIssuerWellKnownResponse credentialIssuerWellKnownResponse = issuersConfigUtil.getIssuerWellknown(credentialIssuerHost);
 
         if(credentialIssuerWellKnownResponse.getAuthorizationServers() == null || credentialIssuerWellKnownResponse.getAuthorizationServers().isEmpty()) {
@@ -113,8 +136,8 @@ public class IssuersServiceImpl implements IssuersService {
     public IssuerConfig getIssuerConfig(String issuerId, @NotBlank String credentialType) throws ApiNotAccessibleException, InvalidIssuerIdException {
         log.info("Fetching issuer config for issuerId: {}", issuerId);
         try {
-            IssuerDTO issuerDTO = getIssuerDetails(issuerId);
-            CredentialIssuerWellKnownResponse wellKnownResponse = issuersConfigUtil.getIssuerWellknown(issuerDTO.getCredential_issuer_host());
+            IssuerV2DTO issuerDTO = getIssuerV2Details(issuerId);
+            CredentialIssuerWellKnownResponse wellKnownResponse = issuersConfigUtil.getIssuerWellknown(issuerDTO.getCredentialIssuerHost());
             return new IssuerConfig(
                     issuerDTO,
                     wellKnownResponse,
@@ -131,34 +154,34 @@ public class IssuersServiceImpl implements IssuersService {
 
     @Override
     public IssuersV2DTO getIssuersV2DTO() throws ApiNotAccessibleException, IOException {
-        IssuersDTO issuersDTO = getIssuers(null);
-        List<IssuerV2DTO> list = issuersDTO.getIssuers().parallelStream().map(this::toIssuerV2DTO).collect(Collectors.toList());
-        return new IssuersV2DTO(list);
+        return getAllEnabledIssuers();
     }
 
     @Override
     public IssuerV2DTO getIssuerV2Details(String issuerId) throws ApiNotAccessibleException, IOException {
-        IssuerDTO issuerDTO = getIssuerDetails(issuerId);
-        return toIssuerV2DTO(issuerDTO);
+        IssuersV2DTO issuersDTO = getAllEnabledIssuers();
+
+        return issuersDTO.getIssuers().stream()
+                .filter(issuer -> issuer.getIssuerId().equals(issuerId))
+                .findFirst()
+                .orElseThrow(InvalidIssuerIdException::new);
     }
 
     /**
-     * Maps an {@link IssuerDTO} (from config) to {@link IssuerV2DTO} (API response).
+     * Maps an {@link IssuerV2DTO} (from config) to {@link IssuerDTO} (API response).
      */
-    private IssuerV2DTO toIssuerV2DTO(IssuerDTO issuer) {
+    private IssuerDTO toIssuerDTO(IssuerV2DTO issuer) throws AuthorizationServerWellknownResponseException, ApiNotAccessibleException, IOException, InvalidWellknownResponseException {
+        String issuerId = issuer.getIssuerId();
+        CredentialIssuerConfiguration issuerConfiguration = getIssuerConfiguration(issuerId);
+        String tokenEndpoint = issuerConfiguration.getAuthorizationServerWellKnownResponse().getTokenEndpoint();
 
-        IssuerV2DTO issuerV2DTO= new  IssuerV2DTO();
+        IssuerDTO issuerDTO = new IssuerDTO().mapFromIssuerV2DTO(issuer);
+        issuerDTO.setCredential_issuer(issuerId);
+        issuerDTO.setWellknown_endpoint(issuer.getCredentialIssuerHost()+"/.well-known/openid-credential-issuer");
+        issuerDTO.setRedirect_uri("io.mosip.residentapp.inji://oauthredirect");
+        issuerDTO.setAuthorization_audience(tokenEndpoint);
+        issuerDTO.setProxy_token_endpoint(tokenEndpoint);
 
-        issuerV2DTO.setIssuerId(issuer.getIssuer_id());
-        issuerV2DTO.setProtocol(issuer.getProtocol());
-        issuerV2DTO.setDisplay(issuer.getDisplay());
-        issuerV2DTO.setClientId(issuer.getClient_id());
-        issuerV2DTO.setTokenEndpoint(issuer.getToken_endpoint());
-        issuerV2DTO.setClientAlias(issuer.getClient_alias());
-        issuerV2DTO.setQrCodeType(issuer.getQr_code_type());
-        issuerV2DTO.setEnabled(issuer.getEnabled());
-        issuerV2DTO.setCredentialIssuerHost(issuer.getCredential_issuer_host());
-
-        return issuerV2DTO;
+        return issuerDTO;
     }
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletCredentialServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletCredentialServiceImpl.java
@@ -3,7 +3,7 @@ package io.mosip.mimoto.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.mimoto.dto.DecryptedCredentialDTO;
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialsSupportedResponse;
 import io.mosip.mimoto.dto.mimoto.IssuerConfig;
@@ -15,11 +15,7 @@ import io.mosip.mimoto.model.CredentialMetadata;
 import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.model.VerifiableCredential;
 import io.mosip.mimoto.repository.WalletCredentialsRepository;
-import io.mosip.mimoto.service.CredentialPDFGeneratorService;
-import io.mosip.mimoto.service.CredentialService;
-import io.mosip.mimoto.service.IssuersService;
-import io.mosip.mimoto.service.WalletCredentialService;
-import io.mosip.mimoto.service.DataProtectionService;
+import io.mosip.mimoto.service.*;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -166,7 +162,7 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
             VCCredentialResponse vcCredentialResponse = objectMapper.readValue(decryptedCredential, VCCredentialResponse.class);
 
             // Fetch issuer details
-            IssuerDTO issuerDTO = issuersService.getIssuerDetails(credentialMetadata.getIssuerId());
+            IssuerV2DTO issuerDTO = issuersService.getIssuerV2Details(credentialMetadata.getIssuerId());
 
             // Fetch issuer configuration
             IssuerConfig issuerConfig = issuersService.getIssuerConfig(credentialMetadata.getIssuerId(), credentialMetadata.getCredentialType());
@@ -183,7 +179,7 @@ public class WalletCredentialServiceImpl implements WalletCredentialService {
                 throw new CredentialProcessingException(CREDENTIAL_FETCH_EXCEPTION.getErrorCode(), "Invalid credential type configuration");
             }
 
-            String dataShareUrl = QRCodeType.OnlineSharing.equals(issuerDTO.getQr_code_type()) ? dataShareService.storeDataInDataShare(objectMapper.writeValueAsString(vcCredentialResponse), credentialValidity) : "";
+            String dataShareUrl = QRCodeType.OnlineSharing.equals(issuerDTO.getQrCodeType()) ? dataShareService.storeDataInDataShare(objectMapper.writeValueAsString(vcCredentialResponse), credentialValidity) : "";
 
 
             // Generate PDF

--- a/src/test/java/io/mosip/mimoto/config/IssuersValidationConfigTest.java
+++ b/src/test/java/io/mosip/mimoto/config/IssuersValidationConfigTest.java
@@ -1,8 +1,8 @@
 package io.mosip.mimoto.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.mosip.mimoto.dto.IssuerDTO;
-import io.mosip.mimoto.dto.IssuersDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
+import io.mosip.mimoto.dto.IssuersV2DTO;
 import io.mosip.mimoto.service.impl.IssuersServiceImpl;
 import org.junit.Assert;
 import org.junit.Test;
@@ -13,9 +13,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
 import java.util.List;
 
-import static io.mosip.mimoto.util.TestUtilities.*;
+import static io.mosip.mimoto.util.TestUtilities.getIssuerConfigDTO;
+import static io.mosip.mimoto.util.TestUtilities.getIssuerConfigDTOWithInvalidFieldValues;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -31,7 +33,7 @@ public class IssuersValidationConfigTest {
     @MockBean
     private IssuersServiceImpl issuersService;
 
-    IssuersDTO issuers = new IssuersDTO();
+    IssuersV2DTO issuers = new IssuersV2DTO();
 
     private static final String VALIDATION_ERROR_MSG = "\n\nValidation failed in Mimoto-issuers-config.json:";
 
@@ -50,7 +52,7 @@ public class IssuersValidationConfigTest {
     @Test
     public void shouldNotValidateIssuersWithProtocolOtp() {
         try {
-            IssuerDTO otpIssuer = getIssuerConfigDTO("OtpIssuer");
+            IssuerV2DTO otpIssuer = getIssuerConfigDTO("OtpIssuer");
             otpIssuer.setProtocol("OTP");
             issuers.setIssuers(List.of(otpIssuer));
             when(issuersService.getAllIssuers()).thenReturn(issuers);

--- a/src/test/java/io/mosip/mimoto/controller/IssuersControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/IssuersControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.IssuersDTO;
 import io.mosip.mimoto.dto.mimoto.CredentialIssuerConfiguration;
 import io.mosip.mimoto.exception.ApiNotAccessibleException;
@@ -161,11 +162,11 @@ public class IssuersControllerTest {
 
     @Test
     public void getIssuerDetailsLogoDtoWithUrlProperty() throws Exception {
-        IssuerDTO issuer = getIssuerConfigDTO("Issuer1");
+        IssuerV2DTO issuer = getIssuerConfigDTO("Issuer1");
         issuer.getDisplay().get(0).getLogo().setUrl("https://example.com/logo-via-url.png");
         issuer.getDisplay().get(0).getLogo().setAlt_text("alt-url");
 
-        Mockito.when(issuersService.getIssuerDetails("id-url")).thenReturn(issuer);
+        Mockito.when(issuersService.getIssuerDetails("id-url")).thenReturn(toIssuerDTO(issuer));
 
         mockMvc.perform(get("/issuers/id-url").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())

--- a/src/test/java/io/mosip/mimoto/controller/IssuersV2ControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/IssuersV2ControllerTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import static io.mosip.mimoto.exception.PlatformErrorMessages.API_NOT_ACCESSIBLE_EXCEPTION;
 import static io.mosip.mimoto.exception.PlatformErrorMessages.INVALID_ISSUER_ID_EXCEPTION;
-import static io.mosip.mimoto.util.TestUtilities.getIssuerResponseDTO;
+import static io.mosip.mimoto.util.TestUtilities.getIssuerConfigDTO;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -61,7 +61,7 @@ public class IssuersV2ControllerTest {
 
     @Test
     public void getAllIssuersSuccessReturnsOkWithIssuersV2DTO() throws Exception {
-        List<IssuerV2DTO> issuerList = List.of(getIssuerResponseDTO("IssuerA"), getIssuerResponseDTO("IssuerB"));
+        List<IssuerV2DTO> issuerList = List.of(getIssuerConfigDTO("IssuerA"), getIssuerConfigDTO("IssuerB"));
         Mockito.when(issuersService.getIssuersV2DTO()).thenReturn(new IssuersV2DTO(issuerList));
 
         performGetList()
@@ -113,7 +113,7 @@ public class IssuersV2ControllerTest {
 
     @Test
     public void getIssuerByIdValidIdReturnsOkWithIssuerV2DTO() throws Exception {
-        IssuerV2DTO issuer = getIssuerResponseDTO("MyIssuer");
+        IssuerV2DTO issuer = getIssuerConfigDTO("MyIssuer");
         Mockito.when(issuersService.getIssuerV2Details("MyIssuerid")).thenReturn(issuer);
 
         performGetIssuer("MyIssuerid")

--- a/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
@@ -26,7 +26,8 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CredentialMatchingServiceTest {
@@ -737,7 +738,7 @@ public class CredentialMatchingServiceTest {
     }
 
     private IssuerConfig createMockIssuerConfig() {
-        IssuerDTO issuerDTO = new IssuerDTO();
+        IssuerV2DTO issuerDTO = new IssuerV2DTO();
         DisplayDTO display = new DisplayDTO();
         display.setName("Test Issuer");
         LogoDTO logoDTO = new LogoDTO();

--- a/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialPDFGeneratorServiceTest.java
@@ -8,10 +8,7 @@ import io.mosip.injivcrenderer.InjiVcRenderer;
 import io.mosip.mimoto.constant.LdpVcV1Constants;
 import io.mosip.mimoto.constant.LdpVcV2Constants;
 import io.mosip.mimoto.constant.SdJwtVcConstants;
-import io.mosip.mimoto.dto.BackgroundImageDTO;
-import io.mosip.mimoto.dto.DisplayDTO;
-import io.mosip.mimoto.dto.IssuerDTO;
-import io.mosip.mimoto.dto.LogoDTO;
+import io.mosip.mimoto.dto.*;
 import io.mosip.mimoto.dto.mimoto.*;
 import io.mosip.mimoto.dto.openid.presentation.PresentationDefinitionDTO;
 import io.mosip.mimoto.model.QRCodeType;
@@ -65,7 +62,7 @@ class CredentialPDFGeneratorServiceTest {
     private CredentialPDFGeneratorService credentialPDFGeneratorService;
 
     private VCCredentialResponse vcCredentialResponse;
-    private IssuerDTO issuerDTO;
+    private IssuerV2DTO issuerDTO;
     private CredentialsSupportedResponse credentialsSupportedResponse;
 
     @BeforeEach
@@ -97,9 +94,9 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(vcProperties)
                 .build();
 
-        issuerDTO = new IssuerDTO();
-        issuerDTO.setIssuer_id("test-issuer");
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO = new IssuerV2DTO();
+        issuerDTO.setIssuerId("test-issuer");
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         DisplayDTO display = new DisplayDTO();
         display.setName("Issuer Display Name");
@@ -165,7 +162,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testGeneratePdfForEmbeddedVCQR() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
         when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
         when(pixelPass.generateQRData(anyString(), anyString())).thenReturn("generated-qr-data");
         when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
@@ -189,7 +186,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testGeneratePdfShouldGeneratePresentationDefinitionForOnlineSharingQrTypeWithNonEmptyDataShareUrl() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
         when(objectMapper.writeValueAsString(any())).thenReturn("{\"credential\":\"data\"}");
         when(utilities.getCredentialSupportedTemplateString(anyString(), anyString()))
                 .thenReturn("<html><body>Test</body></html>");
@@ -668,7 +665,7 @@ class CredentialPDFGeneratorServiceTest {
         ReflectionTestUtils.setField(credentialPDFGeneratorService, "maskDisclosures", true);
 
         when(credentialFormatHandlerFactory.getHandler("vc+sd-jwt")).thenReturn(sdJwtCredentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         String validSdJwt = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOlsiYWJjMTIzIl19.signature~WyJzYWx0IiwgIm5hbWUiLCAiSm9obiBEb2UiXQ~";
 
@@ -1028,7 +1025,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
         when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
@@ -1071,7 +1068,7 @@ class CredentialPDFGeneratorServiceTest {
             .credential(credentialMap)
             .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
         when(injiVcRenderer.generateCredentialDisplayContent(any(), any(), anyString(), any()))
@@ -1098,7 +1095,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
         when(credentialFormatHandler.extractCredentialClaims(any())).thenReturn(Map.of("name", "John"));
@@ -1126,7 +1123,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
         when(credentialFormatHandler.extractCredentialClaims(any())).thenReturn(Map.of("name", "John"));
@@ -1154,7 +1151,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(Map.of("name", "John"));
         when(credentialFormatHandler.loadDisplayPropertiesFromWellknown(any(), any(), anyString()))
@@ -1197,7 +1194,7 @@ class CredentialPDFGeneratorServiceTest {
         when(presentationService.constructPresentationDefinition(any()))
             .thenReturn(new PresentationDefinitionDTO());
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         ByteArrayInputStream result = credentialPDFGeneratorService.generatePdfForVerifiableCredential(
             "TestCredential", vcCredentialResponse, issuerDTO, credentialsSupportedResponse,
@@ -1219,7 +1216,7 @@ class CredentialPDFGeneratorServiceTest {
             .credential(credentialMap)
             .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
 
@@ -1253,7 +1250,7 @@ class CredentialPDFGeneratorServiceTest {
             .credential(credentialMap)
             .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
 
         Map<String, Object> claims = new HashMap<>();
@@ -1303,7 +1300,7 @@ class CredentialPDFGeneratorServiceTest {
             .credential(credentialMap)
             .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(Map.of("name", "John Doe"));
@@ -1334,7 +1331,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
         when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
@@ -1359,7 +1356,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
         when(presentationService.constructPresentationDefinition(any())).thenReturn(new PresentationDefinitionDTO());
@@ -1374,7 +1371,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithValidIdentityQRCode() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         // Setup credential with claim169 containing identityQRCode
         Map<String, Object> claim169Map = new HashMap<>();
@@ -1413,7 +1410,7 @@ class CredentialPDFGeneratorServiceTest {
     @MethodSource("provideClaim169QrFallbackScenarios")
     void testExtractClaim169QrFallbackToVCData(String scenarioName, Map<String, Object> claim169Map) throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         Map<String, Object> subjectData = new HashMap<>();
         subjectData.put("name", "John Doe");
@@ -1464,7 +1461,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithClaim169NotAsMap() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         // Setup credential with claim169 as String (not Map)
         Map<String, Object> subjectData = new HashMap<>();
@@ -1501,7 +1498,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithClaim169Missing() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         // Setup credential without claim169
         Map<String, Object> subjectData = new HashMap<>();
@@ -1538,7 +1535,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithWhitespaceOnlyIdentityQRCode() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         // Setup credential with claim169 containing whitespace-only identityQRCode
         Map<String, Object> claim169Map = new HashMap<>();
@@ -1577,7 +1574,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithSdJwtFormat() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("vc+sd-jwt")).thenReturn(sdJwtCredentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
         vcCredentialResponse.setFormat("vc+sd-jwt");
         String mockSDJWTString = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOltdfQ.signature";
         vcCredentialResponse.setCredential(mockSDJWTString);
@@ -1626,7 +1623,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithNumericIdentityQRCode() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         // Setup credential with claim169 containing numeric identityQRCode (will be converted to string)
         Map<String, Object> claim169Map = new HashMap<>();
@@ -1664,7 +1661,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithEmptyClaim169Map() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         // Setup credential with claim169 as empty Map
         Map<String, Object> claim169Map = new HashMap<>();
@@ -1702,7 +1699,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrWithClaim169AsList() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.EmbeddedVC);
+        issuerDTO.setQrCodeType(QRCodeType.EmbeddedVC);
 
         // Setup credential with claim169 as List (not Map)
         Map<String, Object> subjectData = new HashMap<>();
@@ -1738,7 +1735,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrNotCalledWhenQRCodeTypeIsNone() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         // Setup credential with claim169 containing identityQRCode
         Map<String, Object> claim169Map = new HashMap<>();
@@ -1771,7 +1768,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractClaim169QrNotCalledWhenQRCodeTypeIsNull() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(null);
+        issuerDTO.setQrCodeType(null);
 
         // Setup credential with claim169 containing identityQRCode
         Map<String, Object> claim169Map = new HashMap<>();
@@ -1805,7 +1802,7 @@ class CredentialPDFGeneratorServiceTest {
     void testTitleNameWithMatchingLocaleFromGetPdfResource() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(Map.of("name", "John"));
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         CredentialSupportedDisplayResponse fr = new CredentialSupportedDisplayResponse();
         fr.setName("French Title");
@@ -1839,7 +1836,7 @@ class CredentialPDFGeneratorServiceTest {
     void testTitleNameFallsBackToFirstWhenLocaleNotFoundFromGetPdfResource() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(Map.of("name", "John"));
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         CredentialSupportedDisplayResponse fr = new CredentialSupportedDisplayResponse();
         fr.setName("French Title");
@@ -1873,7 +1870,7 @@ class CredentialPDFGeneratorServiceTest {
     void testTitleNameNullWhenDisplayListNullOrEmptyFromGetPdfResource() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
         when(credentialFormatHandler.extractCredentialClaims(vcCredentialResponse)).thenReturn(Map.of("name", "John"));
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties = new LinkedHashMap<>();
 
@@ -1915,7 +1912,7 @@ class CredentialPDFGeneratorServiceTest {
             LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties,
             CredentialsSupportedResponse credentialsSupportedResponse,
             VCCredentialResponse vcCredentialResponse,
-            IssuerDTO issuerDTO,
+            IssuerV2DTO issuerDTO,
             String dataShareUrl,
             String credentialValidity,
             String locale) throws Exception {
@@ -1924,7 +1921,7 @@ class CredentialPDFGeneratorServiceTest {
                 LinkedHashMap.class,
                 CredentialsSupportedResponse.class,
                 VCCredentialResponse.class,
-                IssuerDTO.class,
+                IssuerV2DTO.class,
                 String.class,
                 String.class,
                 String.class);
@@ -1939,7 +1936,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testIsFaceKeyFalseWhenSelectedFaceKeyNotNullButKeyDoesNotMatch() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         Map<String, Object> subjectData = new HashMap<>();
         subjectData.put("name", "John Doe");
@@ -1971,7 +1968,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testIsFaceKeyTrueWhenSelectedFaceKeyMatchesCurrentKey() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         Map<String, Object> subjectData = new HashMap<>();
         subjectData.put("name", "John Doe");
@@ -2005,7 +2002,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testIsFaceKeyFalseWhenSelectedFaceKeyIsNull() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         Map<String, Object> subjectData = new HashMap<>();
         subjectData.put("name", "John Doe");
@@ -2040,7 +2037,7 @@ class CredentialPDFGeneratorServiceTest {
         ReflectionTestUtils.setField(credentialPDFGeneratorService, "maskDisclosures", false);
         try {
             when(credentialFormatHandlerFactory.getHandler("vc+sd-jwt")).thenReturn(sdJwtCredentialFormatHandler);
-            issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+            issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
 
             String validSdJwt = "eyJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJfc2QiOlsiYWJjMTIzIl19.signature~WyJzYWx0IiwgIm5hbWUiLCAiSm9obiBEb2UiXQ~";
 
@@ -2088,7 +2085,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testDisplayNameNullExcludesFromRowProperties() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         Map<String, Object> extractedClaims = new HashMap<>();
         extractedClaims.put("name", "John Doe");
@@ -2118,7 +2115,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractFaceReturnsNullFaceWhenFaceValueIsNull() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         Map<String, Object> subjectData = new HashMap<>();
         subjectData.put("name", "John Doe");
@@ -2143,7 +2140,7 @@ class CredentialPDFGeneratorServiceTest {
     @Test
     void testExtractFaceReturnsNullFaceWhenFaceValueIsEmptyString() throws Exception {
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         Map<String, Object> subjectData = new HashMap<>();
         subjectData.put("name", "John Doe");
@@ -2266,7 +2263,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
 
         Map<String, Object> claims = new HashMap<>();
@@ -2302,7 +2299,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
 
         Map<String, Object> claims = new HashMap<>();
@@ -2336,7 +2333,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
 
         Map<String, Object> claims = new HashMap<>();
@@ -2370,7 +2367,7 @@ class CredentialPDFGeneratorServiceTest {
                 .credential(credentialMap)
                 .build();
 
-        issuerDTO.setQr_code_type(QRCodeType.OnlineSharing);
+        issuerDTO.setQrCodeType(QRCodeType.OnlineSharing);
         when(credentialFormatHandlerFactory.getHandler("ldp_vc")).thenReturn(credentialFormatHandler);
 
         Map<String, Object> claims = new HashMap<>();

--- a/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialRequestServiceTest.java
@@ -2,16 +2,20 @@ package io.mosip.mimoto.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.mimoto.constant.SigningAlgorithm;
-import io.mosip.mimoto.dto.IssuerDTO;
-import io.mosip.mimoto.dto.mimoto.*;
+import io.mosip.mimoto.dto.IssuerV2DTO;
+import io.mosip.mimoto.dto.mimoto.CredentialIssuerWellKnownResponse;
+import io.mosip.mimoto.dto.mimoto.CredentialsSupportedResponse;
+import io.mosip.mimoto.dto.mimoto.ProofTypesSupported;
+import io.mosip.mimoto.dto.mimoto.VCCredentialRequest;
 import io.mosip.mimoto.repository.ProofSigningKeyRepository;
 import io.mosip.mimoto.service.impl.CredentialRequestServiceImpl;
 import io.mosip.mimoto.service.impl.LdpVcCredentialFormatHandler;
-import io.mosip.mimoto.util.*;
+import io.mosip.mimoto.util.SigningKeyUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,14 +23,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static io.mosip.mimoto.util.TestUtilities.*;
-import static org.junit.Assert.*;
+import static io.mosip.mimoto.util.TestUtilities.getCredentialSupportedResponse;
+import static io.mosip.mimoto.util.TestUtilities.getIssuerConfigDTO;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 @RunWith(SpringRunner.class)
@@ -50,7 +55,7 @@ public class CredentialRequestServiceTest {
 
     private final MockedStatic<SigningKeyUtil> keyGenerationUtilMockedStatic = Mockito.mockStatic(SigningKeyUtil.class, Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
 
-    IssuerDTO issuerDTO;
+    IssuerV2DTO issuerDTO;
     String issuerId;
 
     @Before

--- a/src/test/java/io/mosip/mimoto/service/CredentialServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialServiceTest.java
@@ -1,12 +1,14 @@
 package io.mosip.mimoto.service;
 
-import io.mosip.mimoto.dto.IssuerDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.*;
-import io.mosip.mimoto.exception.InvalidRequestException;
-import io.mosip.mimoto.exception.VCVerificationException;
+import io.mosip.mimoto.exception.*;
 import io.mosip.mimoto.model.QRCodeType;
 import io.mosip.mimoto.model.VerifiableCredential;
+import io.mosip.mimoto.repository.WalletCredentialsRepository;
 import io.mosip.mimoto.service.impl.CredentialServiceImpl;
 import io.mosip.mimoto.service.impl.IssuersServiceImpl;
 import io.mosip.mimoto.util.RestApiClient;
@@ -24,20 +26,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import io.mosip.mimoto.exception.InvalidCredentialResourceException;
-import io.mosip.mimoto.dto.mimoto.VCCredentialRequest;
-import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
-import static org.mockito.Mockito.mock;
-import io.mosip.mimoto.repository.WalletCredentialsRepository;
-import io.mosip.mimoto.dto.mimoto.IssuerConfig;
-import io.mosip.mimoto.dto.mimoto.VerifiableCredentialResponseDTO;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import static io.mosip.mimoto.exception.ErrorConstants.INVALID_REQUEST;
-import io.mosip.mimoto.exception.CredentialProcessingException;
-import static io.mosip.mimoto.exception.ErrorConstants.CREDENTIAL_DOWNLOAD_EXCEPTION;
-import io.mosip.mimoto.exception.ExternalServiceUnavailableException;
-import static io.mosip.mimoto.exception.ErrorConstants.SERVER_UNAVAILABLE;
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
@@ -45,11 +33,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.mosip.mimoto.exception.ErrorConstants.SIGNATURE_VERIFICATION_EXCEPTION;
+import static io.mosip.mimoto.exception.ErrorConstants.*;
 import static io.mosip.mimoto.util.TestUtilities.*;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -85,7 +74,7 @@ public class CredentialServiceTest {
 
     TokenResponseDTO expectedTokenResponse;
     String tokenEndpoint, issuerId;
-    IssuerDTO issuerDTO;
+    IssuerV2DTO issuerDTO;
     HttpEntity<MultiValueMap<String, String>> mockRequest;
     CredentialIssuerConfiguration issuerConfig;
 
@@ -95,7 +84,7 @@ public class CredentialServiceTest {
         issuerDTO = getIssuerConfigDTO(issuerId);
         issuerConfig = getCredentialIssuerConfigurationResponseDto(issuerId, "CredentialType1", List.of());
 
-        Mockito.when(issuersService.getIssuerDetails(issuerId)).thenReturn(issuerDTO);
+        Mockito.when(issuersService.getIssuerV2Details(issuerId)).thenReturn(issuerDTO);
         Mockito.when(issuersService.getIssuerConfiguration(issuerId)).thenReturn(issuerConfig);
 
         tokenEndpoint = issuerConfig.getAuthorizationServerWellKnownResponse().getTokenEndpoint();
@@ -121,9 +110,9 @@ public class CredentialServiceTest {
 
     @Test
     public void shouldThrowExceptionIfDownloadedVCSignatureVerificationFailed() throws Exception {
-        Mockito.when(issuersService.getIssuerDetails(issuerId)).thenReturn(issuerDTO);
+        Mockito.when(issuersService.getIssuerV2Details(issuerId)).thenReturn(issuerDTO);
         Mockito.when(issuersService.getIssuerConfiguration(issuerId)).thenReturn(issuerConfig);
-        when(credentialRequestService.buildRequest(any(IssuerDTO.class),
+        when(credentialRequestService.buildRequest(any(IssuerV2DTO.class),
                 any(String.class),
                 any(CredentialIssuerWellKnownResponse.class),
                 any(String.class), any(), any(), eq(false))).thenReturn(getVCCredentialRequestDTO());
@@ -144,9 +133,9 @@ public class CredentialServiceTest {
 
     @Test
     public void shouldReturnDownloadedVCAsPDFIfSignatureVerificationIsSuccessful() throws Exception {
-        Mockito.when(issuersService.getIssuerDetails(issuerId)).thenReturn(issuerDTO);
+        Mockito.when(issuersService.getIssuerV2Details(issuerId)).thenReturn(issuerDTO);;
         Mockito.when(issuersService.getIssuerConfiguration(issuerId)).thenReturn(issuerConfig);
-        when(credentialRequestService.buildRequest(any(IssuerDTO.class),
+        when(credentialRequestService.buildRequest(any(IssuerV2DTO.class),
                 any(String.class),
                 any(CredentialIssuerWellKnownResponse.class),
                 any(String.class), any(), any(), eq(false))).thenReturn(getVCCredentialRequestDTO());
@@ -159,7 +148,7 @@ public class CredentialServiceTest {
                 any(String.class)
         )).thenReturn(vcCredentialResponse);
         when(credentialVerifierService.verify(any(VCCredentialResponse.class))).thenReturn(true);
-        issuerDTO.setQr_code_type(QRCodeType.None);
+        issuerDTO.setQrCodeType(QRCodeType.None);
 
         ByteArrayInputStream expectedPDFByteArray = generatePdfFromHTML();
         Mockito.when(credentialUtilService.generatePdfForVerifiableCredential(
@@ -236,7 +225,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
         mockWellKnownResponse.setCredentialEndPoint("https://example.com/credential");
 
@@ -280,7 +269,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
         mockWellKnownResponse.setCredentialEndPoint("https://example.com/credential");
 
@@ -407,7 +396,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies for success until buildRequest
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
 
         when(issuerConfig.getIssuerDTO()).thenReturn(mockIssuerDTO);
@@ -438,7 +427,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies for success until downloadCredential
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
         mockWellKnownResponse.setCredentialEndPoint("https://example.com/credential");
 
@@ -472,7 +461,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies for success until verify
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
         mockWellKnownResponse.setCredentialEndPoint("https://example.com/credential");
 
@@ -508,7 +497,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies for success until serialization
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
         mockWellKnownResponse.setCredentialEndPoint("https://example.com/credential");
 
@@ -545,7 +534,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies for success until encryption
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
         mockWellKnownResponse.setCredentialEndPoint("https://example.com/credential");
 
@@ -583,7 +572,7 @@ public class CredentialServiceTest {
 
         // Mock dependencies for success until save
         IssuerConfig issuerConfig = mock(IssuerConfig.class);
-        IssuerDTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
+        IssuerV2DTO mockIssuerDTO = getIssuerConfigDTO(issuerId);
         CredentialIssuerWellKnownResponse mockWellKnownResponse = new CredentialIssuerWellKnownResponse();
         mockWellKnownResponse.setCredentialEndPoint("https://example.com/credential");
 

--- a/src/test/java/io/mosip/mimoto/service/IdpServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IdpServiceTest.java
@@ -1,6 +1,6 @@
 package io.mosip.mimoto.service;
 
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.VerifiableCredentialRequestDTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.AuthorizationServerWellKnownResponse;
@@ -56,7 +56,7 @@ public class IdpServiceTest {
     @Mock
     private TokenResponseDTO tokenResponseDTO;
 
-    private IssuerDTO issuerDTO;
+    private IssuerV2DTO issuerDTO;
     private Map<String, String> params;
     private final String authorizationAudience = "https://example.com/auth";
 
@@ -64,9 +64,9 @@ public class IdpServiceTest {
 
     @Before
     public void setUp() throws IOException {
-        issuerDTO = new IssuerDTO();
-        issuerDTO.setClient_id("client123");
-        issuerDTO.setClient_alias("clientAlias");
+        issuerDTO = new IssuerV2DTO();
+        issuerDTO.setClientId("client123");
+        issuerDTO.setClientAlias("clientAlias");
 
         params = new HashMap<>();
         params.put("code", "sampleCode");
@@ -124,11 +124,11 @@ public class IdpServiceTest {
     public void shouldThrowExceptionIfResponseIsNullWhenFetchingTokenResponse() throws Exception {
         params.put("issuer", "issuer123");
 
-        IssuerDTO mockIssuer = new IssuerDTO();
-        mockIssuer.setClient_id("client123");
-        mockIssuer.setClient_alias("clientAlias");
+        IssuerV2DTO mockIssuer = new IssuerV2DTO();
+        mockIssuer.setClientId("client123");
+        mockIssuer.setClientAlias("clientAlias");
 
-        when(issuersService.getIssuerDetails("issuer123")).thenReturn(mockIssuer);
+        when(issuersService.getIssuerV2Details("issuer123")).thenReturn(mockIssuer);
         when(issuersService.getIssuerConfiguration("issuer123")).thenReturn(credentialIssuerConfiguration);
 
         when(credentialIssuerConfiguration.getAuthorizationServerWellKnownResponse())
@@ -154,11 +154,11 @@ public class IdpServiceTest {
     public void shouldReturnTokenResponseForValidTokenEndpoint() throws Exception {
         params.put("issuer", "issuer123");
 
-        IssuerDTO mockIssuer = new IssuerDTO();
-        mockIssuer.setClient_id("client123");
-        mockIssuer.setClient_alias("clientAlias");
+        IssuerV2DTO mockIssuer = new IssuerV2DTO();
+        mockIssuer.setClientId("client123");
+        mockIssuer.setClientAlias("clientAlias");
 
-        when(issuersService.getIssuerDetails("issuer123")).thenReturn(mockIssuer);
+        when(issuersService.getIssuerV2Details("issuer123")).thenReturn(mockIssuer);
         when(issuersService.getIssuerConfiguration("issuer123")).thenReturn(credentialIssuerConfiguration);
         when(credentialIssuerConfiguration.getAuthorizationServerWellKnownResponse())
                 .thenReturn(authorizationServerWellKnownResponse);
@@ -183,11 +183,11 @@ public class IdpServiceTest {
     public void shouldThrowInvalidRequestExceptionOnBadRequestFromTokenEndpoint() throws Exception {
         params.put("issuer", "issuer123");
 
-        IssuerDTO mockIssuer = new IssuerDTO();
-        mockIssuer.setClient_id("client123");
-        mockIssuer.setClient_alias("clientAlias");
+        IssuerV2DTO mockIssuer = new IssuerV2DTO();
+        mockIssuer.setClientId("client123");
+        mockIssuer.setClientAlias("clientAlias");
 
-        when(issuersService.getIssuerDetails("issuer123")).thenReturn(mockIssuer);
+        when(issuersService.getIssuerV2Details("issuer123")).thenReturn(mockIssuer);
         when(issuersService.getIssuerConfiguration("issuer123")).thenReturn(credentialIssuerConfiguration);
         when(credentialIssuerConfiguration.getAuthorizationServerWellKnownResponse())
                 .thenReturn(authorizationServerWellKnownResponse);
@@ -219,11 +219,11 @@ public class IdpServiceTest {
         requestDTO.setCodeVerifier("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk");
         requestDTO.setIssuer("issuer123");
 
-        IssuerDTO mockIssuer = new IssuerDTO();
-        mockIssuer.setClient_id("client123");
-        mockIssuer.setClient_alias("clientAlias");
+        IssuerV2DTO mockIssuer = new IssuerV2DTO();
+        mockIssuer.setClientId("client123");
+        mockIssuer.setClientAlias("clientAlias");
 
-        when(issuersService.getIssuerDetails("issuer123")).thenReturn(mockIssuer);
+        when(issuersService.getIssuerV2Details("issuer123")).thenReturn(mockIssuer);
         when(issuersService.getIssuerConfiguration("issuer123")).thenReturn(credentialIssuerConfiguration);
         when(credentialIssuerConfiguration.getAuthorizationServerWellKnownResponse())
                 .thenReturn(authorizationServerWellKnownResponse);

--- a/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/IssuersServiceTest.java
@@ -53,7 +53,7 @@ public class IssuersServiceTest {
 
     String issuerWellKnownUrl, issuerId, credentialIssuerHostUrl, authServerWellknownUrl, issuersConfigJsonValue;
     CredentialIssuerConfiguration expectedCredentialIssuerConfiguration;
-    IssuersDTO issuers = new IssuersDTO();
+    IssuersV2DTO issuers = new IssuersV2DTO();
 
     CredentialIssuerWellKnownResponse expectedCredentialIssuerWellKnownResponse;
 
@@ -67,7 +67,7 @@ public class IssuersServiceTest {
         issuers.setIssuers(List.of(getIssuerConfigDTO("Issuer3"), getIssuerConfigDTO("Issuer4")));
         issuersConfigJsonValue = new Gson().toJson(issuers);
         Mockito.when(utilities.getIssuersConfigJsonValue()).thenReturn(issuersConfigJsonValue);
-        Mockito.when(objectMapper.readValue(issuersConfigJsonValue, IssuersDTO.class)).thenReturn(issuers);
+        Mockito.when(objectMapper.readValue(issuersConfigJsonValue, IssuersV2DTO.class)).thenReturn(issuers);
 
         expectedCredentialIssuerWellKnownResponse = getCredentialIssuerWellKnownResponseDto(issuerId,
                 Map.of("CredentialType1", getCredentialSupportedResponse("CredentialType1")));
@@ -83,9 +83,12 @@ public class IssuersServiceTest {
         issuers.setIssuers(List.of(getIssuerConfigDTO("Issuer1"), getIssuerConfigDTO("Issuer2")));
         issuersConfigJsonValue = new Gson().toJson(issuers);
         Mockito.when(utilities.getIssuersConfigJsonValue()).thenReturn(issuersConfigJsonValue);
-        Mockito.when(objectMapper.readValue(issuersConfigJsonValue, IssuersDTO.class)).thenReturn(issuers);
+        Mockito.when(objectMapper.readValue(issuersConfigJsonValue, IssuersV2DTO.class)).thenReturn(issuers);
         IssuersDTO expectedIssuers = new IssuersDTO();
-        List<IssuerDTO> issuers = new ArrayList<>(List.of(getIssuerConfigDTO("Issuer1"), getIssuerConfigDTO("Issuer2")));
+
+        List<IssuerDTO> issuers = new ArrayList<>(List.of(
+                toIssuerDTO(getIssuerConfigDTO("Issuer1")),
+                toIssuerDTO(getIssuerConfigDTO("Issuer2"))));
         expectedIssuers.setIssuers(issuers);
 
         IssuersDTO allIssuers = issuersService.getIssuers(null);
@@ -98,9 +101,9 @@ public class IssuersServiceTest {
         issuers.setIssuers(List.of(getIssuerConfigDTO("Issuer1"), getIssuerConfigDTO("Issuer2")));
         issuersConfigJsonValue = new Gson().toJson(issuers);
         Mockito.when(utilities.getIssuersConfigJsonValue()).thenReturn(issuersConfigJsonValue);
-        Mockito.when(objectMapper.readValue(issuersConfigJsonValue, IssuersDTO.class)).thenReturn(issuers);
+        Mockito.when(objectMapper.readValue(issuersConfigJsonValue, IssuersV2DTO.class)).thenReturn(issuers);
         IssuersDTO expectedFilteredIssuers = new IssuersDTO();
-        List<IssuerDTO> filteredIssuersList = new ArrayList<>(List.of(getIssuerConfigDTO("Issuer1")));
+        List<IssuerDTO> filteredIssuersList = new ArrayList<>(List.of(toIssuerDTO(getIssuerConfigDTO("Issuer1"))));
         expectedFilteredIssuers.setIssuers(filteredIssuersList);
 
         IssuersDTO filteredIssuers = issuersService.getIssuers("Issuer1");
@@ -117,7 +120,7 @@ public class IssuersServiceTest {
 
     @Test
     public void shouldReturnIssuerDataAndConfigForTheIssuerIdIfExist() throws ApiNotAccessibleException, IOException, InvalidIssuerIdException, AuthorizationServerWellknownResponseException, InvalidWellknownResponseException {
-        IssuerDTO expectedIssuer = getIssuerConfigDTO("Issuer3");
+        IssuerDTO expectedIssuer = toIssuerDTO(getIssuerConfigDTO("Issuer3"));
 
         IssuerDTO issuer = issuersService.getIssuerDetails("Issuer3id");
 
@@ -126,11 +129,11 @@ public class IssuersServiceTest {
 
     @Test
     public void shouldReturnIssuerDataAndConfigForAllIssuer() throws ApiNotAccessibleException, IOException {
-        IssuersDTO expectedIssuers = new IssuersDTO();
-        List<IssuerDTO> issuers = new ArrayList<>(List.of(getIssuerConfigDTO("Issuer3"), getIssuerConfigDTO("Issuer4")));
+        IssuersV2DTO expectedIssuers = new IssuersV2DTO();
+        List<IssuerV2DTO> issuers = new ArrayList<>(List.of(getIssuerConfigDTO("Issuer3"), getIssuerConfigDTO("Issuer4")));
         expectedIssuers.setIssuers(issuers);
 
-        IssuersDTO issuersDTO = issuersService.getAllIssuers();
+        IssuersV2DTO issuersDTO = issuersService.getAllIssuers();
 
         assertEquals(expectedIssuers, issuersDTO);
     }
@@ -150,8 +153,8 @@ public class IssuersServiceTest {
     @Test
     public void shouldReturnOnlyEnabledIssuers() throws IOException, ApiNotAccessibleException {
         IssuersDTO issuers = new IssuersDTO();
-        IssuerDTO enabledIssuer = getIssuerConfigDTO("Issuer1");
-        IssuerDTO disabledIssuer = getIssuerConfigDTO("Issuer2");
+        IssuerDTO enabledIssuer = toIssuerDTO(getIssuerConfigDTO("Issuer1"));
+        IssuerDTO disabledIssuer = toIssuerDTO(getIssuerConfigDTO("Issuer2"));
         disabledIssuer.setEnabled("false");
         issuersConfigJsonValue = new Gson().toJson(issuers);
         issuers.setIssuers(List.of(enabledIssuer, disabledIssuer));
@@ -248,7 +251,7 @@ public class IssuersServiceTest {
         // Arrange
         String issuerId = "Issuer3id";
         String credentialType = "CredentialType1";
-        IssuerDTO expectedIssuerDTO = getIssuerConfigDTO("Issuer3");
+        IssuerV2DTO expectedIssuerDTO = getIssuerConfigDTO("Issuer3");
         CredentialIssuerWellKnownResponse wellKnownResponse = getCredentialIssuerWellKnownResponseDto(
                 issuerId, Map.of(credentialType, getCredentialSupportedResponse(credentialType)));
         IssuerConfig expectedIssuerConfig = new IssuerConfig(
@@ -352,7 +355,7 @@ public class IssuersServiceTest {
         assertEquals("123", first.getClientId());
         assertEquals("https://dev/Issuer3id", first.getTokenEndpoint());
         assertEquals("test-client-alias", first.getClientAlias());
-        assertEquals(getIssuerConfigDTO("Issuer3").getQr_code_type(), first.getQrCodeType());
+        assertEquals(getIssuerConfigDTO("Issuer3").getQrCodeType(), first.getQrCodeType());
         assertEquals("true", first.getEnabled());
         assertEquals("https://issuer.env.net", first.getCredentialIssuerHost());
         IssuerV2DTO second = result.getIssuers().get(1);
@@ -371,7 +374,7 @@ public class IssuersServiceTest {
         assertEquals("123", result.getClientId());
         assertEquals("https://dev/Issuer3id", result.getTokenEndpoint());
         assertEquals("test-client-alias", result.getClientAlias());
-        assertEquals(getIssuerConfigDTO("Issuer3").getQr_code_type(), result.getQrCodeType());
+        assertEquals(getIssuerConfigDTO("Issuer3").getQrCodeType(), result.getQrCodeType());
         assertEquals("true", result.getEnabled());
         assertEquals("https://issuer.env.net", result.getCredentialIssuerHost());
         verify(utilities, times(1)).getIssuersConfigJsonValue();

--- a/src/test/java/io/mosip/mimoto/service/WalletCredentialServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/WalletCredentialServiceTest.java
@@ -2,7 +2,7 @@ package io.mosip.mimoto.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.mimoto.dto.DecryptedCredentialDTO;
-import io.mosip.mimoto.dto.IssuerDTO;
+import io.mosip.mimoto.dto.IssuerV2DTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.*;
 import io.mosip.mimoto.dto.resident.WalletCredentialResponseDTO;
@@ -88,8 +88,8 @@ public class WalletCredentialServiceTest {
         verifiableCredential.setCreatedAt(Instant.now());
         verifiableCredential.setUpdatedAt(Instant.now());
 
-        IssuerDTO issuerDTO = new IssuerDTO();
-        issuerDTO.setIssuer_id(issuerId);
+        IssuerV2DTO issuerDTO = new IssuerV2DTO();
+        issuerDTO.setIssuerId(issuerId);
         CredentialIssuerWellKnownResponse wellKnownResponse = new CredentialIssuerWellKnownResponse();
         CredentialsSupportedResponse credentialsSupportedResponse = new CredentialsSupportedResponse();
         issuerConfig = new IssuerConfig(issuerDTO, wellKnownResponse, credentialsSupportedResponse);
@@ -234,9 +234,9 @@ public class WalletCredentialServiceTest {
         when(objectMapper.readValue(decryptedCredentialJson, VCCredentialResponse.class))
                 .thenReturn(vcResponse);
         // IssuerDTO
-        IssuerDTO issuerDTO = new IssuerDTO();
-        issuerDTO.setIssuer_id(issuerId);
-        when(issuersService.getIssuerDetails(issuerId)).thenReturn(issuerDTO);
+        IssuerV2DTO issuerDTO = new IssuerV2DTO();
+        issuerDTO.setIssuerId(issuerId);
+        when(issuersService.getIssuerV2Details(issuerId)).thenReturn(issuerDTO);
 
         // Credential Definition that matches VC type
         CredentialDefinitionResponseDto credentialDefinition = new CredentialDefinitionResponseDto();
@@ -365,7 +365,7 @@ public class WalletCredentialServiceTest {
         when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
         VCCredentialResponse vcResponse = VCCredentialResponse.builder().credential(VCCredentialProperties.builder().type(List.of(credentialType)).build()).build();
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class))).thenReturn(vcResponse);
-        when(issuersService.getIssuerDetails(issuerId)).thenReturn(new IssuerDTO());
+        when(issuersService.getIssuerV2Details(issuerId)).thenReturn(new IssuerV2DTO());
         when(issuersService.getIssuerConfig(issuerId, credentialType)).thenReturn(null);
 
         CredentialProcessingException exception = assertThrows(CredentialProcessingException.class, () ->
@@ -380,14 +380,14 @@ public class WalletCredentialServiceTest {
         when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
         VCCredentialResponse vcResponse = VCCredentialResponse.builder().credential(VCCredentialProperties.builder().type(List.of("OtherType")).build()).build();
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class))).thenReturn(vcResponse);
-        when(issuersService.getIssuerDetails(issuerId)).thenReturn(new IssuerDTO());
+        when(issuersService.getIssuerV2Details(issuerId)).thenReturn(new IssuerV2DTO());
 
         CredentialDefinitionResponseDto credentialDefinition = new CredentialDefinitionResponseDto();
         credentialDefinition.setType(List.of(credentialType));
         CredentialsSupportedResponse supportedResponse = new CredentialsSupportedResponse();
         supportedResponse.setCredentialDefinition(credentialDefinition);
 
-        IssuerConfig issuerConfig = new IssuerConfig(new IssuerDTO(), new CredentialIssuerWellKnownResponse(), supportedResponse);
+        IssuerConfig issuerConfig = new IssuerConfig(new IssuerV2DTO(), new CredentialIssuerWellKnownResponse(), supportedResponse);
         when(issuersService.getIssuerConfig(issuerId, credentialType)).thenReturn(issuerConfig);
 
         CredentialProcessingException exception = assertThrows(CredentialProcessingException.class, () ->
@@ -416,14 +416,14 @@ public class WalletCredentialServiceTest {
         when(dataProtectionService.decryptCredential("encryptedCredential", base64Key)).thenReturn("{}");
         VCCredentialResponse vcResponse = VCCredentialResponse.builder().credential(VCCredentialProperties.builder().type(List.of(credentialType)).build()).build();
         when(objectMapper.readValue(anyString(), eq(VCCredentialResponse.class))).thenReturn(vcResponse);
-        when(issuersService.getIssuerDetails(issuerId)).thenReturn(new IssuerDTO());
+        when(issuersService.getIssuerV2Details(issuerId)).thenReturn(new IssuerV2DTO());
 
         CredentialDefinitionResponseDto credentialDefinition = new CredentialDefinitionResponseDto();
         credentialDefinition.setType(List.of(credentialType));
         CredentialsSupportedResponse supportedResponse = new CredentialsSupportedResponse();
         supportedResponse.setCredentialDefinition(credentialDefinition);
 
-        IssuerConfig issuerConfig = new IssuerConfig(new IssuerDTO(), new CredentialIssuerWellKnownResponse(), supportedResponse);
+        IssuerConfig issuerConfig = new IssuerConfig(new IssuerV2DTO(), new CredentialIssuerWellKnownResponse(), supportedResponse);
         when(issuersService.getIssuerConfig(issuerId, credentialType)).thenReturn(issuerConfig);
 
         when(credentialPDFGeneratorService.generatePdfForVerifiableCredential(any(), any(), any(), any(), any(), any(), any()))

--- a/src/test/java/io/mosip/mimoto/util/TestUtilities.java
+++ b/src/test/java/io/mosip/mimoto/util/TestUtilities.java
@@ -188,28 +188,7 @@ public class TestUtilities {
         return issuer;
     }
 
-    /**
-     * Builds an IssuerResponseDTO for tests (e.g. IssuersController v1 which returns IssuerResponseDTO).
-     */
-    public static IssuerV2DTO getIssuerResponseDTO(String issuerName) {
-        IssuerDTO issuer = getIssuerConfigDTO(issuerName);
-
-        IssuerV2DTO issuerV2DTO= new  IssuerV2DTO();
-
-        issuerV2DTO.setIssuerId(issuer.getIssuer_id());
-        issuerV2DTO.setProtocol(issuer.getProtocol());
-        issuerV2DTO.setDisplay(issuer.getDisplay());
-        issuerV2DTO.setClientId(issuer.getClient_id());
-        issuerV2DTO.setTokenEndpoint(issuer.getToken_endpoint());
-        issuerV2DTO.setClientAlias(issuer.getClient_alias());
-        issuerV2DTO.setQrCodeType(issuer.getQr_code_type());
-        issuerV2DTO.setEnabled(issuer.getEnabled());
-        issuerV2DTO.setCredentialIssuerHost(issuer.getCredential_issuer_host());
-
-        return issuerV2DTO;
-    }
-
-    public static IssuerDTO getIssuerConfigDTO(String issuerName) {
+    public static IssuerV2DTO getIssuerConfigDTO(String issuerName) {
         LogoDTO logo = new LogoDTO();
         logo.setUrl("https://logo");
         logo.setAlt_text("logo-url");
@@ -219,19 +198,24 @@ public class TestUtilities {
         display.setDescription(issuerName + " description");
         display.setLanguage("en");
         display.setLogo(logo);
-        IssuerDTO issuer = new IssuerDTO();
-        issuer.setIssuer_id(issuerName + "id");
+        IssuerV2DTO issuer = new IssuerV2DTO();
+        issuer.setIssuerId(issuerName + "id");
         issuer.setDisplay(Collections.singletonList(display));
-        issuer.setClient_id("123");
-        issuer.setClient_alias("test-client-alias");
+        issuer.setClientId("123");
+        issuer.setClientAlias("test-client-alias");
         issuer.setEnabled("true");
         issuer.setProtocol("OpenId4VCI");
-        issuer.setCredential_issuer_host("https://issuer.env.net");
-        issuer.setToken_endpoint("https://dev/" + issuerName + "id");
+        issuer.setCredentialIssuerHost("https://issuer.env.net");
         return issuer;
     }
 
-    public static IssuerDTO getIssuerConfigDTOWithInvalidFieldValues(String issuerName, boolean emptyValues, boolean invalidUrls) {
+    public static IssuerDTO toIssuerDTO(IssuerV2DTO issuer) {
+        IssuerDTO issuerDTO = new IssuerDTO().mapFromIssuerV2DTO(issuer);
+        issuerDTO.setToken_endpoint("https://dev/" + issuer.getIssuerId());
+        return issuerDTO;
+    }
+
+    public static IssuerV2DTO getIssuerConfigDTOWithInvalidFieldValues(String issuerName, boolean emptyValues, boolean invalidUrls) {
         LogoDTO logo = new LogoDTO();
         logo.setUrl(emptyValues ? "/logo" : "https://logo");
         logo.setAlt_text("logo-url");
@@ -243,17 +227,16 @@ public class TestUtilities {
         display.setLanguage(emptyValues ? "" : "en");
         display.setLogo(logo);
 
-        IssuerDTO issuer = new IssuerDTO();
-        issuer.setIssuer_id(emptyValues ? "" : issuerName + "id");
+        IssuerV2DTO issuer = new IssuerV2DTO();
+        issuer.setIssuerId(emptyValues ? "" : issuerName + "id");
         issuer.setDisplay(Collections.singletonList(display));
-        issuer.setClient_id(emptyValues ? "" : "123");
-        issuer.setClient_alias(emptyValues ? "" : "test-client-alias");
+        issuer.setClientId(emptyValues ? "" : "123");
+        issuer.setClientAlias(emptyValues ? "" : "test-client-alias");
         issuer.setEnabled(emptyValues ? "" : "true");
         issuer.setProtocol(emptyValues ? "" : "OpenId4VCI");
 
         // Handle valid and invalid URLs
-        issuer.setCredential_issuer_host(emptyValues ? "" : (invalidUrls ? "https//issuer.env.net" : "https://issuer.env.net"));
-        issuer.setToken_endpoint(emptyValues ? "" : (invalidUrls ? "h://dev/token" : "https://dev/token"));
+        issuer.setCredentialIssuerHost(emptyValues ? "" : (invalidUrls ? "https//issuer.env.net" : "https://issuer.env.net"));
 
         return issuer;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated issuer configuration to a new standardized schema across services, improving credential issuance, token exchange, QR-code handling, and PDF generation flows.

* **Tests**
  * Updated test fixtures and utilities to align with the new issuer schema and ensure end-to-end validation of issuance, token, QR and PDF behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->