### PR TITLE
[DSD-1203] inji-web 0.17.0 release

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-mimoto</name>
 	<description>Parent project of apitest-mimoto</description>
 	<url>https://github.com/inji/mimoto</url>
-	<version>0.22.0-SNAPSHOT</version>
+	<version>0.22.0</version>
 
 	<licenses>
 		<license>
@@ -61,7 +61,7 @@
 		<maven.source.plugin.version>2.2.1</maven.source.plugin.version>
 
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
-		<fileName>apitest-mimoto-0.22.0-SNAPSHOT-jar-with-dependencies</fileName>
+		<fileName>apitest-mimoto-0.22.0-jar-with-dependencies</fileName>
 	</properties>
 
 	<dependencies>

--- a/db_scripts/init_values.yaml
+++ b/db_scripts/init_values.yaml
@@ -12,4 +12,4 @@ databases:
         name: postgres-postgresql
         key: postgres-password
     dml: 1
-    branch: release-0.22.x
+    branch: v0.22.0

--- a/deploy/mimoto-apitestrig/values.yaml
+++ b/deploy/mimoto-apitestrig/values.yaml
@@ -10,56 +10,8 @@ modules:
   mimoto:
     enabled: true
     image:
-      repository: injistackqa/apitest-mimoto
-      tag: 0.22.x
-      pullPolicy: Always
-  masterdata:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-masterdata
-      tag: develop
-      pullPolicy: Always
-  prereg:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-prereg
-      tag: develop
-      pullPolicy: Always
-  idrepo:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-idrepo
-      tag: develop
-      pullPolicy: Always
-  partner:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-partner
-      tag: develop
-      pullPolicy: Always
-  resident:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-resident
-      tag: develop
-      pullPolicy: Always
-  auth:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-auth
-      tag: develop
-      pullPolicy: Always
-  esignet:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-esignet
-      tag: develop
-      pullPolicy: Always
-  pms:
-    enabled: false
-    image:
-      repository: mosipqa/apitest-pms
-      tag: develop
+      repository: injistack/apitest-mimoto
+      tag: 0.22.0
       pullPolicy: Always
 
 apitestrig:

--- a/deploy/mimoto/install.sh
+++ b/deploy/mimoto/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb
-CHART_VERSION=0.22.0-develop
+CHART_VERSION=0.22.0
 KEYGEN_CHART_VERSION=1.3.0-beta.2
 SOFTHSM_NS=softhsm
 SOFTHSM_CHART_VERSION=1.3.0-beta.2

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: 'injistackqa/mimoto:0.22.x'
+    image: 'injistack/mimoto:0.22.0'
     user: root
     ports:
       - '8099:8099'

--- a/helm/mimoto/Chart.yaml
+++ b/helm/mimoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimoto
 description: A Helm chart for INJI mimoto Application
 type: application
-version: 0.22.0-develop
+version: 0.22.0
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mimoto/values.yaml
+++ b/helm/mimoto/values.yaml
@@ -53,8 +53,8 @@ service:
 
 image:
   registry: docker.io
-  repository: injistackqa/mimoto
-  tag: 0.22.x
+  repository: injistack/mimoto
+  tag: 0.22.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -377,7 +377,7 @@ volumePermissions:
   enabled: true
   image:
     registry: docker.io
-    repository: mosipint/os-shell
+    repository: mosipid/os-shell
     tag: "12-debian-12-r46"
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.

--- a/partner-onboarder/install.sh
+++ b/partner-onboarder/install.sh
@@ -89,7 +89,7 @@ fi
   fi
 
   export NS=$custom_ns
-  CHART_VERSION=0.0.1-develop
+  CHART_VERSION=1.3.0
 
   echo Create $NS namespace
   kubectl create ns $NS || true

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji</groupId>
     <artifactId>mimoto</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>0.22.0</version>
     <name>mimoto</name>
     <url>https://github.com/inji/mimoto</url>
     <description>Mobile server backend supporting Inji.</description>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Release version finalized to 0.22.0 across all build and deployment configurations
* Container images updated to use production registries
* Partner-onboarder module upgraded to version 1.3.0
* Helm chart and related deployment manifests aligned with release version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->