### PR TITLE
feat(openid4vp): present SD-JWT credentials with selective disclosure

### DIFF
--- a/docs/api-documentation-openapi.json
+++ b/docs/api-documentation-openapi.json
@@ -4405,7 +4405,7 @@
                   "schema": {
                     "oneOf": [
                       { "$ref": "#/components/schemas/PresentationSubmissionRequestDTO" },
-                      { "$ref": "#/components/schemas/Error" }
+                      { "$ref": "#/components/schemas/PresentationRejectionRequestDTO" }
                     ]
                   },
                   "examples": {
@@ -5172,7 +5172,28 @@
               },
               "required": [
                 "selectedCredentials"
-              ]
+              ],
+              "additionalProperties": false
+            },
+            "PresentationRejectionRequestDTO": {
+              "type": "object",
+              "properties": {
+                "errorCode": {
+                  "type": "string",
+                  "description": "Error code for rejecting the verifier",
+                  "example": "access_denied"
+                },
+                "errorMessage": {
+                  "type": "string",
+                  "description": "Error message for rejecting the verifier",
+                  "example": "User denied authorization to share credentials"
+                }
+              },
+              "required": [
+                "errorCode",
+                "errorMessage"
+              ],
+              "additionalProperties": false
             },
             "IssuerConfigurationSuccessResponse": {
                 "type": "object",

--- a/docs/api-documentation-openapi.json
+++ b/docs/api-documentation-openapi.json
@@ -4362,192 +4362,200 @@
             }
         },
         "/wallets/{walletId}/presentations/{presentationId}": {
-            "patch": {
-                "tags": [
-                    "Wallet Presentations"
-                ],
-                "summary": "Handles user submission or rejection of a presentation",
-                "description": "This API allows users to accept or reject a presentation request by selecting specific credentials. The API is secured using session-based authentication. For state-changing requests (POST, PUT, DELETE, PATCH), a valid CSRF token must be included in the X-XSRF-TOKEN header. The CSRF token can be obtained from the XSRF-TOKEN cookie set by the server on GET requests. Upon acceptance, the system fetches the selected credentials, constructs and signs a VP token, shares it with the verifier, and stores the presentation record in the database.",
-                "operationId": "handlePresentationSubmission",
-                "parameters": [
-                    {
-                        "name": "walletId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The unique identifier of the Wallet."
-                    },
-                    {
-                        "name": "presentationId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The unique identifier of the Presentation."
-                    },
-                    {
-                        "name": "X-XSRF-TOKEN",
-                        "in": "header",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "CSRF token obtained from the XSRF-TOKEN cookie set by the server on GET requests."
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    { "$ref": "#/components/schemas/PresentationSubmissionRequestDTO" },
-                                    { "$ref": "#/components/schemas/Error" }
-                                ]
-                            },
-                            "examples": {
-                                "Presentation Submission Request": {
-                                    "value": {
-                                        "selectedCredentials": ["cred-123", "cred-456"]
-                                    }
-                                },
-                                "Rejection payload": {
-                                    "value": {
-                                        "errorCode": "access_denied",
-                                        "errorMessage": "User denied authorization to share credentials"
-                                    }
-                                }
-                            }
-                        }
-                    }
+          "patch": {
+            "tags": [
+              "Wallet Presentations"
+            ],
+            "summary": "Handles user submission or rejection of a presentation",
+            "description": "This API allows users to accept or reject a presentation request by selecting specific credentials. For SD-JWT credentials (vc+sd-jwt and dc+sd-jwt), the user may optionally include selectedSdClaims to selectively disclose the chosen claims. Only the explicitly selected disclosures are shared; when omitted (or empty) for an SD-JWT credential, none of its selectively-disclosable claims are shared. The API is secured using session-based authentication. For state-changing requests (POST, PUT, DELETE, PATCH), a valid CSRF token must be included in the X-XSRF-TOKEN header. The CSRF token can be obtained from the XSRF-TOKEN cookie set by the server on GET requests. Upon acceptance, the system fetches the selected credentials, constructs and signs a VP token, shares it with the verifier, and stores the presentation record in the database.",
+            "operationId": "handlePresentationSubmission",
+            "parameters": [
+              {
+                "name": "walletId",
+                "in": "path",
+                "required": true,
+                "schema": {
+                  "type": "string"
                 },
-                "responses": {
-                    "200": {
-                        "description": "Successfully processed the presentation submission.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SubmitPresentationResponseDTO"
-                                },
-                                "examples": {
-                                    "Success response": {
-                                        "value": {
-                                            "status": "success",
-                                            "redirectUri": "https://verifier.example.com/callback?state=af0ifjsldkj",
-                                            "message": "Presentation successfully submitted"
-                                        }
-                                    },
-                                    "Response when successfully rejected": {
-                                        "value": {
-                                            "status": "success",
-                                            "redirectUri": "https://client.example.org/cb#response_code=091535f699ea575c7937fa5f0f454aee",
-                                            "message": "Presentation request rejected. An OpenID4VP error response has been sent to the verifier."
-                                        }
-                                    },
-                                    "Response when an error occurs while submitting a rejection": {
-                                        "value": {
-                                            "status": "error",
-                                            "message": "Failed to submit Verifiable Presentation."
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request or missing required parameters.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                },
-                                "examples": {
-                                    "Invalid Wallet ID": {
-                                        "value": {
-                                            "errorCode": "invalid_request",
-                                            "errorMessage": "Invalid Wallet ID. Session and request Wallet ID do not match"
-                                        }
-                                    },
-                                    "Wallet ID not found in session": {
-                                        "value": {
-                                            "errorCode": "wallet_locked",
-                                            "errorMessage": "Wallet is locked"
-                                        }
-                                    },
-                                    "Credential not found": {
-                                        "value": {
-                                            "errorCode": "invalid_request",
-                                            "errorMessage": "Credential not found: cred-123"
-                                        }
-                                    },
-                                    "presentationId not found in session": {
-                                        "value": { 
-                                            "errorCode": "invalid_request", 
-                                            "errorMessage": "presentationId not found in session" 
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized user performing the presentation submission",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                },
-                                "examples": {
-                                    "User ID is not present in session": {
-                                        "value": {
-                                            "errorCode": "unauthorized",
-                                            "errorMessage": "User ID not found in session"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                },
-                                "examples": {
-                                    "Failed to process presentation submission": {
-                                        "value": {
-                                            "errorCode": "wallet_vp_submission_error",
-                                            "errorMessage": "Failed to process presentation submission: Error message"
-                                        }
-                                    },
-                                    "Unexpected Server Error": {
-                                        "value": {
-                                            "errorCode": "internal_server_error",
-                                            "errorMessage": "We are unable to process request now"
-                                        }
-                                    },
-                                    "Failed to reject verifier": {
-                                        "value": { 
-                                            "errorCode": "error", 
-                                            "errorMessage": "Unable to process reject verifier request" 
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                "description": "The unique identifier of the Wallet."
+              },
+              {
+                "name": "presentationId",
+                "in": "path",
+                "required": true,
+                "schema": {
+                  "type": "string"
                 },
-                "security": [
-                    {
-                        "SessionAuth": []
+                "description": "The unique identifier of the Presentation."
+              },
+              {
+                "name": "X-XSRF-TOKEN",
+                "in": "header",
+                "required": false,
+                "schema": {
+                  "type": "string"
+                },
+                "description": "CSRF token obtained from the XSRF-TOKEN cookie set by the server on GET requests."
+              }
+            ],
+            "requestBody": {
+              "required": true,
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "oneOf": [
+                      { "$ref": "#/components/schemas/PresentationSubmissionRequestDTO" },
+                      { "$ref": "#/components/schemas/Error" }
+                    ]
+                  },
+                  "examples": {
+                    "Presentation Submission Request": {
+                      "value": {
+                        "selectedCredentials": ["cred-123", "cred-456"]
+                      }
+                    },
+                    "Presentation Submission Request (SD-JWT with selective disclosure)": {
+                      "value": {
+                        "selectedCredentials": ["cred-123"],
+                        "selectedSdClaims": {
+                          "cred-123": ["name", "dob"]
+                        }
+                      }
+                    },
+                    "Rejection payload": {
+                      "value": {
+                        "errorCode": "access_denied",
+                        "errorMessage": "User denied authorization to share credentials"
+                      }
                     }
-                ]
-            }
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Successfully processed the presentation submission.",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/SubmitPresentationResponseDTO"
+                    },
+                    "examples": {
+                      "Success response": {
+                        "value": {
+                          "status": "success",
+                          "redirectUri": "https://verifier.example.com/callback?state=af0ifjsldkj",
+                          "message": "Presentation successfully submitted"
+                        }
+                      },
+                      "Response when successfully rejected": {
+                        "value": {
+                          "status": "success",
+                          "redirectUri": "https://client.example.org/cb#response_code=091535f699ea575c7937fa5f0f454aee",
+                          "message": "Presentation request rejected. An OpenID4VP error response has been sent to the verifier."
+                        }
+                      },
+                      "Response when an error occurs while submitting a rejection": {
+                        "value": {
+                          "status": "error",
+                          "message": "Failed to submit Verifiable Presentation."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "400": {
+                "description": "Invalid request or missing required parameters.",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Error"
+                    },
+                    "examples": {
+                      "Invalid Wallet ID": {
+                        "value": {
+                          "errorCode": "invalid_request",
+                          "errorMessage": "Invalid Wallet ID. Session and request Wallet ID do not match"
+                        }
+                      },
+                      "Wallet ID not found in session": {
+                        "value": {
+                          "errorCode": "wallet_locked",
+                          "errorMessage": "Wallet is locked"
+                        }
+                      },
+                      "Credential not found": {
+                        "value": {
+                          "errorCode": "invalid_request",
+                          "errorMessage": "Credential not found: cred-123"
+                        }
+                      },
+                      "presentationId not found in session": {
+                        "value": {
+                          "errorCode": "invalid_request",
+                          "errorMessage": "presentationId not found in session"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "401": {
+                "description": "Unauthorized user performing the presentation submission",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Error"
+                    },
+                    "examples": {
+                      "User ID is not present in session": {
+                        "value": {
+                          "errorCode": "unauthorized",
+                          "errorMessage": "User ID not found in session"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "500": {
+                "description": "Internal server error",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/Error"
+                    },
+                    "examples": {
+                      "Failed to process presentation submission": {
+                        "value": {
+                          "errorCode": "wallet_vp_submission_error",
+                          "errorMessage": "Failed to process presentation submission: Error message"
+                        }
+                      },
+                      "Unexpected Server Error": {
+                        "value": {
+                          "errorCode": "internal_server_error",
+                          "errorMessage": "We are unable to process request now"
+                        }
+                      },
+                      "Failed to reject verifier": {
+                        "value": {
+                          "errorCode": "error",
+                          "errorMessage": "Unable to process reject verifier request"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "security": [
+              {
+                "SessionAuth": []
+              }
+            ]
+          }
         },
         "/wallets/{walletId}/presentations/{presentationId}/credentials": {
             "get": {
@@ -5138,20 +5146,33 @@
                 }
             },
             "PresentationSubmissionRequestDTO": {
-                "type": "object",
-                "properties": {
-                    "selectedCredentials": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "description": "List of selected credential IDs for presentation",
-                        "example": ["cred-123", "cred-456"]
-                    }
+              "type": "object",
+              "properties": {
+                "selectedCredentials": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of selected credential IDs for presentation",
+                  "example": ["cred-123", "cred-456"]
                 },
-                "required": [
-                    "selectedCredentials"
-                ]
+                "selectedSdClaims": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "description": "Optional. Selected SD-JWT claim paths per credential ID for selective disclosure (only for SD-JWT credentials: vc+sd-jwt and dc+sd-jwt). Keyed by credential ID; values are the claim paths to disclose. Only the explicitly selected disclosures are shared; when omitted (or empty) for an SD-JWT credential, none of its selectively-disclosable claims are shared.",
+                  "example": {
+                    "cred-123": ["name", "dob"]
+                  }
+                }
+              },
+              "required": [
+                "selectedCredentials"
+              ]
             },
             "IssuerConfigurationSuccessResponse": {
                 "type": "object",

--- a/src/main/java/io/mosip/mimoto/constant/CredentialFormat.java
+++ b/src/main/java/io/mosip/mimoto/constant/CredentialFormat.java
@@ -23,4 +23,12 @@ public enum CredentialFormat {
         }
         throw new IllegalArgumentException("Unknown credential format: " + format);
     }
+
+    /**
+     * Returns true if the given format string is an SD-JWT family format (vc+sd-jwt or dc+sd-jwt).
+     * Both share the same SD-JWT structure, parser, and KB-JWT signing.
+     */
+    public static boolean isSdJwt(String format) {
+        return VC_SD_JWT.format.equalsIgnoreCase(format) || DC_SD_JWT.format.equalsIgnoreCase(format);
+    }
 }

--- a/src/main/java/io/mosip/mimoto/constant/SigningAlgorithm.java
+++ b/src/main/java/io/mosip/mimoto/constant/SigningAlgorithm.java
@@ -29,7 +29,7 @@ public enum SigningAlgorithm {
             case "RS256" -> RS256;
             case "ES256" -> ES256;
             case "ES256K" -> ES256K;
-            case "ED25519" -> ED25519;
+            case "ED25519", "EDDSA" -> ED25519;
             default -> throw new IllegalArgumentException("Unsupported signing algorithm: " + value);
         };
     }

--- a/src/main/java/io/mosip/mimoto/constant/SwaggerLiteralConstants.java
+++ b/src/main/java/io/mosip/mimoto/constant/SwaggerLiteralConstants.java
@@ -143,9 +143,11 @@ public class SwaggerLiteralConstants {
     public static final String WALLET_PRESENTATIONS_GET_MATCHING_CREDENTIALS_500_SERVER_ERROR_VALUE = "{\"errorCode\": \"internal_server_error\", \"errorMessage\": \"We are unable to process request now\"}";
 
     public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_SUMMARY = "Submit presentation or reject verifier";
-    public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_DESCRIPTION = "This API handles both presentation submission and verifier rejection based on the request content. For submission: include selectedCredentials array. For rejection: include errorCode and errorMessage fields.";
+    public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_DESCRIPTION = "This API handles both presentation submission and verifier rejection based on the request content. For submission: include selectedCredentials array, and optionally selectedSdClaims to selectively disclose the chosen claims for SD-JWT credentials (vc+sd-jwt and dc+sd-jwt). Only the explicitly selected SD-JWT disclosures are shared; when selectedSdClaims is omitted (or empty) for an SD-JWT credential, none of its selectively-disclosable claims are shared. For rejection: include errorCode and errorMessage fields.";
     public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_EXAMPLE_NAME = "Submit Presentation";
     public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_EXAMPLE_VALUE = "{ \"selectedCredentials\": [\"cred-123\", \"cred-456\"] }";
+    public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_SDJWT_EXAMPLE_NAME = "Submit Presentation (SD-JWT with selective disclosure)";
+    public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_SDJWT_EXAMPLE_VALUE = "{ \"selectedCredentials\": [\"cred-123\"], \"selectedSdClaims\": { \"cred-123\": [\"name\", \"dob\"] } }";
     public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_REJECT_EXAMPLE_NAME = "Reject Verifier";
     public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_REJECT_EXAMPLE_VALUE = "{ \"errorCode\": \"access_denied\", \"errorMessage\": \"User denied authorization to share credentials\" }";
     public static final String WALLET_PRESENTATIONS_HANDLE_ACTION_200_SUBMITTED_NAME = "Presentation submitted";

--- a/src/main/java/io/mosip/mimoto/controller/WalletPresentationsController.java
+++ b/src/main/java/io/mosip/mimoto/controller/WalletPresentationsController.java
@@ -183,6 +183,7 @@ public class WalletPresentationsController {
                             schema = @Schema(implementation = SubmitPresentationRequestDTO.class),
                             examples = {
                                     @ExampleObject(name = SwaggerLiteralConstants.WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_EXAMPLE_NAME, value = SwaggerLiteralConstants.WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_EXAMPLE_VALUE),
+                                    @ExampleObject(name = SwaggerLiteralConstants.WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_SDJWT_EXAMPLE_NAME, value = SwaggerLiteralConstants.WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_SUBMIT_SDJWT_EXAMPLE_VALUE),
                                     @ExampleObject(name = SwaggerLiteralConstants.WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_REJECT_EXAMPLE_NAME, value = SwaggerLiteralConstants.WALLET_PRESENTATIONS_HANDLE_ACTION_REQ_REJECT_EXAMPLE_VALUE)
                             }
                     )

--- a/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * DTO for submitting a presentation with selected credentials or rejecting a verifier
@@ -21,6 +22,10 @@ public class SubmitPresentationRequestDTO {
     @Schema(description = "List of credential IDs that the user has selected to include in the presentation", 
             example = "[\"cred-123\", \"cred-456\"]")
     private List<String> selectedCredentials;
+
+    @Schema(description = "Selected SD-JWT claim paths per credential ID for selective disclosure (only for SD-JWT credentials)",
+            example = "{\"cred-123\": [\"name\", \"dob\"]}")
+    private Map<String, List<String>> selectedSdClaims;
 
     @Schema(description = "Error code for rejecting the verifier (used when user denies the presentation request)", 
             example = "access_denied")

--- a/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/SubmitPresentationRequestDTO.java
@@ -40,18 +40,19 @@ public class SubmitPresentationRequestDTO {
      */
     public boolean isSubmissionRequest() {
         boolean hasCredentials = selectedCredentials != null && !selectedCredentials.isEmpty();
-        boolean hasErrorFields = (errorCode != null && !errorCode.trim().isEmpty()) || 
+        boolean hasErrorFields = (errorCode != null && !errorCode.trim().isEmpty()) ||
                                  (errorMessage != null && !errorMessage.trim().isEmpty());
         return hasCredentials && !hasErrorFields;
     }
 
     /**
-     * Checks if this is a rejection request (has error code and message and NO credentials)
+     * Checks if this is a rejection request (has error code and message, NO credentials, NO SD-claim selections)
      */
     public boolean isRejectionRequest() {
-        boolean hasErrorFields = errorCode != null && !errorCode.trim().isEmpty() && 
+        boolean hasErrorFields = errorCode != null && !errorCode.trim().isEmpty() &&
                                 errorMessage != null && !errorMessage.trim().isEmpty();
         boolean hasCredentials = selectedCredentials != null && !selectedCredentials.isEmpty();
-        return hasErrorFields && !hasCredentials;
+        boolean hasSdClaims = selectedSdClaims != null && !selectedSdClaims.isEmpty();
+        return hasErrorFields && !hasCredentials && !hasSdClaims;
     }
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
@@ -219,8 +219,8 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
         String vcFormat = vc.getFormat();
 
-        if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(vcFormat) && descriptorFormat.containsKey(CredentialFormat.VC_SD_JWT.getFormat())) {
-            return matchesSdJwtAlgorithm(vc, descriptorFormat);
+        if (CredentialFormat.isSdJwt(vcFormat) && descriptorFormat.containsKey(vcFormat.toLowerCase())) {
+            return matchesSdJwtAlgorithm(vc, descriptorFormat, vcFormat.toLowerCase());
         }
         if (CredentialFormat.LDP_VC.getFormat().equalsIgnoreCase(vcFormat) && descriptorFormat.containsKey(LDP_VC_FORMAT)) {
             return matchesLdpVcFormat(vc, descriptorFormat);
@@ -250,12 +250,12 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
         return vcProofType != null && requiredProofTypes.contains(vcProofType);
     }
 
-    private boolean matchesSdJwtAlgorithm(VCCredentialResponse vc, Map<String, Map<String, List<String>>> requestFormat) {
+    private boolean matchesSdJwtAlgorithm(VCCredentialResponse vc, Map<String, Map<String, List<String>>> requestFormat, String formatKey) {
         if (vc.getCredential() == null || !(vc.getCredential() instanceof String sdJwtString)) {
             return false;
         }
 
-        Map<String, List<String>> sdJwtFormat = requestFormat.get(CredentialFormat.VC_SD_JWT.getFormat());
+        Map<String, List<String>> sdJwtFormat = requestFormat.get(formatKey);
         List<?> requestAlgorithms = sdJwtFormat.get(SD_JWT_ALG_VALUES_KEY);
         if (requestAlgorithms != null) {
             return requestAlgorithms.contains(extractSdJwtAlgorithm(sdJwtString));
@@ -307,7 +307,7 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
         if (CredentialFormat.LDP_VC.getFormat().equalsIgnoreCase(format)) {
             return credentialFormatHandler.extractAllCredentialProperties(vc);
-        } else if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+        } else if (CredentialFormat.isSdJwt(format)) {
             Map<String, ?> extractedMap = credentialFormatHandler.extractAllCredentialProperties(vc);
             if (extractedMap == null) {
                 return Collections.emptyMap();
@@ -420,8 +420,8 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
             log.warn("Failed to fetch issuer config for issuerId: {}, credentialType: {}", issuerId, credentialType, e);
         }
 
-        if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(decryptedCredentialDTO.getCredential().getFormat())) {
-            CredentialFormatHandler credentialFormatHandler = credentialFormatHandlerFactory.getHandler(CredentialFormat.VC_SD_JWT.getFormat());
+        if (CredentialFormat.isSdJwt(decryptedCredentialDTO.getCredential().getFormat())) {
+            CredentialFormatHandler credentialFormatHandler = credentialFormatHandlerFactory.getHandler(decryptedCredentialDTO.getCredential().getFormat());
             Map<String, Map<String, Object>> allClaims = (Map<String, Map<String, Object>>) credentialFormatHandler.extractAllCredentialProperties(decryptedCredentialDTO.getCredential());
 
             publicClaimsMap = allClaims.get("publicClaims");
@@ -512,7 +512,7 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
         }
 
         Set<String> result = new HashSet<>();
-        if (format.containsKey(CredentialFormat.VC_SD_JWT.getFormat())) {
+        if (format.containsKey(CredentialFormat.VC_SD_JWT.getFormat()) || format.containsKey(CredentialFormat.DC_SD_JWT.getFormat())) {
             result.add(SD_JWT_ALG_VALUES_KEY);
         }
         if (format.containsKey(LDP_VC_FORMAT)) {

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
@@ -99,7 +99,13 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
                     if (!matches.isEmpty()) {
                         matchingCredentialsByDescriptor.put(i, matches);
                     } else {
-                        missingClaims.addAll(extractClaimsFromInputDescriptor(descriptor));
+                        boolean hasFormatMatch = decryptedCredentials.stream()
+                                .anyMatch(decrypted -> matchesFormat(decrypted.getCredential(), descriptor.getFormat()));
+                        if (hasFormatMatch) {
+                            missingClaims.addAll(extractClaimsFromInputDescriptor(descriptor));
+                        } else {
+                            missingClaims.addAll(extractFormatConstraintKeys(descriptor));
+                        }
                     }
         });
 
@@ -153,9 +159,12 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
     private MatchingCredentialsResponseDTO createEmptyResponseWithMissingClaims(PresentationDefinition presentationDefinition) {
         log.info("No credentials found for wallet");
+        Set<String> missingClaims = presentationDefinition.getInputDescriptors().stream()
+                .flatMap(descriptor -> extractFormatConstraintKeys(descriptor).stream())
+                .collect(Collectors.toSet());
         return MatchingCredentialsResponseDTO.builder()
                 .availableCredentials(Collections.emptyList())
-                .missingClaims(new HashSet<>(extractRequiredClaims(presentationDefinition)))
+                .missingClaims(missingClaims)
                 .build();
     }
 
@@ -491,6 +500,23 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
                 paths.add(currentPath);
             }
         }
+    }
+
+    private Set<String> extractFormatConstraintKeys(InputDescriptor descriptor) {
+        Map<String, Map<String, List<String>>> format = descriptor.getFormat();
+        if (format == null || format.isEmpty()) {
+            return Collections.singleton(descriptor.getId());
+        }
+
+        Set<String> result = new HashSet<>();
+        if (format.containsKey(CredentialFormat.VC_SD_JWT.getFormat())) {
+            result.add(SD_JWT_ALG_VALUES_KEY);
+        }
+        if (format.containsKey(LDP_VC_FORMAT)) {
+            result.add(PROOF_TYPE_KEY);
+        }
+
+        return result.isEmpty() ? Collections.singleton(descriptor.getId()) : result;
     }
 
     private boolean hasUniformKeys(List<?> list) {

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
@@ -321,6 +321,7 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
             if (extractedMap == null) {
                 return Collections.emptyMap();
             }
+            @SuppressWarnings("unchecked")
             Map<String, Map<String, Object>> allCredentialProperties = (Map<String, Map<String, Object>>) extractedMap;
             Map<String, Object> credentialClaimsMap = new HashMap<>();
             allCredentialProperties.values().forEach(credentialClaimsMap::putAll);
@@ -452,10 +453,10 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
             Map<String, Object> csMap = (Map<String, Object>) credentialSubject;
             collectPaths(csMap, "$", paths);
         } else {
-            // Remove standard JWT claims and SD-JWT metadata
             List<String> metadataKeys = Arrays.asList("vct", "cnf", "iss", "sub", "aud", "exp", "nbf", "iat", "jti", SD, "_sd_alg", "id");
-            metadataKeys.forEach(publicClaimsMap::remove);
-            collectPaths(publicClaimsMap, "$", paths);
+            Map<String, Object> filteredMap = new HashMap<>(publicClaimsMap);
+            metadataKeys.forEach(filteredMap::remove);
+            collectPaths(filteredMap, "$", paths);
         }
         return paths;
     }

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
@@ -251,25 +251,16 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
     }
 
     private boolean matchesSdJwtAlgorithm(VCCredentialResponse vc, Map<String, Map<String, List<String>>> requestFormat) {
-        Map<String, List<String>> sdJwtFormat = requestFormat.get(CredentialFormat.VC_SD_JWT.getFormat());
         if (vc.getCredential() == null || !(vc.getCredential() instanceof String sdJwtString)) {
             return false;
         }
 
-        if (!sdJwtFormat.containsKey(SD_JWT_ALG_VALUES_KEY)) {
-            return false;
+        Map<String, List<String>> sdJwtFormat = requestFormat.get(CredentialFormat.VC_SD_JWT.getFormat());
+        List<?> requestAlgorithms = sdJwtFormat.get(SD_JWT_ALG_VALUES_KEY);
+        if (requestAlgorithms != null) {
+            return requestAlgorithms.contains(extractSdJwtAlgorithm(sdJwtString));
         }
-
-        String sdJwtAlgorithm = extractSdJwtAlgorithm(sdJwtString);
-        Map<String, List<String>> requestFormatMap = requestFormat.get(CredentialFormat.VC_SD_JWT.getFormat());
-        if (requestFormatMap != null) {
-            List<?> requestAlgorithms = requestFormatMap.get(SD_JWT_ALG_VALUES_KEY);
-            if (requestAlgorithms != null) {
-                return requestAlgorithms.contains(sdJwtAlgorithm);
-            }
-            return true; // If no specific algorithms are required, any algorithm is acceptable
-        }
-        return false;
+        return true; // No sd-jwt_alg_values constraint → any algorithm is acceptable
     }
 
     private String extractSdJwtAlgorithm(String sdJwtString) {
@@ -321,10 +312,21 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
             if (extractedMap == null) {
                 return Collections.emptyMap();
             }
-            @SuppressWarnings("unchecked")
-            Map<String, Map<String, Object>> allCredentialProperties = (Map<String, Map<String, Object>>) extractedMap;
             Map<String, Object> credentialClaimsMap = new HashMap<>();
-            allCredentialProperties.values().forEach(credentialClaimsMap::putAll);
+            // publicClaims and sdClaims are mutually exclusive by SD-JWT spec — no key collision.
+            // sdClaims values are disclosure blobs (List<String>), not decoded claim values.
+            // This supports existence-based field matching (e.g. $.given_name present).
+            // Value-filter matching on SD claims (e.g. $.age >= 18) is not supported here
+            // and requires decoding disclosures — tracked as a follow-up improvement.
+            for (Map.Entry<String, ?> outer : extractedMap.entrySet()) {
+                if (outer.getValue() instanceof Map<?, ?> innerMap) {
+                    for (Map.Entry<?, ?> inner : innerMap.entrySet()) {
+                        if (inner.getKey() instanceof String key) {
+                            credentialClaimsMap.put(key, inner.getValue());
+                        }
+                    }
+                }
+            }
             return credentialClaimsMap;
         } else {
             throw new InvalidRequestException(UNSUPPORTED_FORMAT.getErrorCode(), "Unsupported credential format: " + format);

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -35,7 +35,7 @@ public class OpenID4VPService {
     public OpenID4VP create(String presentationId) {
         WalletMetadata walletMetadata = new WalletMetadata();
         walletMetadata.setVpFormatsSupported(Map.of(
-                VPFormatType.LDP_VC, new VPFormatSupported(List.of("EEd25519Signature2020")),
+                VPFormatType.LDP_VC, new VPFormatSupported(List.of("Ed25519Signature2020")),
                 VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "EdDSA"))
         ));
 

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -34,12 +34,12 @@ public class OpenID4VPService {
 
     public OpenID4VP create(String presentationId) {
         WalletMetadata walletMetadata = new WalletMetadata();
-        walletMetadata.setVpFormatsSupported(Map.of(VPFormatType.LDP_VC, new VPFormatSupported(List.of("EEd25519Signature2020"))));
+        walletMetadata.setVpFormatsSupported(Map.of(
+                VPFormatType.LDP_VC, new VPFormatSupported(List.of("EEd25519Signature2020")),
+                VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "EdDSA"))
+        ));
 
-        return new OpenID4VP(
-                presentationId,
-                walletMetadata
-        );
+        return new OpenID4VP(presentationId, walletMetadata);
     }
 
     /**

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -36,7 +36,7 @@ public class OpenID4VPService {
         WalletMetadata walletMetadata = new WalletMetadata();
         walletMetadata.setVpFormatsSupported(Map.of(
                 VPFormatType.LDP_VC, new VPFormatSupported(List.of("Ed25519Signature2020")),
-                VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "EdDSA"))
+                VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "ES256K", "EdDSA"))
         ));
 
         return new OpenID4VP(presentationId, walletMetadata);

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -36,7 +36,8 @@ public class OpenID4VPService {
         WalletMetadata walletMetadata = new WalletMetadata();
         walletMetadata.setVpFormatsSupported(Map.of(
                 VPFormatType.LDP_VC, new VPFormatSupported(List.of("Ed25519Signature2020")),
-                VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "ES256K", "EdDSA"))
+                VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "ES256K", "EdDSA", "RS256")),
+                VPFormatType.DC_SD_JWT, new VPFormatSupported(List.of("ES256", "ES256K", "EdDSA", "RS256"))
         ));
 
         return new OpenID4VP(presentationId, walletMetadata);

--- a/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/OpenID4VPService.java
@@ -36,8 +36,8 @@ public class OpenID4VPService {
         WalletMetadata walletMetadata = new WalletMetadata();
         walletMetadata.setVpFormatsSupported(Map.of(
                 VPFormatType.LDP_VC, new VPFormatSupported(List.of("Ed25519Signature2020")),
-                VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "ES256K", "EdDSA", "RS256")),
-                VPFormatType.DC_SD_JWT, new VPFormatSupported(List.of("ES256", "ES256K", "EdDSA", "RS256"))
+                VPFormatType.VC_SD_JWT, new VPFormatSupported(List.of("ES256", "EdDSA")),
+                VPFormatType.DC_SD_JWT, new VPFormatSupported(List.of("ES256", "EdDSA"))
         ));
 
         return new OpenID4VP(presentationId, walletMetadata);

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
@@ -263,13 +263,13 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
 
         // Holder key for LDP_VC is always ED25519 (Ed25519Signature2020). SD-JWT KB-JWT signing
         // derives its own per-credential key from the KB-JWT header alg inside signVPToken.
-        KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, SigningAlgorithm.ED25519);
-        JWK jwk = SigningKeyUtil.generateJwk(SigningAlgorithm.ED25519, keyPair);
+        SigningAlgorithm signingAlgorithm = SigningAlgorithm.ED25519;
+        KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, signingAlgorithm);
+        JWK jwk = SigningKeyUtil.generateJwk(signingAlgorithm, keyPair);
         Map<FormatType, UnsignedVPToken> unsignedVPToken = constructUnsignedVPToken(openID4VP, selectedCredentials, jwk, request.getSelectedSdClaims());
 
-        // Step 3: Sign tokens - LDP_VC uses the ED25519 holder signer; SD-JWT uses per-credential signers
-        Map<FormatType, JWSSigner> signers = buildFormatSigners(unsignedVPToken.keySet(), jwk);
-        Map<FormatType, VPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, signers, walletId, base64Key);
+        // Step 3: Sign each unsigned VP token using format-specific signing logic
+        Map<FormatType, VPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, jwk, walletId, base64Key);
 
         // Step 4: Share verifiable presentation with verifier using OpenID4VP JAR
         log.debug("Calling OpenID4VP JAR's shareVerifiablePresentation method");
@@ -289,9 +289,11 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     }
 
     /**
-     * Signs VP token using per-format signers - dispatches to format-specific signing logic
+     * Signs each unsigned VP token by dispatching to the signing logic for its credential format.
+     * LDP_VC is signed with the ED25519 holder key; SD-JWT (vc+sd-jwt / dc+sd-jwt) signers are derived
+     * per credential from the KB-JWT header alg inside signSdJwtFormat.
      */
-    private Map<FormatType, VPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, Map<FormatType, JWSSigner> signers, String walletId, String base64Key) throws JOSEException, KeyGenerationException, DecryptionException {
+    private Map<FormatType, VPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, JWK ldpVcJwk, String walletId, String base64Key) throws JOSEException, KeyGenerationException, DecryptionException {
         log.debug("Signing VP token for {} format types", unsignedVPTokensMap.size());
 
         Map<FormatType, VPTokenSigningResult> results = new HashMap<>();
@@ -301,9 +303,8 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
 
             VPTokenSigningResult signingResult;
             if (formatType == FormatType.LDP_VC) {
-                signingResult = signLdpVcFormat(unsignedVPToken, signers.get(formatType));
+                signingResult = signLdpVcFormat(unsignedVPToken, ldpVcJwk);
             } else if (formatType == FormatType.VC_SD_JWT || formatType == FormatType.DC_SD_JWT) {
-                // SD-JWT signers are derived per credential from the KB-JWT header alg, not from the pre-built signers map
                 signingResult = signSdJwtFormat(unsignedVPToken, walletId, base64Key);
             } else {
                 log.error("Unsupported format type: {}", formatType);
@@ -365,8 +366,11 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     /**
      * Signs LDP_VC format verifiable presentation using detached JWT
      */
-    private LdpVPTokenSigningResult signLdpVcFormat(UnsignedVPToken unsignedVPToken, JWSSigner jwsSigner) throws JOSEException {
+    private LdpVPTokenSigningResult signLdpVcFormat(UnsignedVPToken unsignedVPToken, JWK ed25519Jwk) throws JOSEException {
         log.debug("Signing LDP_VC format VP token");
+
+        // LDP_VC is always signed with the ED25519 holder key (Ed25519Signature2020)
+        JWSSigner jwsSigner = SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, ed25519Jwk);
 
         String dataToSign = ((UnsignedLdpVPToken) unsignedVPToken).getDataToSign();
 
@@ -549,18 +553,6 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
             log.error("Failed to filter SD-JWT disclosures for credential: {}, selectedPaths: {}. Sharing no disclosures. Error: {}", credential.getId(), selectedPaths, e.getMessage(), e);
             return credentialJwt + "~";
         }
-    }
-
-    /**
-     * Builds the LDP_VC signer from the ED25519 holder key.
-     * SD-JWT signers are derived per credential from the KB-JWT header alg in signVPToken, so they are not built here.
-     */
-    private Map<FormatType, JWSSigner> buildFormatSigners(Set<FormatType> formats, JWK ed25519Jwk) throws JOSEException {
-        Map<FormatType, JWSSigner> signers = new EnumMap<>(FormatType.class);
-        if (formats.contains(FormatType.LDP_VC)) {
-            signers.put(FormatType.LDP_VC, SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, ed25519Jwk));
-        }
-        return signers;
     }
 
     /**

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
@@ -270,9 +270,9 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
         JWK jwk = SigningKeyUtil.generateJwk(signingAlgorithm, keyPair);
         Map<FormatType, UnsignedVPToken> unsignedVPToken = constructUnsignedVPToken(openID4VP, selectedCredentials, jwk, request.getSelectedSdClaims());
 
-        // Step 3: Sign token using user's private key
-        JWSSigner jwsSigner = SigningKeyUtil.createSigner(signingAlgorithm, jwk);
-        Map<FormatType, VPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, jwsSigner);
+        // Step 3: Sign token using per-format signers
+        Map<FormatType, JWSSigner> signers = buildFormatSigners(unsignedVPToken.keySet(), signingAlgorithm, jwk, walletId, base64Key);
+        Map<FormatType, VPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, signers);
 
         // Step 4: Share verifiable presentation with verifier using OpenID4VP JAR
         log.debug("Calling OpenID4VP JAR's shareVerifiablePresentation method");
@@ -292,14 +292,15 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     }
 
     /**
-     * Signs VP token using JWSSigner - dispatches to format-specific signing logic
+     * Signs VP token using per-format signers - dispatches to format-specific signing logic
      */
-    private Map<FormatType, VPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, JWSSigner jwsSigner) {
+    private Map<FormatType, VPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, Map<FormatType, JWSSigner> signers) {
         log.debug("Signing VP token for {} format types", unsignedVPTokensMap.size());
 
         return unsignedVPTokensMap.entrySet().stream().map(entry -> {
             FormatType formatType = entry.getKey();
             UnsignedVPToken unsignedVPToken = entry.getValue();
+            JWSSigner jwsSigner = signers.get(formatType);
 
             try {
                 VPTokenSigningResult signingResult;
@@ -474,7 +475,10 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
      * If selectedPaths is null/empty, all disclosures are retained.
      */
     private String buildFilteredSdJwt(DecryptedCredentialDTO credential, List<String> selectedPaths) {
-        String sdJwtString = (String) credential.getCredential().getCredential();
+        if (!(credential.getCredential().getCredential() instanceof String sdJwtString)) {
+            log.warn("Credential {} payload is not a String; skipping SD-JWT filtering", credential.getId());
+            return String.valueOf(credential.getCredential().getCredential());
+        }
 
         if (selectedPaths == null || selectedPaths.isEmpty()) {
             return sdJwtString;
@@ -543,6 +547,33 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
                     return resolveAlgorithmFromSdJwt(sdJwt);
                 })
                 .orElse(SigningAlgorithm.valueOf(DEFAULT_SIGNING_ALGORITHM_NAME));
+    }
+
+    /**
+     * Builds a per-format signer map so each format uses the correct algorithm.
+     * LDP-VC is always signed with ED25519 (hardwired in signLdpVcFormat).
+     * SD-JWT uses the algorithm derived from the credential's cnf.jwk.
+     * When both formats are present and the SD-JWT algorithm differs from ED25519,
+     * a separate ED25519 key pair is fetched for the LDP-VC signer.
+     */
+    private Map<FormatType, JWSSigner> buildFormatSigners(Set<FormatType> formats, SigningAlgorithm sdJwtAlgorithm, JWK sdJwtJwk, String walletId, String base64Key) throws JOSEException, KeyGenerationException, DecryptionException {
+        Map<FormatType, JWSSigner> signers = new EnumMap<>(FormatType.class);
+
+        for (FormatType format : formats) {
+            if (format == FormatType.LDP_VC) {
+                if (sdJwtAlgorithm == SigningAlgorithm.ED25519) {
+                    signers.put(FormatType.LDP_VC, SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, sdJwtJwk));
+                } else {
+                    KeyPair ldpKeyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, SigningAlgorithm.ED25519);
+                    JWK ldpJwk = SigningKeyUtil.generateJwk(SigningAlgorithm.ED25519, ldpKeyPair);
+                    signers.put(FormatType.LDP_VC, SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, ldpJwk));
+                }
+            } else if (format == FormatType.VC_SD_JWT) {
+                signers.put(FormatType.VC_SD_JWT, SigningKeyUtil.createSigner(sdJwtAlgorithm, sdJwtJwk));
+            }
+        }
+
+        return signers;
     }
 
     /**

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
@@ -1,6 +1,5 @@
 package io.mosip.mimoto.service.impl;
 
-import com.authlete.sd.SDJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
@@ -34,7 +33,6 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest;
 import io.mosip.openID4VP.authorizationRequest.Verifier;
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.ClientMetadata;
 import io.mosip.mimoto.service.CredentialFormatHandlerFactory;
-import io.mosip.mimoto.util.JwtUtils;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken;
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult;
@@ -70,7 +68,6 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     private static final String DEFAULT_SIGNATURE_SUITE = "JsonWebSignature2020";
     private static final String UNKNOWN_VERIFIER = "unknown";
     private static final String EMPTY_JSON = "{}";
-    private static final String DEFAULT_SIGNING_ALGORITHM_NAME = "ED25519";
 
     private final VerifierService verifierService;
 
@@ -264,15 +261,15 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
         List<Verifier> preRegisteredVerifiers = verifierService.getTrustedVerifiers().getVerifiers().stream().map(verifierDTO -> new Verifier(verifierDTO.getClientId(), verifierDTO.getResponseUris(), verifierDTO.getJwksUri(), verifierDTO.getAllowUnsignedRequest())).toList();
         openID4VP.authenticateVerifier(sessionData.getAuthorizationRequest(), preRegisteredVerifiers, sessionData.isVerifierClientPreregistered());
 
-        // Determine signing algorithm - ED25519 for LDP_VC, derived from cnf.jwk for SD-JWT
-        SigningAlgorithm signingAlgorithm = resolveSigningAlgorithm(selectedCredentials);
-        KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, signingAlgorithm);
-        JWK jwk = SigningKeyUtil.generateJwk(signingAlgorithm, keyPair);
+        // Holder key for LDP_VC is always ED25519 (Ed25519Signature2020). SD-JWT KB-JWT signing
+        // derives its own per-credential key from the KB-JWT header alg inside signVPToken.
+        KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, SigningAlgorithm.ED25519);
+        JWK jwk = SigningKeyUtil.generateJwk(SigningAlgorithm.ED25519, keyPair);
         Map<FormatType, UnsignedVPToken> unsignedVPToken = constructUnsignedVPToken(openID4VP, selectedCredentials, jwk, request.getSelectedSdClaims());
 
-        // Step 3: Sign token using per-format signers
-        Map<FormatType, JWSSigner> signers = buildFormatSigners(unsignedVPToken.keySet(), signingAlgorithm, jwk, walletId, base64Key);
-        Map<FormatType, VPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, signers);
+        // Step 3: Sign tokens - LDP_VC uses the ED25519 holder signer; SD-JWT uses per-credential signers
+        Map<FormatType, JWSSigner> signers = buildFormatSigners(unsignedVPToken.keySet(), jwk);
+        Map<FormatType, VPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, signers, walletId, base64Key);
 
         // Step 4: Share verifiable presentation with verifier using OpenID4VP JAR
         log.debug("Calling OpenID4VP JAR's shareVerifiablePresentation method");
@@ -294,38 +291,39 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     /**
      * Signs VP token using per-format signers - dispatches to format-specific signing logic
      */
-    private Map<FormatType, VPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, Map<FormatType, JWSSigner> signers) {
+    private Map<FormatType, VPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, Map<FormatType, JWSSigner> signers, String walletId, String base64Key) throws JOSEException, KeyGenerationException, DecryptionException {
         log.debug("Signing VP token for {} format types", unsignedVPTokensMap.size());
 
-        return unsignedVPTokensMap.entrySet().stream().map(entry -> {
+        Map<FormatType, VPTokenSigningResult> results = new HashMap<>();
+        for (Map.Entry<FormatType, UnsignedVPToken> entry : unsignedVPTokensMap.entrySet()) {
             FormatType formatType = entry.getKey();
             UnsignedVPToken unsignedVPToken = entry.getValue();
-            JWSSigner jwsSigner = signers.get(formatType);
 
-            try {
-                VPTokenSigningResult signingResult;
-                if (formatType == FormatType.LDP_VC) {
-                    signingResult = signLdpVcFormat(unsignedVPToken, jwsSigner);
-                } else if (formatType == FormatType.VC_SD_JWT) {
-                    signingResult = signSdJwtFormat(unsignedVPToken, jwsSigner);
-                } else {
-                    log.error("Unsupported format type: {}", formatType);
-                    throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Unsupported format type: " + formatType);
-                }
-                return Map.entry(formatType, signingResult);
-            } catch (JOSEException | ParseException e) {
-                throw new RuntimeException("Failed to sign VP token for format: " + formatType, e);
+            VPTokenSigningResult signingResult;
+            if (formatType == FormatType.LDP_VC) {
+                signingResult = signLdpVcFormat(unsignedVPToken, signers.get(formatType));
+            } else if (formatType == FormatType.VC_SD_JWT || formatType == FormatType.DC_SD_JWT) {
+                // SD-JWT signers are derived per credential from the KB-JWT header alg, not from the pre-built signers map
+                signingResult = signSdJwtFormat(unsignedVPToken, walletId, base64Key);
+            } else {
+                log.error("Unsupported format type: {}", formatType);
+                throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Unsupported format type: " + formatType);
             }
-        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            results.put(formatType, signingResult);
+        }
+        return results;
     }
 
     /**
      * Signs SD-JWT JB-JWT tokens. The library provides unsigned KB-JWTs (header.payload) per credential UUID.
      * Mimoto signs each one and returns the signatures.
      */
-    private SdJwtVPTokenSigningResult signSdJwtFormat(UnsignedVPToken unsignedVPToken, JWSSigner jwsSigner) throws JOSEException, ParseException {
+    private SdJwtVPTokenSigningResult signSdJwtFormat(UnsignedVPToken unsignedVPToken, String walletId, String base64Key) throws JOSEException, KeyGenerationException, DecryptionException {
         UnsignedSdJwtVPToken sdJwtToken = (UnsignedSdJwtVPToken) unsignedVPToken;
         Map<String, String> uuidToUnsignedKBT = sdJwtToken.getUuidToUnsignedKBT();
+
+        // Cache one signer per algorithm so multiple credentials sharing an alg reuse the same key fetch
+        Map<SigningAlgorithm, JWSSigner> signerCache = new EnumMap<>(SigningAlgorithm.class);
 
         Map<String, String> uuidToSignature = new HashMap<>();
         for (Map.Entry<String, String> entry: uuidToUnsignedKBT.entrySet()) {
@@ -333,9 +331,28 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
             // "headerB64.payloadB64"
             String unsignedKBT = entry.getValue();
 
+            // Parse the KB-JWT header produced by the OpenID4VP JAR and read its alg.
+            // The JAR derives this alg from the credential's cnf, so the header is the source of truth.
+            JWSHeader kbHeader;
+            try {
+                String[] parts = unsignedKBT.split("\\.");
+                kbHeader = JWSHeader.parse(new Base64URL(parts[0]));
+            } catch (ParseException e) {
+                throw new JOSEException("Failed to parse KB-JWT header for credential uuid: " + uuid, e);
+            }
+
+            SigningAlgorithm algorithm = SigningAlgorithm.fromString(kbHeader.getAlgorithm().getName());
+
+            // Build (or reuse) a signer for this algorithm using the wallet's key pair for that alg
+            JWSSigner jwsSigner = signerCache.get(algorithm);
+            if (jwsSigner == null) {
+                KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, algorithm);
+                JWK jwk = SigningKeyUtil.generateJwk(algorithm, keyPair);
+                jwsSigner = SigningKeyUtil.createSigner(algorithm, jwk);
+                signerCache.put(algorithm, jwsSigner);
+            }
+
             // Standard JWT signing input: ASCII bytes of "headerB64.payloadB64"
-            String[] parts = unsignedKBT.split("\\.");
-            JWSHeader kbHeader = JWSHeader.parse(new Base64URL(parts[0]));
             byte[] signingInput = unsignedKBT.getBytes(StandardCharsets.US_ASCII);
 
             Base64URL signature = jwsSigner.sign(kbHeader, signingInput);
@@ -438,7 +455,7 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
             FormatType formatType = mapStringToFormatType(format);
 
             Object credentialData;
-            if(CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+            if(CredentialFormat.isSdJwt(format)) {
                 List<String> selectedPaths = selectedSdClaims != null ? selectedSdClaims.get(credential.getId()) : null;
                 credentialData = buildFilteredSdJwt(credential, selectedPaths);
             } else {
@@ -465,14 +482,16 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
         String formatLower = format.toLowerCase();
         if (CredentialFormat.LDP_VC.getFormat().equals(formatLower)) return FormatType.LDP_VC;
         if (CredentialFormat.VC_SD_JWT.getFormat().equals(formatLower)) return FormatType.VC_SD_JWT;
+        if (CredentialFormat.DC_SD_JWT.getFormat().equals(formatLower)) return FormatType.DC_SD_JWT;
 
         log.error("Unsupported credential format: {}", format);
         throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Unsupported credential format: " + format);
     }
 
     /**
-     * Builds a filtered SD-JWT string containing only the user-selected disclosures.
-     * If selectedPaths is null/empty, all disclosures are retained.
+     * Builds an SD-JWT string containing ONLY the user-selected disclosures.
+     * Disclosures are shared only when explicitly selected; if selectedPaths is null/empty
+     * (the user selected no SD claims for this credential), no disclosures are shared.
      */
     private String buildFilteredSdJwt(DecryptedCredentialDTO credential, List<String> selectedPaths) {
         if (!(credential.getCredential().getCredential() instanceof String sdJwtString)) {
@@ -480,8 +499,13 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
             return String.valueOf(credential.getCredential().getCredential());
         }
 
+        // The issuer-signed credential JWT is everything before the first '~'.
+        // We rebuild from this and append ONLY the explicitly selected disclosures - never all.
+        String credentialJwt = sdJwtString.split("~", -1)[0];
+
+        // No selection for this credential -> user chose to disclose nothing -> share zero disclosures
         if (selectedPaths == null || selectedPaths.isEmpty()) {
-            return sdJwtString;
+            return credentialJwt + "~";
         }
 
         try {
@@ -491,12 +515,12 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
                     .extractAllCredentialProperties(credential.getCredential());
 
             if (!(allProps.get("sdClaims") instanceof Map<?, ?> rawSdClaims)) {
-                return sdJwtString;
+                return credentialJwt + "~";
             }
             @SuppressWarnings("unchecked")
             Map<String, Object> sdClaimsMap = (Map<String, Object>) rawSdClaims;
             if (sdClaimsMap.isEmpty()) {
-                return sdJwtString;
+                return credentialJwt + "~";
             }
 
             // Normalize paths: "$.name" -> "name", "$.address.city" -> "address.city"
@@ -514,8 +538,7 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
             }
 
             // Reconstruct: credentialJwt ~ disc1 ~ disc2 ~ (trailing ~ required by SD-JWT)
-            SDJWT sdJwt = SDJWT.parse(sdJwtString);
-            StringBuilder sb = new StringBuilder(sdJwt.getCredentialJwt());
+            StringBuilder sb = new StringBuilder(credentialJwt);
             for (String disc: allDisclosuresB64) {
                 sb.append("~").append(disc);
             }
@@ -523,99 +546,21 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
             return sb.toString();
 
         } catch (Exception e) {
-            log.error("Failed to filter SD-JWT disclosures for credential: {}, selectedPaths: {}. Returning original SD-JWT. Error: {}", credential.getId(), selectedPaths, e.getMessage(), e);
-            return sdJwtString;
+            log.error("Failed to filter SD-JWT disclosures for credential: {}, selectedPaths: {}. Sharing no disclosures. Error: {}", credential.getId(), selectedPaths, e.getMessage(), e);
+            return credentialJwt + "~";
         }
     }
 
     /**
-     * Determines the signing algorithm
-     * - SD-JWT credentials: reads alg from cnf.jwk in the credential payload
-     * - LDP-VC credentials: defaults to ED25519
+     * Builds the LDP_VC signer from the ED25519 holder key.
+     * SD-JWT signers are derived per credential from the KB-JWT header alg in signVPToken, so they are not built here.
      */
-    private SigningAlgorithm resolveSigningAlgorithm(List<DecryptedCredentialDTO> credentials) {
-        return credentials.stream()
-                .map(c -> c.getCredential().getFormat())
-                .filter(f -> CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(f))
-                .findFirst()
-                .map(f -> {
-                    String sdJwt = (String) credentials.stream()
-                            .filter(c -> f.equalsIgnoreCase(c.getCredential().getFormat()))
-                            .findFirst()
-                            .map(c -> c.getCredential().getCredential())
-                            .orElse(null);
-                    return resolveAlgorithmFromSdJwt(sdJwt);
-                })
-                .orElse(SigningAlgorithm.valueOf(DEFAULT_SIGNING_ALGORITHM_NAME));
-    }
-
-    /**
-     * Builds a per-format signer map so each format uses the correct algorithm.
-     * LDP-VC is always signed with ED25519 (hardwired in signLdpVcFormat).
-     * SD-JWT uses the algorithm derived from the credential's cnf.jwk.
-     * When both formats are present and the SD-JWT algorithm differs from ED25519,
-     * a separate ED25519 key pair is fetched for the LDP-VC signer.
-     */
-    private Map<FormatType, JWSSigner> buildFormatSigners(Set<FormatType> formats, SigningAlgorithm sdJwtAlgorithm, JWK sdJwtJwk, String walletId, String base64Key) throws JOSEException, KeyGenerationException, DecryptionException {
+    private Map<FormatType, JWSSigner> buildFormatSigners(Set<FormatType> formats, JWK ed25519Jwk) throws JOSEException {
         Map<FormatType, JWSSigner> signers = new EnumMap<>(FormatType.class);
-
-        for (FormatType format : formats) {
-            if (format == FormatType.LDP_VC) {
-                if (sdJwtAlgorithm == SigningAlgorithm.ED25519) {
-                    signers.put(FormatType.LDP_VC, SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, sdJwtJwk));
-                } else {
-                    KeyPair ldpKeyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, SigningAlgorithm.ED25519);
-                    JWK ldpJwk = SigningKeyUtil.generateJwk(SigningAlgorithm.ED25519, ldpKeyPair);
-                    signers.put(FormatType.LDP_VC, SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, ldpJwk));
-                }
-            } else if (format == FormatType.VC_SD_JWT) {
-                signers.put(FormatType.VC_SD_JWT, SigningKeyUtil.createSigner(sdJwtAlgorithm, sdJwtJwk));
-            }
+        if (formats.contains(FormatType.LDP_VC)) {
+            signers.put(FormatType.LDP_VC, SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, ed25519Jwk));
         }
-
         return signers;
-    }
-
-    /**
-     * Extracts the signing algorithm from the SD-JWT's cnf.jwk claim.
-     * When cnf.jwk is absent (e.g. cnf uses jkt/kid), the JAR picks EdDSA from wallet metadata,
-     * so we default to ED25519 to keep the signer consistent with the KB-JWT alg header.
-     */
-    private SigningAlgorithm resolveAlgorithmFromSdJwt(Object sdJwtObj) {
-        if (!(sdJwtObj instanceof String sdJwt)) {
-            return SigningAlgorithm.ED25519;
-        }
-
-        try {
-            Map<String, Object> payload = JwtUtils.extractJwtPayloadFromSdJwt(sdJwt);
-            if (payload == null || payload.isEmpty()) {
-                return SigningAlgorithm.ED25519;
-            }
-            Map<String, Object> cnf = (Map<String, Object>) payload.get("cnf");
-            if (cnf == null) {
-                return SigningAlgorithm.ED25519;
-            }
-            Map<String, Object> jwk = (Map<String, Object>) cnf.get("jwk");
-            if (jwk == null) {
-                // cnf uses jkt/kid form — JAR will put EdDSA in KB-JWT header via wallet metadata
-                return SigningAlgorithm.ED25519;
-            }
-            String alg = (String) jwk.get("alg");
-            if (alg != null) {
-                return SigningAlgorithm.fromString(alg);
-            }
-
-            // Derive from kty + crv when alg is absent
-            String kty = (String) jwk.get("kty");
-            String crv = (String) jwk.get("crv");
-            if ("EC".equals(kty) && "P-256".equals(crv)) return SigningAlgorithm.ES256;
-            if ("EC".equals(kty) && "secp256k1".equals(crv)) return SigningAlgorithm.ES256K;
-            if ("OKP".equals(kty) && "Ed25519".equalsIgnoreCase(crv)) return SigningAlgorithm.ED25519;
-
-        } catch (Exception e) {
-            log.warn("Failed to resolve signing algorithm from SD-JWT cnf.jwk, defaulting to ED25519", e);
-        }
-        return SigningAlgorithm.ED25519;
     }
 
     /**

--- a/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/WalletPresentationServiceImpl.java
@@ -1,5 +1,6 @@
 package io.mosip.mimoto.service.impl;
 
+import com.authlete.sd.SDJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
@@ -27,12 +28,16 @@ import io.mosip.mimoto.util.SigningKeyUtil;
 import io.mosip.mimoto.util.Utilities;
 import io.mosip.mimoto.util.UrlParameterUtils;
 import io.mosip.openID4VP.OpenID4VP;
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.UnsignedSdJwtVPToken;
 import io.mosip.openID4VP.common.EncoderKt;
 import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest;
 import io.mosip.openID4VP.authorizationRequest.Verifier;
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.ClientMetadata;
+import io.mosip.mimoto.service.CredentialFormatHandlerFactory;
+import io.mosip.mimoto.util.JwtUtils;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken;
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult;
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult;
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult;
 import io.mosip.openID4VP.constants.FormatType;
@@ -48,6 +53,7 @@ import java.lang.IllegalArgumentException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
+import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -80,7 +86,9 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
 
     private final DataProtectionService dataProtectionService;
 
-    public WalletPresentationServiceImpl(VerifierService verifierService, OpenID4VPService openID4VPService, ObjectMapper objectMapper, KeyPairRetrievalService keyPairService, CredentialMatchingService credentialMatchingService, VerifiablePresentationsRepository verifiablePresentationsRepository, DataProtectionService dataProtectionService) {
+    private final CredentialFormatHandlerFactory credentialFormatHandlerFactory;
+
+    public WalletPresentationServiceImpl(VerifierService verifierService, OpenID4VPService openID4VPService, ObjectMapper objectMapper, KeyPairRetrievalService keyPairService, CredentialMatchingService credentialMatchingService, VerifiablePresentationsRepository verifiablePresentationsRepository, DataProtectionService dataProtectionService, CredentialFormatHandlerFactory credentialFormatHandlerFactory) {
         this.verifierService = verifierService;
         this.openID4VPService = openID4VPService;
         this.objectMapper = objectMapper;
@@ -88,6 +96,7 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
         this.credentialMatchingService = credentialMatchingService;
         this.verifiablePresentationsRepository = verifiablePresentationsRepository;
         this.dataProtectionService = dataProtectionService;
+        this.credentialFormatHandlerFactory = credentialFormatHandlerFactory;
     }
 
     @Override
@@ -255,22 +264,20 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
         List<Verifier> preRegisteredVerifiers = verifierService.getTrustedVerifiers().getVerifiers().stream().map(verifierDTO -> new Verifier(verifierDTO.getClientId(), verifierDTO.getResponseUris(), verifierDTO.getJwksUri(), verifierDTO.getAllowUnsignedRequest())).toList();
         openID4VP.authenticateVerifier(sessionData.getAuthorizationRequest(), preRegisteredVerifiers, sessionData.isVerifierClientPreregistered());
 
-        // Use configurable signing algorithm
-        SigningAlgorithm signingAlgorithm = SigningAlgorithm.valueOf(DEFAULT_SIGNING_ALGORITHM_NAME);
+        // Determine signing algorithm - ED25519 for LDP_VC, derived from cnf.jwk for SD-JWT
+        SigningAlgorithm signingAlgorithm = resolveSigningAlgorithm(selectedCredentials);
         KeyPair keyPair = keyPairService.getKeyPairFromDB(walletId, base64Key, signingAlgorithm);
         JWK jwk = SigningKeyUtil.generateJwk(signingAlgorithm, keyPair);
-        Map<FormatType, UnsignedVPToken> unsignedVPToken = constructUnsignedVPToken(openID4VP, selectedCredentials, jwk);
+        Map<FormatType, UnsignedVPToken> unsignedVPToken = constructUnsignedVPToken(openID4VP, selectedCredentials, jwk, request.getSelectedSdClaims());
 
         // Step 3: Sign token using user's private key
         JWSSigner jwsSigner = SigningKeyUtil.createSigner(signingAlgorithm, jwk);
-        Map<FormatType, LdpVPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, jwsSigner);
+        Map<FormatType, VPTokenSigningResult> vpTokenSigningResults = signVPToken(unsignedVPToken, jwsSigner);
 
         // Step 4: Share verifiable presentation with verifier using OpenID4VP JAR
         log.debug("Calling OpenID4VP JAR's shareVerifiablePresentation method");
-        // Cast to the expected type for the JAR method
-        @SuppressWarnings({"unchecked", "rawtypes"}) Map<FormatType, VPTokenSigningResult> jarMap = (Map) vpTokenSigningResults;
         try {
-            VerifierResponse response = openID4VP.sendVPResponseToVerifier(jarMap);
+            VerifierResponse response = openID4VP.sendVPResponseToVerifier(vpTokenSigningResults);
             boolean shareSuccess = response.getStatusCode() >= 200 && response.getStatusCode() < 300;
             // Step 5: Store presentation record in database
             storePresentationRecord(walletId, presentationId, request, sessionData, shareSuccess, requestedAt);
@@ -285,28 +292,56 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     }
 
     /**
-     * Signs VP token using JWSSigner for LDP_VC format
-     * Only LDP_VC format is supported. Throws InvalidRequestException for other formats.
+     * Signs VP token using JWSSigner - dispatches to format-specific signing logic
      */
-    private Map<FormatType, LdpVPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, JWSSigner jwsSigner) {
+    private Map<FormatType, VPTokenSigningResult> signVPToken(Map<FormatType, UnsignedVPToken> unsignedVPTokensMap, JWSSigner jwsSigner) {
         log.debug("Signing VP token for {} format types", unsignedVPTokensMap.size());
 
         return unsignedVPTokensMap.entrySet().stream().map(entry -> {
             FormatType formatType = entry.getKey();
             UnsignedVPToken unsignedVPToken = entry.getValue();
 
-            if (formatType != FormatType.LDP_VC) {
-                log.error("Unsupported format type: {}. Only ldp_vc format is supported.", formatType);
-                throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Unsupported credential format: " + formatType + ". Only ldp_vc format is supported.");
-            }
-
             try {
-                LdpVPTokenSigningResult signingResult = signLdpVcFormat(unsignedVPToken, jwsSigner);
+                VPTokenSigningResult signingResult;
+                if (formatType == FormatType.LDP_VC) {
+                    signingResult = signLdpVcFormat(unsignedVPToken, jwsSigner);
+                } else if (formatType == FormatType.VC_SD_JWT) {
+                    signingResult = signSdJwtFormat(unsignedVPToken, jwsSigner);
+                } else {
+                    log.error("Unsupported format type: {}", formatType);
+                    throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Unsupported format type: " + formatType);
+                }
                 return Map.entry(formatType, signingResult);
-            } catch (JOSEException e) {
+            } catch (JOSEException | ParseException e) {
                 throw new RuntimeException("Failed to sign VP token for format: " + formatType, e);
             }
         }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Signs SD-JWT JB-JWT tokens. The library provides unsigned KB-JWTs (header.payload) per credential UUID.
+     * Mimoto signs each one and returns the signatures.
+     */
+    private SdJwtVPTokenSigningResult signSdJwtFormat(UnsignedVPToken unsignedVPToken, JWSSigner jwsSigner) throws JOSEException, ParseException {
+        UnsignedSdJwtVPToken sdJwtToken = (UnsignedSdJwtVPToken) unsignedVPToken;
+        Map<String, String> uuidToUnsignedKBT = sdJwtToken.getUuidToUnsignedKBT();
+
+        Map<String, String> uuidToSignature = new HashMap<>();
+        for (Map.Entry<String, String> entry: uuidToUnsignedKBT.entrySet()) {
+            String uuid = entry.getKey();
+            // "headerB64.payloadB64"
+            String unsignedKBT = entry.getValue();
+
+            // Standard JWT signing input: ASCII bytes of "headerB64.payloadB64"
+            String[] parts = unsignedKBT.split("\\.");
+            JWSHeader kbHeader = JWSHeader.parse(new Base64URL(parts[0]));
+            byte[] signingInput = unsignedKBT.getBytes(StandardCharsets.US_ASCII);
+
+            Base64URL signature = jwsSigner.sign(kbHeader, signingInput);
+            uuidToSignature.put(uuid, signature.toString());
+        }
+
+        return new SdJwtVPTokenSigningResult(uuidToSignature);
     }
 
     /**
@@ -360,13 +395,14 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     }
 
     /**
-     * Constructs unsigned VP token using the OpenID4VP JAR
+     * Constructs unsigned VP token using the OpenID4VP JAR.
+     * For SD-JWT credentials, disclosures are pre-filtered to the user's selectedSdClaims.
      */
-    private Map<FormatType, UnsignedVPToken> constructUnsignedVPToken(OpenID4VP openID4VP, List<DecryptedCredentialDTO> credentials, JWK jwk) throws JsonProcessingException {
+    private Map<FormatType, UnsignedVPToken> constructUnsignedVPToken(OpenID4VP openID4VP, List<DecryptedCredentialDTO> credentials, JWK jwk, Map<String, List<String>> selectedSdClaims) throws JsonProcessingException {
 
         log.debug("Constructing unsigned VP token for {} credentials", credentials.size());
 
-        Map<String, Map<FormatType, List<Object>>> verifiableCredentials = convertCredentialsToJarFormat(credentials);
+        Map<String, Map<FormatType, List<Object>>> verifiableCredentials = convertCredentialsToJarFormat(credentials, selectedSdClaims);
         String holderId = resolveHolderId(jwk);
         return openID4VP.constructUnsignedVPToken(verifiableCredentials, holderId, DEFAULT_SIGNATURE_SUITE);
 
@@ -388,37 +424,167 @@ public class WalletPresentationServiceImpl implements WalletPresentationService 
     }
 
     /**
-     * Converts DecryptedCredentialDTO list to the format expected by the OpenID4VP JAR
-     * Extracts the inner credential data from VCCredentialResponse wrapper to remove the "credential" wrapper
+     * Converts DecryptedCredentialDTO list to the format expected by the OpenID4VP JAR.
+     * Extracts the inner credential data from VCCredentialResponse wrapper to remove the "credential" wrapper.
+     * For SD-JWT credentials, filters disclosures down to only the user-selected claims.
      */
-    private Map<String, Map<FormatType, List<Object>>> convertCredentialsToJarFormat(List<DecryptedCredentialDTO> credentials) {
+    private Map<String, Map<FormatType, List<Object>>> convertCredentialsToJarFormat(List<DecryptedCredentialDTO> credentials, Map<String, List<String>> selectedSdClaims) {
+        Map<String, Map<FormatType, List<Object>>> result = new HashMap<>();
 
-        return credentials.stream().collect(Collectors.groupingBy(DecryptedCredentialDTO::getId, Collectors.collectingAndThen(Collectors.toList(), credList -> credList.stream().collect(Collectors.groupingBy(credential -> {
-            // Get format and credential data
-            VCCredentialResponse vcCredentialResponse = credential.getCredential();
-            String credentialFormat = vcCredentialResponse.getFormat();
-            // Convert format string to FormatType enum
-            return mapStringToFormatType(credentialFormat);
-        }, Collectors.mapping(credential -> credential.getCredential().getCredential(), Collectors.toList()))))));
+        for (DecryptedCredentialDTO credential: credentials) {
+            VCCredentialResponse vcResponse = credential.getCredential();
+            String format = vcResponse.getFormat();
+            FormatType formatType = mapStringToFormatType(format);
+
+            Object credentialData;
+            if(CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+                List<String> selectedPaths = selectedSdClaims != null ? selectedSdClaims.get(credential.getId()) : null;
+                credentialData = buildFilteredSdJwt(credential, selectedPaths);
+            } else {
+                credentialData = vcResponse.getCredential();
+            }
+
+            result.computeIfAbsent(credential.getId(), k -> new HashMap<>())
+                    .computeIfAbsent(formatType, k -> new ArrayList<>())
+                    .add(credentialData);
+        }
+
+        return result;
     }
 
     /**
-     * Maps format string to FormatType enum
-     * Only ldp_vc format is supported. Throws InvalidRequestException for other formats.
+     * Maps format string to FormatType enum.
      */
     private FormatType mapStringToFormatType(String format) {
         if (format == null) {
             log.error("Credential format is null");
-            throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Credential format is required. Only ldp_vc format is supported.");
+            throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Credential format is required.");
         }
 
         String formatLower = format.toLowerCase();
-        if (CredentialFormat.LDP_VC.getFormat().equals(formatLower)) {
-            return FormatType.LDP_VC;
+        if (CredentialFormat.LDP_VC.getFormat().equals(formatLower)) return FormatType.LDP_VC;
+        if (CredentialFormat.VC_SD_JWT.getFormat().equals(formatLower)) return FormatType.VC_SD_JWT;
+
+        log.error("Unsupported credential format: {}", format);
+        throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Unsupported credential format: " + format);
+    }
+
+    /**
+     * Builds a filtered SD-JWT string containing only the user-selected disclosures.
+     * If selectedPaths is null/empty, all disclosures are retained.
+     */
+    private String buildFilteredSdJwt(DecryptedCredentialDTO credential, List<String> selectedPaths) {
+        String sdJwtString = (String) credential.getCredential().getCredential();
+
+        if (selectedPaths == null || selectedPaths.isEmpty()) {
+            return sdJwtString;
         }
 
-        log.error("Unsupported credential format: {}. Only ldp_vc format is supported.", format);
-        throw new InvalidRequestException(INVALID_REQUEST.getErrorCode(), "Unsupported credential format: " + format + ". Only ldp_vc format is supported.");
+        try {
+            // Get path -> List <disclosuresB64> mapping from the format handler
+            Map<String, ?> allProps = credentialFormatHandlerFactory
+                    .getHandler(credential.getCredential().getFormat())
+                    .extractAllCredentialProperties(credential.getCredential());
+
+            if (!(allProps.get("sdClaims") instanceof Map<?, ?> rawSdClaims)) {
+                return sdJwtString;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> sdClaimsMap = (Map<String, Object>) rawSdClaims;
+            if (sdClaimsMap.isEmpty()) {
+                return sdJwtString;
+            }
+
+            // Normalize paths: "$.name" -> "name", "$.address.city" -> "address.city"
+            Set<String> normalizedPaths = selectedPaths.stream().
+                    map(p -> p.startsWith("$.") ? p.substring(2) : p)
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            // Collect all disclosures B64 strings for the selected paths (preserving order, deduplicating)
+            Set<String> allDisclosuresB64 = new LinkedHashSet<>();
+            for (String path : normalizedPaths) {
+                Object disclosures = sdClaimsMap.get(path);
+                if (disclosures instanceof List<?> discList) {
+                    discList.forEach(d -> allDisclosuresB64.add((String) d));
+                }
+            }
+
+            // Reconstruct: credentialJwt ~ disc1 ~ disc2 ~ (trailing ~ required by SD-JWT)
+            SDJWT sdJwt = SDJWT.parse(sdJwtString);
+            StringBuilder sb = new StringBuilder(sdJwt.getCredentialJwt());
+            for (String disc: allDisclosuresB64) {
+                sb.append("~").append(disc);
+            }
+            sb.append("~");
+            return sb.toString();
+
+        } catch (Exception e) {
+            log.error("Failed to filter SD-JWT disclosures for credential: {}, selectedPaths: {}. Returning original SD-JWT. Error: {}", credential.getId(), selectedPaths, e.getMessage(), e);
+            return sdJwtString;
+        }
+    }
+
+    /**
+     * Determines the signing algorithm
+     * - SD-JWT credentials: reads alg from cnf.jwk in the credential payload
+     * - LDP-VC credentials: defaults to ED25519
+     */
+    private SigningAlgorithm resolveSigningAlgorithm(List<DecryptedCredentialDTO> credentials) {
+        return credentials.stream()
+                .map(c -> c.getCredential().getFormat())
+                .filter(f -> CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(f))
+                .findFirst()
+                .map(f -> {
+                    String sdJwt = (String) credentials.stream()
+                            .filter(c -> f.equalsIgnoreCase(c.getCredential().getFormat()))
+                            .findFirst()
+                            .map(c -> c.getCredential().getCredential())
+                            .orElse(null);
+                    return resolveAlgorithmFromSdJwt(sdJwt);
+                })
+                .orElse(SigningAlgorithm.valueOf(DEFAULT_SIGNING_ALGORITHM_NAME));
+    }
+
+    /**
+     * Extracts the signing algorithm from the SD-JWT's cnf.jwk claim.
+     * When cnf.jwk is absent (e.g. cnf uses jkt/kid), the JAR picks EdDSA from wallet metadata,
+     * so we default to ED25519 to keep the signer consistent with the KB-JWT alg header.
+     */
+    private SigningAlgorithm resolveAlgorithmFromSdJwt(Object sdJwtObj) {
+        if (!(sdJwtObj instanceof String sdJwt)) {
+            return SigningAlgorithm.ED25519;
+        }
+
+        try {
+            Map<String, Object> payload = JwtUtils.extractJwtPayloadFromSdJwt(sdJwt);
+            if (payload == null || payload.isEmpty()) {
+                return SigningAlgorithm.ED25519;
+            }
+            Map<String, Object> cnf = (Map<String, Object>) payload.get("cnf");
+            if (cnf == null) {
+                return SigningAlgorithm.ED25519;
+            }
+            Map<String, Object> jwk = (Map<String, Object>) cnf.get("jwk");
+            if (jwk == null) {
+                // cnf uses jkt/kid form — JAR will put EdDSA in KB-JWT header via wallet metadata
+                return SigningAlgorithm.ED25519;
+            }
+            String alg = (String) jwk.get("alg");
+            if (alg != null) {
+                return SigningAlgorithm.fromString(alg);
+            }
+
+            // Derive from kty + crv when alg is absent
+            String kty = (String) jwk.get("kty");
+            String crv = (String) jwk.get("crv");
+            if ("EC".equals(kty) && "P-256".equals(crv)) return SigningAlgorithm.ES256;
+            if ("EC".equals(kty) && "secp256k1".equals(crv)) return SigningAlgorithm.ES256K;
+            if ("OKP".equals(kty) && "Ed25519".equalsIgnoreCase(crv)) return SigningAlgorithm.ED25519;
+
+        } catch (Exception e) {
+            log.warn("Failed to resolve signing algorithm from SD-JWT cnf.jwk, defaulting to ED25519", e);
+        }
+        return SigningAlgorithm.ED25519;
     }
 
     /**

--- a/src/main/java/io/mosip/mimoto/util/factory/Ed25519AlgorithmHandler.java
+++ b/src/main/java/io/mosip/mimoto/util/factory/Ed25519AlgorithmHandler.java
@@ -76,7 +76,7 @@ public class Ed25519AlgorithmHandler implements SigningAlgorithmHandler {
 
             @Override
             public Set<JWSAlgorithm> supportedJWSAlgorithms() {
-                return Collections.singleton(JWSAlgorithm.Ed25519);
+                return Set.of(JWSAlgorithm.Ed25519, JWSAlgorithm.EdDSA);
             }
 
             @Override

--- a/src/test/java/io/mosip/mimoto/constant/CredentialFormatTest.java
+++ b/src/test/java/io/mosip/mimoto/constant/CredentialFormatTest.java
@@ -1,0 +1,64 @@
+package io.mosip.mimoto.constant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CredentialFormatTest {
+
+    @Test
+    void shouldReturnCorrectFormatStringForEachValue() {
+        assertEquals("vc+sd-jwt", CredentialFormat.VC_SD_JWT.getFormat());
+        assertEquals("dc+sd-jwt", CredentialFormat.DC_SD_JWT.getFormat());
+        assertEquals("ldp_vc", CredentialFormat.LDP_VC.getFormat());
+    }
+
+    @Test
+    void shouldHaveThreeEnumValues() {
+        assertEquals(3, CredentialFormat.values().length);
+    }
+
+    @Test
+    void fromStringShouldResolveEachFormatCaseInsensitively() {
+        assertEquals(CredentialFormat.VC_SD_JWT, CredentialFormat.fromString("vc+sd-jwt"));
+        assertEquals(CredentialFormat.DC_SD_JWT, CredentialFormat.fromString("dc+sd-jwt"));
+        assertEquals(CredentialFormat.LDP_VC, CredentialFormat.fromString("ldp_vc"));
+        // case-insensitive
+        assertEquals(CredentialFormat.VC_SD_JWT, CredentialFormat.fromString("VC+SD-JWT"));
+        assertEquals(CredentialFormat.DC_SD_JWT, CredentialFormat.fromString("DC+SD-JWT"));
+    }
+
+    @Test
+    void fromStringShouldThrowForUnknownFormat() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> CredentialFormat.fromString("unknown_format"));
+        assertEquals("Unknown credential format: unknown_format", exception.getMessage());
+    }
+
+    @Test
+    void isSdJwtShouldBeTrueForBothSdJwtFormats() {
+        assertTrue(CredentialFormat.isSdJwt("vc+sd-jwt"));
+        assertTrue(CredentialFormat.isSdJwt("dc+sd-jwt"));
+        // case-insensitive
+        assertTrue(CredentialFormat.isSdJwt("VC+SD-JWT"));
+        assertTrue(CredentialFormat.isSdJwt("DC+SD-JWT"));
+    }
+
+    @Test
+    void isSdJwtShouldBeFalseForLdpVc() {
+        assertFalse(CredentialFormat.isSdJwt("ldp_vc"));
+    }
+
+    @Test
+    void isSdJwtShouldBeFalseForNull() {
+        assertFalse(CredentialFormat.isSdJwt(null));
+    }
+
+    @Test
+    void isSdJwtShouldBeFalseForUnknownFormat() {
+        assertFalse(CredentialFormat.isSdJwt("mso_mdoc"));
+    }
+}

--- a/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
@@ -1180,8 +1180,8 @@ public class CredentialMatchingServiceTest {
         // Act
         MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
 
-        // Assert
-        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        // Assert - no sd-jwt_alg_values constraint means any algorithm is acceptable
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
@@ -78,7 +78,7 @@ public class CredentialMatchingServiceTest {
                     VCCredentialResponse vc = invocation.getArgument(0);
                     String format = vc.getFormat();
 
-                    if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+                    if (CredentialFormat.isSdJwt(format)) {
                         Map<String, Object> publicClaims = new LinkedHashMap<>();
                         publicClaims.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
                         Map<String, Map<String, Object>> result = new LinkedHashMap<>();
@@ -474,18 +474,26 @@ public class CredentialMatchingServiceTest {
                 result.getMatchingCredentialsResponse().getAvailableCredentials().get(0).getFormat());
     }
 
-    @Test(expected = InvalidRequestException.class)
+    @Test
     public void testGetMatchingCredentialsWithDcSdJwtFormat() throws Exception {
         // Arrange
         PresentationDefinition pd = createMockPresentationDefinition();
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pd);
-        List<DecryptedCredentialDTO> dcSdJwtCredentials = createMockWalletCredentialsWithDcSdJwtFormat();
+        when(credentialFormatHandlerFactory.getHandler(eq(CredentialFormat.DC_SD_JWT.getFormat())))
+                .thenReturn(credentialFormatHandler);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(dcSdJwtCredentials);
+                .thenReturn(createMockWalletCredentialsWithDcSdJwtFormat());
 
         // Act
-        credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+        MatchingCredentialsDTO result = credentialMatchingService
+                .getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert - dc+sd-jwt is handled like vc+sd-jwt and surfaces as an available credential
+        assertNotNull(result);
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertEquals(CredentialFormat.DC_SD_JWT.getFormat(),
+                result.getMatchingCredentialsResponse().getAvailableCredentials().get(0).getFormat());
     }
 
     @Test

--- a/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
@@ -79,8 +79,10 @@ public class CredentialMatchingServiceTest {
                     String format = vc.getFormat();
 
                     if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+                        Map<String, Object> publicClaims = new LinkedHashMap<>();
+                        publicClaims.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
                         Map<String, Map<String, Object>> result = new LinkedHashMap<>();
-                        result.put("publicClaims", new LinkedHashMap<>());
+                        result.put("publicClaims", publicClaims);
                         result.put("sdClaims", new LinkedHashMap<>());
                         return result;
                     }
@@ -465,9 +467,11 @@ public class CredentialMatchingServiceTest {
         MatchingCredentialsDTO result = credentialMatchingService
                 .getMatchingCredentials(sessionData, walletId, base64Key);
 
-        // Assert
+        // Assert - PD has no format constraint; SD-JWT credential with $.type satisfies the constraint
         assertNotNull(result);
-        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertEquals(CredentialFormat.VC_SD_JWT.getFormat(),
+                result.getMatchingCredentialsResponse().getAvailableCredentials().get(0).getFormat());
     }
 
     @Test(expected = InvalidRequestException.class)
@@ -1226,10 +1230,12 @@ public class CredentialMatchingServiceTest {
     }
 
     @Test
-    public void testMatchesSdJwtFormatWhenFormatConfigValueIsNullCredentialNotSelected() throws Exception {
-        // Arrange
+    public void testMatchesSdJwtFormatWhenFormatConfigValueIsNullCredentialSelected() throws Exception {
+        // Arrange - sd-jwt_alg_values key present but value is explicitly null → any alg acceptable
+        Map<String, List<String>> sdJwtFormatConfig = new HashMap<>();
+        sdJwtFormatConfig.put("sd-jwt_alg_values", null);
         Map<String, Map<String, List<String>>> format = new HashMap<>();
-        format.put(CredentialFormat.VC_SD_JWT.getFormat(), Map.of("jwt_alg_values", List.of("ES256")));
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), sdJwtFormatConfig);
 
         Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
         Constraints constraints = new Constraints(Collections.singletonList(field), null);
@@ -1243,8 +1249,8 @@ public class CredentialMatchingServiceTest {
         // Act
         MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
 
-        // Assert
-        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        // Assert - null alg list means no restriction, credential should be selected
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test
@@ -1940,7 +1946,7 @@ public class CredentialMatchingServiceTest {
         // Assert
         assertNotNull(result);
         assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
-        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("type"));
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("test"));
     }
 
     @Test
@@ -1963,7 +1969,7 @@ public class CredentialMatchingServiceTest {
         // Assert
         assertNotNull(result);
         assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
-        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().isEmpty());
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("sd-jwt_alg_values"));
     }
 
     @Test
@@ -1987,8 +1993,9 @@ public class CredentialMatchingServiceTest {
         MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
 
         // Assert
-        assertEquals(1, result.getMatchingCredentialsResponse().getMissingClaims().size());
-        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("type"));
+        assertEquals(2, result.getMatchingCredentialsResponse().getMissingClaims().size());
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("desc-1"));
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("desc-2"));
     }
 
 
@@ -2105,8 +2112,9 @@ public class CredentialMatchingServiceTest {
         MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
 
         // Assert
-        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("name"));
-        assertEquals(1, result.getMatchingCredentialsResponse().getMissingClaims().size());
+        assertEquals(2, result.getMatchingCredentialsResponse().getMissingClaims().size());
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("desc-null"));
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("desc-valid"));
     }
 
     @Test
@@ -2125,7 +2133,7 @@ public class CredentialMatchingServiceTest {
         MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
 
         // Assert
-        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("id"));
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("test"));
     }
 
     @Test
@@ -2240,5 +2248,128 @@ public class CredentialMatchingServiceTest {
             map.put((String) keyValues[i], keyValues[i + 1]);
         }
         return map;
+    }
+
+    // --- extractFormatConstraintKeys ---
+
+    @Test
+    public void testExtractFormatConstraintKeysWhenVcSdJwtFormatReturnsSdJwtAlgValues() throws Exception {
+        Method method = CredentialMatchingServiceImpl.class.getDeclaredMethod("extractFormatConstraintKeys", InputDescriptor.class);
+        method.setAccessible(true);
+
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), new HashMap<>());
+        InputDescriptor descriptor = new InputDescriptor("test-id", null, null, format, new Constraints(null, null));
+
+        @SuppressWarnings("unchecked")
+        Set<String> result = (Set<String>) method.invoke(credentialMatchingService, descriptor);
+        assertEquals(1, result.size());
+        assertTrue(result.contains("sd-jwt_alg_values"));
+    }
+
+    @Test
+    public void testExtractFormatConstraintKeysWhenLdpVcFormatReturnsProofType() throws Exception {
+        Method method = CredentialMatchingServiceImpl.class.getDeclaredMethod("extractFormatConstraintKeys", InputDescriptor.class);
+        method.setAccessible(true);
+
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put("ldp_vc", new HashMap<>());
+        InputDescriptor descriptor = new InputDescriptor("test-id", null, null, format, new Constraints(null, null));
+
+        @SuppressWarnings("unchecked")
+        Set<String> result = (Set<String>) method.invoke(credentialMatchingService, descriptor);
+        assertEquals(1, result.size());
+        assertTrue(result.contains("proof_type"));
+    }
+
+    @Test
+    public void testExtractFormatConstraintKeysWhenNullFormatReturnsDescriptorId() throws Exception {
+        Method method = CredentialMatchingServiceImpl.class.getDeclaredMethod("extractFormatConstraintKeys", InputDescriptor.class);
+        method.setAccessible(true);
+
+        InputDescriptor descriptor = new InputDescriptor("my-descriptor-id", null, null, null, new Constraints(null, null));
+
+        @SuppressWarnings("unchecked")
+        Set<String> result = (Set<String>) method.invoke(credentialMatchingService, descriptor);
+        assertEquals(1, result.size());
+        assertTrue(result.contains("my-descriptor-id"));
+    }
+
+    @Test
+    public void testExtractFormatConstraintKeysWhenBothFormatsPresentReturnsBothKeys() throws Exception {
+        Method method = CredentialMatchingServiceImpl.class.getDeclaredMethod("extractFormatConstraintKeys", InputDescriptor.class);
+        method.setAccessible(true);
+
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), new HashMap<>());
+        format.put("ldp_vc", new HashMap<>());
+        InputDescriptor descriptor = new InputDescriptor("test-id", null, null, format, new Constraints(null, null));
+
+        @SuppressWarnings("unchecked")
+        Set<String> result = (Set<String>) method.invoke(credentialMatchingService, descriptor);
+        assertEquals(2, result.size());
+        assertTrue(result.contains("sd-jwt_alg_values"));
+        assertTrue(result.contains("proof_type"));
+    }
+
+    // --- getMatchingCredentials else-block: hasFormatMatch paths ---
+
+    @Test
+    public void testGetMatchingCredentialsWhenFormatMatchesButConstraintFailsUsesMissingFieldNames() throws Exception {
+        // Descriptor: ldp_vc with empty proof_type list + $.name constraint
+        // Wallet: ldp_vc credential that passes matchesFormat but not matchesConstraints
+        // Expected: missingClaims = ["name"] (field names), not "proof_type" (format key)
+        Map<String, List<String>> ldpVcFormatMap = new HashMap<>();
+        ldpVcFormatMap.put("proof_type", Collections.emptyList());
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put("ldp_vc", ldpVcFormatMap);
+
+        Fields nameField = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(nameField), null);
+        InputDescriptor descriptor = new InputDescriptor("ldp-desc", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        // ldp_vc credential without a top-level "name" field → constraint fails
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        VCCredentialProperties props = new VCCredentialProperties();
+        doReturn(props).when(objectMapper).convertValue(any(), eq(VCCredentialProperties.class));
+
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertTrue("field name must appear when format matched",
+                result.getMatchingCredentialsResponse().getMissingClaims().contains("name"));
+        assertFalse("format key must NOT appear when format matched",
+                result.getMatchingCredentialsResponse().getMissingClaims().contains("proof_type"));
+    }
+
+    @Test
+    public void testGetMatchingCredentialsWhenNoFormatMatchReturnsSdJwtAlgValuesKey() throws Exception {
+        // Descriptor: vc+sd-jwt format; wallet has only ldp_vc credential
+        // Expected: missingClaims = ["sd-jwt_alg_values"] (format key), not constraint field names
+        Map<String, List<String>> sdJwtFormatMap = new HashMap<>();
+        sdJwtFormatMap.put("sd-jwt_alg_values", Arrays.asList("ES256"));
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), sdJwtFormatMap);
+
+        Fields vctField = new Fields(Arrays.asList("$.vct"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(vctField), null);
+        InputDescriptor descriptor = new InputDescriptor("sdjwt-desc", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData()); // ldp_vc credential only
+
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertTrue("format key must appear when no format match",
+                result.getMatchingCredentialsResponse().getMissingClaims().contains("sd-jwt_alg_values"));
+        assertFalse("field name must NOT appear when no format match",
+                result.getMatchingCredentialsResponse().getMissingClaims().contains("vct"));
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.util.Base64URL;
+import com.authlete.sd.SDJWT;
 import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.constant.OpenID4VPConstants;
 import io.mosip.mimoto.constant.SigningAlgorithm;
@@ -19,6 +20,9 @@ import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
 import io.mosip.mimoto.exception.*;
 import io.mosip.mimoto.model.VerifiablePresentation;
 import io.mosip.mimoto.repository.VerifiablePresentationsRepository;
+import io.mosip.mimoto.service.CredentialFormatHandler;
+import io.mosip.mimoto.service.CredentialFormatHandlerFactory;
+import io.mosip.mimoto.service.CredentialMatchingService;
 import io.mosip.mimoto.service.impl.OpenID4VPService;
 import io.mosip.mimoto.service.impl.WalletPresentationServiceImpl;
 import io.mosip.mimoto.util.SigningKeyUtil;
@@ -29,7 +33,9 @@ import io.mosip.openID4VP.authorizationRequest.AuthorizationRequest;
 import io.mosip.openID4VP.authorizationRequest.clientMetadata.ClientMetadata;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
 import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.ldp.UnsignedLdpVPToken;
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.types.sdJwt.UnsignedSdJwtVPToken;
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.ldp.LdpVPTokenSigningResult;
+import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.types.sdJwt.SdJwtVPTokenSigningResult;
 import io.mosip.openID4VP.constants.FormatType;
 import io.mosip.openID4VP.verifier.VerifierResponse;
 import org.junit.Before;
@@ -41,10 +47,13 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.time.Instant;
 import java.util.*;
+import java.util.Base64;
 
 import static io.mosip.mimoto.exception.ErrorConstants.*;
 import static org.junit.Assert.*;
@@ -71,6 +80,15 @@ public class WalletPresentationServiceTest {
 
     @Mock
     private DataProtectionService dataProtectionService;
+
+    @Mock
+    private CredentialMatchingService credentialMatchingService;
+
+    @Mock
+    private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
+
+    @Mock
+    private CredentialFormatHandler credentialFormatHandler;
 
     @InjectMocks
     private WalletPresentationServiceImpl walletPresentationService;
@@ -302,6 +320,7 @@ public class WalletPresentationServiceTest {
         when(testOpenID4VP.authenticateVerifier(anyString(), anyList(), anyBoolean())).thenReturn(mockAuthorizationRequest);
 
         Map<FormatType, UnsignedVPToken> unsignedTokens = new HashMap<>();
+        unsignedTokens.put(FormatType.LDP_VC, mock(UnsignedLdpVPToken.class));
         when(testOpenID4VP.constructUnsignedVPToken(any(), anyString(), anyString())).thenReturn(unsignedTokens);
 
         try (MockedStatic<SigningKeyUtil> jwtUtilMock = mockStatic(SigningKeyUtil.class);
@@ -1143,5 +1162,289 @@ public class WalletPresentationServiceTest {
 
         assertNotNull(response);
         assertEquals(500, response.getStatusCode().value());
+    }
+
+    // --- resolveAlgorithmFromSdJwt ---
+
+    private String buildSdJwtWithPayload(String payloadJson) {
+        String header = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"ES256\"}".getBytes(StandardCharsets.UTF_8));
+        String payload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+        return header + "." + payload + ".sig";
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenInputIsNullReturnsED25519() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, (Object) null);
+        assertEquals(SigningAlgorithm.ED25519, result);
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenSdJwtIsBlankReturnsED25519() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, "   ");
+        assertEquals(SigningAlgorithm.ED25519, result);
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenCnfAbsentReturnsED25519() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
+                buildSdJwtWithPayload("{\"iss\":\"test\"}"));
+        assertEquals(SigningAlgorithm.ED25519, result);
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenCnfJwkAbsentReturnsED25519() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
+                buildSdJwtWithPayload("{\"cnf\":{\"jkt\":\"some-thumbprint\"}}"));
+        assertEquals(SigningAlgorithm.ED25519, result);
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenCnfJwkIsEcP256ReturnsES256() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
+                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"P-256\"}}}"));
+        assertEquals(SigningAlgorithm.ES256, result);
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenCnfJwkIsEcSecp256k1ReturnsES256K() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
+                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"secp256k1\"}}}"));
+        assertEquals(SigningAlgorithm.ES256K, result);
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenCnfJwkIsOkpEd25519ReturnsED25519() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
+                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"OKP\",\"crv\":\"Ed25519\"}}}"));
+        assertEquals(SigningAlgorithm.ED25519, result);
+    }
+
+    @Test
+    public void testResolveAlgorithmFromSdJwtWhenCnfJwkHasAlgFieldUsesAlg() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
+                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"P-256\",\"alg\":\"ES256\"}}}"));
+        assertEquals(SigningAlgorithm.ES256, result);
+    }
+
+    // --- resolveSigningAlgorithm ---
+
+    @Test
+    public void testResolveSigningAlgorithmWhenOnlyLdpVcCredentialReturnsED25519() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveSigningAlgorithm", List.class);
+        method.setAccessible(true);
+
+        DecryptedCredentialDTO ldpCred = DecryptedCredentialDTO.builder()
+                .id("cred-ldp")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.LDP_VC.getFormat())
+                        .credential(new HashMap<>())
+                        .build())
+                .build();
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, List.of(ldpCred));
+        assertEquals(SigningAlgorithm.ED25519, result);
+    }
+
+    @Test
+    public void testResolveSigningAlgorithmWhenEmptyListReturnsED25519() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveSigningAlgorithm", List.class);
+        method.setAccessible(true);
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, Collections.emptyList());
+        assertEquals(SigningAlgorithm.ED25519, result);
+    }
+
+    @Test
+    public void testResolveSigningAlgorithmWhenSdJwtCredentialWithEcP256ReturnsES256() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveSigningAlgorithm", List.class);
+        method.setAccessible(true);
+
+        String sdJwt = buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"P-256\"}}}");
+        DecryptedCredentialDTO sdJwtCred = DecryptedCredentialDTO.builder()
+                .id("cred-sdjwt")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential(sdJwt)
+                        .build())
+                .build();
+
+        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, List.of(sdJwtCred));
+        assertEquals(SigningAlgorithm.ES256, result);
+    }
+
+    // --- signSdJwtFormat ---
+
+    @Test
+    public void testSignSdJwtFormatSignsKBTAndReturnsSignaturePerUuid() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "signSdJwtFormat", UnsignedVPToken.class, JWSSigner.class);
+        method.setAccessible(true);
+
+        String kbHeader = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"ES256\"}".getBytes(StandardCharsets.UTF_8));
+        String kbPayload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"nonce\":\"abc\"}".getBytes(StandardCharsets.UTF_8));
+        String unsignedKBT = kbHeader + "." + kbPayload;
+
+        Map<String, String> uuidToKBT = new HashMap<>();
+        uuidToKBT.put("uuid-1", unsignedKBT);
+
+        UnsignedSdJwtVPToken mockToken = mock(UnsignedSdJwtVPToken.class);
+        when(mockToken.getUuidToUnsignedKBT()).thenReturn(uuidToKBT);
+        when(jwsSigner.sign(any(JWSHeader.class), any(byte[].class))).thenReturn(Base64URL.encode("test-sig"));
+
+        SdJwtVPTokenSigningResult result = (SdJwtVPTokenSigningResult) method.invoke(
+                walletPresentationService, mockToken, jwsSigner);
+
+        assertNotNull(result);
+        verify(jwsSigner).sign(any(JWSHeader.class),
+                eq(unsignedKBT.getBytes(StandardCharsets.US_ASCII)));
+        assertTrue(result.getUuidToKbJWTSignature().containsKey("uuid-1"));
+        assertEquals(Base64URL.encode("test-sig").toString(), result.getUuidToKbJWTSignature().get("uuid-1"));
+    }
+
+    // --- buildFilteredSdJwt ---
+
+    @Test
+    public void testBuildFilteredSdJwtWhenSelectedPathsIsNullReturnsOriginal() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        String originalSdJwt = "header.payload.sig~disc1~";
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential(originalSdJwt)
+                        .build())
+                .build();
+
+        String result = (String) method.invoke(walletPresentationService, credential, null);
+        assertEquals(originalSdJwt, result);
+    }
+
+    @Test
+    public void testBuildFilteredSdJwtWhenSelectedPathsFiltersToSelectedDisclosures() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        String originalSdJwt = "header.payload.sig~emailDiscB64~nameDiscB64~";
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential(originalSdJwt)
+                        .build())
+                .build();
+
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("email", List.of("emailDiscB64"));
+        sdClaims.put("name", List.of("nameDiscB64"));
+        Map<String, Object> allProps = new HashMap<>();
+        allProps.put("sdClaims", sdClaims);
+
+        when(credentialFormatHandlerFactory.getHandler(CredentialFormat.VC_SD_JWT.getFormat()))
+                .thenReturn(credentialFormatHandler);
+        doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
+
+        SDJWT mockSdJwt = mock(SDJWT.class);
+        when(mockSdJwt.getCredentialJwt()).thenReturn("header.payload.sig");
+
+        try (MockedStatic<SDJWT> mockedSdjwt = mockStatic(SDJWT.class)) {
+            mockedSdjwt.when(() -> SDJWT.parse(originalSdJwt)).thenReturn(mockSdJwt);
+
+            String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
+            assertEquals("header.payload.sig~emailDiscB64~", result);
+        }
+    }
+
+    @Test
+    public void testBuildFilteredSdJwtNormalizesPathsWithoutDollarDotPrefix() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        String originalSdJwt = "header.payload.sig~emailDiscB64~";
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential(originalSdJwt)
+                        .build())
+                .build();
+
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("email", List.of("emailDiscB64"));
+        Map<String, Object> allProps = new HashMap<>();
+        allProps.put("sdClaims", sdClaims);
+
+        when(credentialFormatHandlerFactory.getHandler(CredentialFormat.VC_SD_JWT.getFormat()))
+                .thenReturn(credentialFormatHandler);
+        doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
+
+        SDJWT mockSdJwt = mock(SDJWT.class);
+        when(mockSdJwt.getCredentialJwt()).thenReturn("header.payload.sig");
+
+        try (MockedStatic<SDJWT> mockedSdjwt = mockStatic(SDJWT.class)) {
+            mockedSdjwt.when(() -> SDJWT.parse(originalSdJwt)).thenReturn(mockSdJwt);
+
+            // "email" without "$." prefix should produce the same result as "$.email"
+            String result = (String) method.invoke(walletPresentationService, credential, List.of("email"));
+            assertEquals("header.payload.sig~emailDiscB64~", result);
+        }
+    }
+
+    @Test
+    public void testBuildFilteredSdJwtWhenSdClaimsKeyMissingReturnsOriginal() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        String originalSdJwt = "header.payload.sig~disc~";
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential(originalSdJwt)
+                        .build())
+                .build();
+
+        Map<String, Object> allProps = new HashMap<>();
+        allProps.put("publicClaims", new HashMap<>());
+
+        when(credentialFormatHandlerFactory.getHandler(CredentialFormat.VC_SD_JWT.getFormat()))
+                .thenReturn(credentialFormatHandler);
+        doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
+
+        String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
+        assertEquals(originalSdJwt, result);
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
@@ -7,7 +7,6 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.util.Base64URL;
-import com.authlete.sd.SDJWT;
 import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.constant.OpenID4VPConstants;
 import io.mosip.mimoto.constant.SigningAlgorithm;
@@ -20,9 +19,6 @@ import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
 import io.mosip.mimoto.exception.*;
 import io.mosip.mimoto.model.VerifiablePresentation;
 import io.mosip.mimoto.repository.VerifiablePresentationsRepository;
-import io.mosip.mimoto.service.CredentialFormatHandler;
-import io.mosip.mimoto.service.CredentialFormatHandlerFactory;
-import io.mosip.mimoto.service.CredentialMatchingService;
 import io.mosip.mimoto.service.impl.OpenID4VPService;
 import io.mosip.mimoto.service.impl.WalletPresentationServiceImpl;
 import io.mosip.mimoto.util.SigningKeyUtil;
@@ -1164,146 +1160,10 @@ public class WalletPresentationServiceTest {
         assertEquals(500, response.getStatusCode().value());
     }
 
-    // --- resolveAlgorithmFromSdJwt ---
-
-    private String buildSdJwtWithPayload(String payloadJson) {
-        String header = Base64.getUrlEncoder().withoutPadding()
-                .encodeToString("{\"alg\":\"ES256\"}".getBytes(StandardCharsets.UTF_8));
-        String payload = Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
-        return header + "." + payload + ".sig";
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenInputIsNullReturnsED25519() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, (Object) null);
-        assertEquals(SigningAlgorithm.ED25519, result);
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenSdJwtIsBlankReturnsED25519() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, "   ");
-        assertEquals(SigningAlgorithm.ED25519, result);
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenCnfAbsentReturnsED25519() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
-                buildSdJwtWithPayload("{\"iss\":\"test\"}"));
-        assertEquals(SigningAlgorithm.ED25519, result);
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenCnfJwkAbsentReturnsED25519() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
-                buildSdJwtWithPayload("{\"cnf\":{\"jkt\":\"some-thumbprint\"}}"));
-        assertEquals(SigningAlgorithm.ED25519, result);
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenCnfJwkIsEcP256ReturnsES256() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
-                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"P-256\"}}}"));
-        assertEquals(SigningAlgorithm.ES256, result);
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenCnfJwkIsEcSecp256k1ReturnsES256K() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
-                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"secp256k1\"}}}"));
-        assertEquals(SigningAlgorithm.ES256K, result);
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenCnfJwkIsOkpEd25519ReturnsED25519() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
-                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"OKP\",\"crv\":\"Ed25519\"}}}"));
-        assertEquals(SigningAlgorithm.ED25519, result);
-    }
-
-    @Test
-    public void testResolveAlgorithmFromSdJwtWhenCnfJwkHasAlgFieldUsesAlg() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveAlgorithmFromSdJwt", Object.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService,
-                buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"P-256\",\"alg\":\"ES256\"}}}"));
-        assertEquals(SigningAlgorithm.ES256, result);
-    }
-
-    // --- resolveSigningAlgorithm ---
-
-    @Test
-    public void testResolveSigningAlgorithmWhenOnlyLdpVcCredentialReturnsED25519() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveSigningAlgorithm", List.class);
-        method.setAccessible(true);
-
-        DecryptedCredentialDTO ldpCred = DecryptedCredentialDTO.builder()
-                .id("cred-ldp")
-                .credential(VCCredentialResponse.builder()
-                        .format(CredentialFormat.LDP_VC.getFormat())
-                        .credential(new HashMap<>())
-                        .build())
-                .build();
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, List.of(ldpCred));
-        assertEquals(SigningAlgorithm.ED25519, result);
-    }
-
-    @Test
-    public void testResolveSigningAlgorithmWhenEmptyListReturnsED25519() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveSigningAlgorithm", List.class);
-        method.setAccessible(true);
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, Collections.emptyList());
-        assertEquals(SigningAlgorithm.ED25519, result);
-    }
-
-    @Test
-    public void testResolveSigningAlgorithmWhenSdJwtCredentialWithEcP256ReturnsES256() throws Exception {
-        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod("resolveSigningAlgorithm", List.class);
-        method.setAccessible(true);
-
-        String sdJwt = buildSdJwtWithPayload("{\"cnf\":{\"jwk\":{\"kty\":\"EC\",\"crv\":\"P-256\"}}}");
-        DecryptedCredentialDTO sdJwtCred = DecryptedCredentialDTO.builder()
-                .id("cred-sdjwt")
-                .credential(VCCredentialResponse.builder()
-                        .format(CredentialFormat.VC_SD_JWT.getFormat())
-                        .credential(sdJwt)
-                        .build())
-                .build();
-
-        SigningAlgorithm result = (SigningAlgorithm) method.invoke(walletPresentationService, List.of(sdJwtCred));
-        assertEquals(SigningAlgorithm.ES256, result);
-    }
-
-    // --- signSdJwtFormat ---
-
     @Test
     public void testSignSdJwtFormatSignsKBTAndReturnsSignaturePerUuid() throws Exception {
         Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
-                "signSdJwtFormat", UnsignedVPToken.class, JWSSigner.class);
+                "signSdJwtFormat", UnsignedVPToken.class, String.class, String.class);
         method.setAccessible(true);
 
         String kbHeader = Base64.getUrlEncoder().withoutPadding()
@@ -1319,20 +1179,31 @@ public class WalletPresentationServiceTest {
         when(mockToken.getUuidToUnsignedKBT()).thenReturn(uuidToKBT);
         when(jwsSigner.sign(any(JWSHeader.class), any(byte[].class))).thenReturn(Base64URL.encode("test-sig"));
 
-        SdJwtVPTokenSigningResult result = (SdJwtVPTokenSigningResult) method.invoke(
-                walletPresentationService, mockToken, jwsSigner);
+        // The signer is now derived per credential from the KB-JWT header alg (ES256 here)
+        KeyPair mockKeyPair = mock(KeyPair.class);
+        JWK mockJwk = mock(JWK.class);
+        when(keyPairService.getKeyPairFromDB(eq("wallet-1"), eq("base64Key"), eq(SigningAlgorithm.ES256)))
+                .thenReturn(mockKeyPair);
 
-        assertNotNull(result);
-        verify(jwsSigner).sign(any(JWSHeader.class),
-                eq(unsignedKBT.getBytes(StandardCharsets.US_ASCII)));
-        assertTrue(result.getUuidToKbJWTSignature().containsKey("uuid-1"));
-        assertEquals(Base64URL.encode("test-sig").toString(), result.getUuidToKbJWTSignature().get("uuid-1"));
+        try (MockedStatic<SigningKeyUtil> mockedSigningKeyUtil = mockStatic(SigningKeyUtil.class)) {
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.generateJwk(SigningAlgorithm.ES256, mockKeyPair))
+                    .thenReturn(mockJwk);
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.createSigner(SigningAlgorithm.ES256, mockJwk))
+                    .thenReturn(jwsSigner);
+
+            SdJwtVPTokenSigningResult result = (SdJwtVPTokenSigningResult) method.invoke(
+                    walletPresentationService, mockToken, "wallet-1", "base64Key");
+
+            assertNotNull(result);
+            verify(jwsSigner).sign(any(JWSHeader.class),
+                    eq(unsignedKBT.getBytes(StandardCharsets.US_ASCII)));
+            assertTrue(result.getUuidToKbJWTSignature().containsKey("uuid-1"));
+            assertEquals(Base64URL.encode("test-sig").toString(), result.getUuidToKbJWTSignature().get("uuid-1"));
+        }
     }
 
-    // --- buildFilteredSdJwt ---
-
     @Test
-    public void testBuildFilteredSdJwtWhenSelectedPathsIsNullReturnsOriginal() throws Exception {
+    public void testBuildFilteredSdJwtWhenSelectedPathsIsNullSharesNoDisclosures() throws Exception {
         Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
                 "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
         method.setAccessible(true);
@@ -1346,8 +1217,9 @@ public class WalletPresentationServiceTest {
                         .build())
                 .build();
 
+        // No selected paths -> user disclosed nothing -> credential JWT with zero disclosures
         String result = (String) method.invoke(walletPresentationService, credential, null);
-        assertEquals(originalSdJwt, result);
+        assertEquals("header.payload.sig~", result);
     }
 
     @Test
@@ -1375,15 +1247,8 @@ public class WalletPresentationServiceTest {
                 .thenReturn(credentialFormatHandler);
         doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
 
-        SDJWT mockSdJwt = mock(SDJWT.class);
-        when(mockSdJwt.getCredentialJwt()).thenReturn("header.payload.sig");
-
-        try (MockedStatic<SDJWT> mockedSdjwt = mockStatic(SDJWT.class)) {
-            mockedSdjwt.when(() -> SDJWT.parse(originalSdJwt)).thenReturn(mockSdJwt);
-
-            String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
-            assertEquals("header.payload.sig~emailDiscB64~", result);
-        }
+        String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
+        assertEquals("header.payload.sig~emailDiscB64~", result);
     }
 
     @Test
@@ -1410,20 +1275,13 @@ public class WalletPresentationServiceTest {
                 .thenReturn(credentialFormatHandler);
         doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
 
-        SDJWT mockSdJwt = mock(SDJWT.class);
-        when(mockSdJwt.getCredentialJwt()).thenReturn("header.payload.sig");
-
-        try (MockedStatic<SDJWT> mockedSdjwt = mockStatic(SDJWT.class)) {
-            mockedSdjwt.when(() -> SDJWT.parse(originalSdJwt)).thenReturn(mockSdJwt);
-
-            // "email" without "$." prefix should produce the same result as "$.email"
-            String result = (String) method.invoke(walletPresentationService, credential, List.of("email"));
-            assertEquals("header.payload.sig~emailDiscB64~", result);
-        }
+        // "email" without "$." prefix should produce the same result as "$.email"
+        String result = (String) method.invoke(walletPresentationService, credential, List.of("email"));
+        assertEquals("header.payload.sig~emailDiscB64~", result);
     }
 
     @Test
-    public void testBuildFilteredSdJwtWhenSdClaimsKeyMissingReturnsOriginal() throws Exception {
+    public void testBuildFilteredSdJwtWhenSdClaimsKeyMissingSharesNoDisclosures() throws Exception {
         Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
                 "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
         method.setAccessible(true);
@@ -1444,7 +1302,185 @@ public class WalletPresentationServiceTest {
                 .thenReturn(credentialFormatHandler);
         doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
 
+        // sdClaims key missing -> cannot resolve selections -> credential JWT with zero disclosures
         String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
-        assertEquals(originalSdJwt, result);
+        assertEquals("header.payload.sig~", result);
+    }
+
+    @Test
+    public void testBuildFilteredSdJwtWhenSelectedPathsEmptySharesNoDisclosures() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential("header.payload.sig~disc1~disc2~")
+                        .build())
+                .build();
+
+        String result = (String) method.invoke(walletPresentationService, credential, Collections.emptyList());
+        assertEquals("header.payload.sig~", result);
+    }
+
+    @Test
+    public void testBuildFilteredSdJwtWhenSdClaimsMapEmptySharesNoDisclosures() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential("header.payload.sig~disc~")
+                        .build())
+                .build();
+
+        Map<String, Object> allProps = new HashMap<>();
+        allProps.put("sdClaims", new LinkedHashMap<>()); // present but empty
+
+        when(credentialFormatHandlerFactory.getHandler(CredentialFormat.VC_SD_JWT.getFormat()))
+                .thenReturn(credentialFormatHandler);
+        doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
+
+        String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
+        assertEquals("header.payload.sig~", result);
+    }
+
+    @Test
+    public void testBuildFilteredSdJwtWhenSelectedPathNotInSdClaimsSharesNoDisclosures() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential("header.payload.sig~nameDiscB64~")
+                        .build())
+                .build();
+
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("name", List.of("nameDiscB64"));
+        Map<String, Object> allProps = new HashMap<>();
+        allProps.put("sdClaims", sdClaims);
+
+        when(credentialFormatHandlerFactory.getHandler(CredentialFormat.VC_SD_JWT.getFormat()))
+                .thenReturn(credentialFormatHandler);
+        doReturn(allProps).when(credentialFormatHandler).extractAllCredentialProperties(any());
+
+        // user selects "email" but only "name" is selectively disclosable -> no disclosures shared
+        String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
+        assertEquals("header.payload.sig~", result);
+    }
+
+    @Test
+    public void testBuildFilteredSdJwtWhenCredentialNotStringReturnsRawValue() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "buildFilteredSdJwt", DecryptedCredentialDTO.class, List.class);
+        method.setAccessible(true);
+
+        Map<String, Object> mapCredential = new HashMap<>();
+        mapCredential.put("type", "not-a-string-sdjwt");
+        DecryptedCredentialDTO credential = DecryptedCredentialDTO.builder()
+                .id("cred-id")
+                .credential(VCCredentialResponse.builder()
+                        .format(CredentialFormat.VC_SD_JWT.getFormat())
+                        .credential(mapCredential)
+                        .build())
+                .build();
+
+        // Non-String payload cannot be SD-JWT filtered; the raw value is returned as-is
+        String result = (String) method.invoke(walletPresentationService, credential, List.of("$.email"));
+        assertEquals(String.valueOf(mapCredential), result);
+    }
+
+    @Test
+    public void testSignSdJwtFormatBuildsPerCredentialSignersForDifferentAlgs() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "signSdJwtFormat", UnsignedVPToken.class, String.class, String.class);
+        method.setAccessible(true);
+
+        String payload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"nonce\":\"abc\"}".getBytes(StandardCharsets.UTF_8));
+        String es256Kbt = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"ES256\"}".getBytes(StandardCharsets.UTF_8)) + "." + payload;
+        String eddsaKbt = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"EdDSA\"}".getBytes(StandardCharsets.UTF_8)) + "." + payload;
+
+        Map<String, String> uuidToKBT = new LinkedHashMap<>();
+        uuidToKBT.put("uuid-es256", es256Kbt);
+        uuidToKBT.put("uuid-eddsa", eddsaKbt);
+
+        UnsignedSdJwtVPToken mockToken = mock(UnsignedSdJwtVPToken.class);
+        when(mockToken.getUuidToUnsignedKBT()).thenReturn(uuidToKBT);
+
+        KeyPair mockKeyPair = mock(KeyPair.class);
+        JWK mockJwk = mock(JWK.class);
+        when(keyPairService.getKeyPairFromDB(eq("wallet-1"), eq("base64Key"), eq(SigningAlgorithm.ES256)))
+                .thenReturn(mockKeyPair);
+        when(keyPairService.getKeyPairFromDB(eq("wallet-1"), eq("base64Key"), eq(SigningAlgorithm.ED25519)))
+                .thenReturn(mockKeyPair);
+
+        JWSSigner es256Signer = mock(JWSSigner.class);
+        JWSSigner eddsaSigner = mock(JWSSigner.class);
+        when(es256Signer.sign(any(JWSHeader.class), any(byte[].class))).thenReturn(Base64URL.encode("es256-sig"));
+        when(eddsaSigner.sign(any(JWSHeader.class), any(byte[].class))).thenReturn(Base64URL.encode("eddsa-sig"));
+
+        try (MockedStatic<SigningKeyUtil> mockedSigningKeyUtil = mockStatic(SigningKeyUtil.class)) {
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.generateJwk(SigningAlgorithm.ES256, mockKeyPair)).thenReturn(mockJwk);
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.generateJwk(SigningAlgorithm.ED25519, mockKeyPair)).thenReturn(mockJwk);
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.createSigner(SigningAlgorithm.ES256, mockJwk)).thenReturn(es256Signer);
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.createSigner(SigningAlgorithm.ED25519, mockJwk)).thenReturn(eddsaSigner);
+
+            SdJwtVPTokenSigningResult result = (SdJwtVPTokenSigningResult) method.invoke(
+                    walletPresentationService, mockToken, "wallet-1", "base64Key");
+
+            // Each credential is signed with the signer matching its own KB-JWT header alg
+            assertEquals(Base64URL.encode("es256-sig").toString(), result.getUuidToKbJWTSignature().get("uuid-es256"));
+            assertEquals(Base64URL.encode("eddsa-sig").toString(), result.getUuidToKbJWTSignature().get("uuid-eddsa"));
+        }
+    }
+
+    @Test
+    public void testSignSdJwtFormatReusesSignerForSameAlg() throws Exception {
+        Method method = WalletPresentationServiceImpl.class.getDeclaredMethod(
+                "signSdJwtFormat", UnsignedVPToken.class, String.class, String.class);
+        method.setAccessible(true);
+
+        String header = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"ES256\"}".getBytes(StandardCharsets.UTF_8));
+        String payload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"nonce\":\"abc\"}".getBytes(StandardCharsets.UTF_8));
+        String kbt = header + "." + payload;
+
+        Map<String, String> uuidToKBT = new LinkedHashMap<>();
+        uuidToKBT.put("uuid-1", kbt);
+        uuidToKBT.put("uuid-2", kbt);
+
+        UnsignedSdJwtVPToken mockToken = mock(UnsignedSdJwtVPToken.class);
+        when(mockToken.getUuidToUnsignedKBT()).thenReturn(uuidToKBT);
+
+        KeyPair mockKeyPair = mock(KeyPair.class);
+        JWK mockJwk = mock(JWK.class);
+        when(keyPairService.getKeyPairFromDB(eq("wallet-1"), eq("base64Key"), eq(SigningAlgorithm.ES256)))
+                .thenReturn(mockKeyPair);
+        when(jwsSigner.sign(any(JWSHeader.class), any(byte[].class))).thenReturn(Base64URL.encode("sig"));
+
+        try (MockedStatic<SigningKeyUtil> mockedSigningKeyUtil = mockStatic(SigningKeyUtil.class)) {
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.generateJwk(SigningAlgorithm.ES256, mockKeyPair)).thenReturn(mockJwk);
+            mockedSigningKeyUtil.when(() -> SigningKeyUtil.createSigner(SigningAlgorithm.ES256, mockJwk)).thenReturn(jwsSigner);
+
+            SdJwtVPTokenSigningResult result = (SdJwtVPTokenSigningResult) method.invoke(
+                    walletPresentationService, mockToken, "wallet-1", "base64Key");
+
+            // Two credentials share ES256 -> the key pair is fetched only once (signer is cached)
+            verify(keyPairService, times(1)).getKeyPairFromDB("wallet-1", "base64Key", SigningAlgorithm.ES256);
+            assertEquals(2, result.getUuidToKbJWTSignature().size());
+        }
     }
 }

--- a/src/test/java/io/mosip/mimoto/util/factory/Ed25519AlgorithmHandlerTest.java
+++ b/src/test/java/io/mosip/mimoto/util/factory/Ed25519AlgorithmHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -108,6 +109,18 @@ public class Ed25519AlgorithmHandlerTest {
     public void shouldThrowExceptionWhenCreateJWKWithNonEdKeyPair() throws Exception {
         KeyPair rsaKeyPair = new RS256AlgorithmHandler().generateKeyPair();
         handler.createJWK(rsaKeyPair);
+    }
+
+    @Test
+    public void shouldSupportBothEd25519AndEdDSAAlgorithms() throws Exception {
+        KeyPair keyPair = handler.generateKeyPair();
+        JWK jwk = handler.createJWK(keyPair);
+        JWSSigner signer = handler.createSigner(jwk);
+
+        Set<JWSAlgorithm> supported = signer.supportedJWSAlgorithms();
+        assertTrue("signer must declare Ed25519 (pre-standard Nimbus name)", supported.contains(JWSAlgorithm.Ed25519));
+        assertTrue("signer must declare EdDSA (IANA RFC 8037 name used in KB-JWT alg header)", supported.contains(JWSAlgorithm.EdDSA));
+        assertEquals(2, supported.size());
     }
 
 }


### PR DESCRIPTION
## What does this PR do?
Adds SD-JWT credential presentation to the OpenID4VP flow for both `vc+sd-jwt` and `dc+sd-jwt` formats with holder-selected selective disclosure. KB-JWT signing derives the algorithm per credential from the library-provided header, and shares only the disclosures the user explicitly selects (none when selectedSdClaims is omitted).

## Related Issue
Related to inji/inji-web#638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SD-JWT selective disclosure: choose which claims to share per credential; per-format VP token signing.

* **Bug Fixes**
  * Wallet accepts EdDSA as an alias/option alongside Ed25519.
  * Fixed advertised Ed25519 signature name.

* **Improvements**
  * Improved credential matching and clearer missing-claim reporting; signing algorithm chosen per token.

* **Documentation**
  * OpenAPI examples and schemas updated to document SD-JWT selective disclosure.

* **Tests**
  * Expanded unit tests covering SD-JWT selection and signing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->