### PR TITLE
[INJIWEB-1856] - Add Logic for sd-jwt ovp credential matching (#1038)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -130,9 +130,9 @@ fileignoreconfig:
 - filename: docker-compose/README.md
   checksum: f70385d1be6b7945df1afac0890bdce5ecceb63cdba08bdd3f760f40f843c630
 - filename: src/main/java/io/mosip/mimoto/service/impl/VcSdJwtCredentialFormatHandler.java
-  checksum: 425cb4066c02d93572b1db02099532465479e7f4c94c3684c5d46a063352631d
+  checksum: f44f44a691f7bbc2e34e22d2d48791b883b79794011d514865de2ebecd58a655
 - filename: src/test/java/io/mosip/mimoto/service/VcSdJwtCredentialFormatHandlerTest.java
-  checksum: e91aa11aa049453a3a7cd542386dbb813f5c868678f68d6bd71af92149e0d5db
+  checksum: 3c0a06bac77cde10b2d7d4b0c43ce010fe00a31b9aa97af78af9e87e8df8401d
 - filename: db_scripts/inji_mimoto/ddl.sql
   checksum: 51cd2efbe5220b995ae7cff7d70797b2c1bde0ce3325b70d62a31a1f4f41aa47
 - filename: db_scripts/inji_mimoto/ddl/mimoto-trusted-verifiers.sql
@@ -165,9 +165,9 @@ fileignoreconfig:
 - filename: src/main/java/io/mosip/mimoto/service/CredentialMatchingService.java
   checksum: b2ceada5c81b9dadb6e7780604c68b7ae2d4272d2f67442fab0f5a45bd33727e
 - filename: src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
-  checksum: 1a353f792fdc393262ea2c3cf539f12277929e1f89456564a8c3ae31a378f678
+  checksum: deb4e42b6723163a610fe21a20bf8ed53e2acf858fcc19fc9ae8d35f41394bb0
 - filename: src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
-  checksum: b1323c5b2d2209440ff2d4705d72d67cf93f3a790ef1a4bdeccc5c557686bd85
+  checksum: f0064149fe98f4dc82195f23956bb6ae206e8b6555c8f53adb61982f26a5285e
 - filename: src/test/java/io/mosip/mimoto/service/SessionManagerTest.java
   checksum: f541358ce3b674a8865592b8c899c2dac484730b8790f9a99b6a79a5b7953c9a
 - filename: src/main/java/io/mosip/mimoto/constant/OpenID4VPConstants.java

--- a/src/main/java/io/mosip/mimoto/dto/CredentialDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/CredentialDTO.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -28,5 +30,13 @@ public class CredentialDTO {
     @JsonProperty("format")
     @Schema(description = "Format of the credential (e.g., ldp_vc, vc+sd-jwt, dc+sd-jwt)")
     private String format;
+
+    @JsonProperty("claims")
+    @Schema(description = "Claims that are always disclosed as part of the credential")
+    private List<String> claims;
+
+    @JsonProperty("sdClaims")
+    @Schema(description = "Selective Disclosure Claims that require user consent to be shared")
+    private List<String> sdClaims;
 }
 

--- a/src/main/java/io/mosip/mimoto/service/CredentialFormatHandler.java
+++ b/src/main/java/io/mosip/mimoto/service/CredentialFormatHandler.java
@@ -25,5 +25,8 @@ public interface CredentialFormatHandler {
             CredentialsSupportedResponse credentialsSupportedResponse,
             String userLocale);
 
-
+    /**
+     * Extract all properties from the Credential
+     */
+    Map<String, ?> extractAllCredentialProperties(VCCredentialResponse vcCredentialResponse);
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/CredentialMatchingServiceImpl.java
@@ -16,13 +16,17 @@ import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
 import io.mosip.mimoto.exception.ApiNotAccessibleException;
 import io.mosip.mimoto.exception.InvalidIssuerIdException;
 import io.mosip.mimoto.exception.InvalidRequestException;
-import static io.mosip.mimoto.exception.ErrorConstants.UNSUPPORTED_FORMAT;
+import io.mosip.mimoto.service.CredentialFormatHandlerFactory;
+import io.mosip.mimoto.service.CredentialFormatHandler;
 import io.mosip.mimoto.service.CredentialMatchingService;
 import io.mosip.mimoto.service.IssuersService;
 import io.mosip.mimoto.service.WalletCredentialService;
+import io.mosip.mimoto.util.JwtUtils;
 import io.mosip.openID4VP.authorizationRequest.presentationDefinition.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import static io.mosip.mimoto.exception.ErrorConstants.UNSUPPORTED_FORMAT;
 
 import java.io.IOException;
 import java.util.*;
@@ -37,6 +41,11 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
     private static final String JSON_PATH_PREFIX = "$.";
     private static final String LDP_VC_FORMAT = "ldp_vc";
     private static final String PROOF_TYPE_KEY = "proof_type";
+    private static final String SD_JWT_ALG_VALUES_KEY = "sd-jwt_alg_values";
+    private static final String CREDENTIAL_SUBJECT_PREFIX = "credentialSubject.";
+    private static final String ALG = "alg";
+    private static final String CREDENTIAL_SUBJECT = "credentialSubject";
+    private static final String SD = "_sd";
 
     private final ObjectMapper objectMapper;
 
@@ -46,12 +55,16 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
     private final WalletCredentialService walletCredentialService;
 
-    public CredentialMatchingServiceImpl(ObjectMapper objectMapper, IssuersService issuersService, OpenID4VPService openID4VPService, WalletCredentialService walletCredentialService) {
+    private final CredentialFormatHandlerFactory credentialFormatHandlerFactory;
+
+    public CredentialMatchingServiceImpl(ObjectMapper objectMapper, IssuersService issuersService, OpenID4VPService openID4VPService, WalletCredentialService walletCredentialService, CredentialFormatHandlerFactory credentialFormatHandlerFactory) {
         this.objectMapper = objectMapper;
         this.issuersService = issuersService;
         this.openID4VPService = openID4VPService;
         this.walletCredentialService = walletCredentialService;
+        this.credentialFormatHandlerFactory = credentialFormatHandlerFactory;
     }
+
 
     @Override
     public MatchingCredentialsDTO getMatchingCredentials(VerifiablePresentationSessionData sessionData, String walletId, String base64Key) throws ApiNotAccessibleException, IOException {
@@ -59,11 +72,6 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
         // Extract presentation definition from the session data
         PresentationDefinition presentationDefinition = openID4VPService.resolvePresentationDefinition(sessionData.getPresentationId(), sessionData.getAuthorizationRequest(), sessionData.isVerifierClientPreregistered());
-
-        if (presentationDefinition == null) {
-            log.warn("No presentation definition found in session data");
-            throw new IllegalArgumentException("Presentation definition not found in session data");
-        }
 
         validateInputParameters(presentationDefinition, walletId, base64Key);
 
@@ -93,7 +101,7 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
                     } else {
                         missingClaims.addAll(extractClaimsFromInputDescriptor(descriptor));
                     }
-                });
+        });
 
         // Flatten all matching credentials into a single list, removing duplicates by credential ID
         Set<String> addedCredentialIds = new HashSet<>();
@@ -202,21 +210,70 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
         String vcFormat = vc.getFormat();
 
-        if (!CredentialFormat.LDP_VC.getFormat().equalsIgnoreCase(vcFormat) || !descriptorFormat.containsKey(LDP_VC_FORMAT)) {
+        if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(vcFormat) && descriptorFormat.containsKey(CredentialFormat.VC_SD_JWT.getFormat())) {
+            return matchesSdJwtAlgorithm(vc, descriptorFormat);
+        }
+        if (CredentialFormat.LDP_VC.getFormat().equalsIgnoreCase(vcFormat) && descriptorFormat.containsKey(LDP_VC_FORMAT)) {
+            return matchesLdpVcFormat(vc, descriptorFormat);
+        }
+        return false;
+    }
+
+    private boolean matchesLdpVcFormat(VCCredentialResponse vc, Map<String, Map<String, List<String>>> descriptorFormat) {
+        Map<String, List<String>> ldpVcFormat = descriptorFormat.get(LDP_VC_FORMAT);
+
+        if (ldpVcFormat == null) {
             return false;
         }
 
-        Map<String, List<String>> ldpVcFormat = descriptorFormat.get(LDP_VC_FORMAT);
-
         if (!ldpVcFormat.containsKey(PROOF_TYPE_KEY)) {
-            return true;
+            return false;
         }
 
         VCCredentialProperties ldpCredential = objectMapper.convertValue(vc.getCredential(), VCCredentialProperties.class);
         String vcProofType = ldpCredential.getProof() != null ? ldpCredential.getProof().getType() : null;
         List<String> requiredProofTypes = ldpVcFormat.get(PROOF_TYPE_KEY);
 
+        if (requiredProofTypes == null || requiredProofTypes.isEmpty()) {
+            return true;
+        }
+
         return vcProofType != null && requiredProofTypes.contains(vcProofType);
+    }
+
+    private boolean matchesSdJwtAlgorithm(VCCredentialResponse vc, Map<String, Map<String, List<String>>> requestFormat) {
+        Map<String, List<String>> sdJwtFormat = requestFormat.get(CredentialFormat.VC_SD_JWT.getFormat());
+        if (vc.getCredential() == null || !(vc.getCredential() instanceof String sdJwtString)) {
+            return false;
+        }
+
+        if (!sdJwtFormat.containsKey(SD_JWT_ALG_VALUES_KEY)) {
+            return false;
+        }
+
+        String sdJwtAlgorithm = extractSdJwtAlgorithm(sdJwtString);
+        Map<String, List<String>> requestFormatMap = requestFormat.get(CredentialFormat.VC_SD_JWT.getFormat());
+        if (requestFormatMap != null) {
+            List<?> requestAlgorithms = requestFormatMap.get(SD_JWT_ALG_VALUES_KEY);
+            if (requestAlgorithms != null) {
+                return requestAlgorithms.contains(sdJwtAlgorithm);
+            }
+            return true; // If no specific algorithms are required, any algorithm is acceptable
+        }
+        return false;
+    }
+
+    private String extractSdJwtAlgorithm(String sdJwtString) {
+        if (sdJwtString == null || sdJwtString.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            Map<String, Object> header = JwtUtils.parseJwtHeader(sdJwtString);
+            return (String) header.get(ALG);
+        } catch (Exception e) {
+            log.warn("Failed to extract algorithm from SD-JWT header", e);
+            return null;
+        }
     }
 
     private boolean matchesConstraints(VCCredentialResponse vc, Constraints constraints) {
@@ -237,7 +294,7 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
         List<Object> matches = evaluateJsonPath(path, credentialData);
 
-        if (matches == null || matches.isEmpty()) {
+        if (matches.isEmpty()) {
             return false;
         }
 
@@ -246,21 +303,22 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
     private Object getCredentialData(VCCredentialResponse vc) {
         String format = vc.getFormat();
+        CredentialFormatHandler credentialFormatHandler = credentialFormatHandlerFactory.getHandler(vc.getFormat());
 
         if (CredentialFormat.LDP_VC.getFormat().equalsIgnoreCase(format)) {
-            Object credentialData = vc.getCredential();
-
-            if (credentialData instanceof Map) {
-                return credentialData;
-            } else {
-                return objectMapper.convertValue(credentialData, VCCredentialProperties.class);
+            return credentialFormatHandler.extractAllCredentialProperties(vc);
+        } else if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+            Map<String, ?> extractedMap = credentialFormatHandler.extractAllCredentialProperties(vc);
+            if (extractedMap == null) {
+                return Collections.emptyMap();
             }
-        } else if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format) || CredentialFormat.DC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
-            throw new InvalidRequestException(UNSUPPORTED_FORMAT.getErrorCode(), 
-                "SD-JWT credential format (" + format + ") is not supported for credential matching");
+            Map<String, Map<String, Object>> allCredentialProperties = (Map<String, Map<String, Object>>) extractedMap;
+            Map<String, Object> credentialClaimsMap = new HashMap<>();
+            allCredentialProperties.values().forEach(credentialClaimsMap::putAll);
+            return credentialClaimsMap;
+        } else {
+            throw new InvalidRequestException(UNSUPPORTED_FORMAT.getErrorCode(), "Unsupported credential format: " + format);
         }
-
-        return vc.getCredential();
     }
 
     private boolean matchesFilter(Object match, Filter filter) {
@@ -333,6 +391,11 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
 
         String credentialTypeDisplayName = "Unknown Credential";
         String credentialTypeLogo = null;
+        Map<String, Object> publicClaimsMap;
+        Map<String, Object> sdClaimsMap;
+
+        List<String> publicClaims = new ArrayList<>();
+        List<String> sdClaims = new ArrayList<>();
 
         try {
             IssuerConfig issuerConfig = issuersService.getIssuerConfig(issuerId, credentialType);
@@ -345,13 +408,107 @@ public class CredentialMatchingServiceImpl implements CredentialMatchingService 
             log.warn("Failed to fetch issuer config for issuerId: {}, credentialType: {}", issuerId, credentialType, e);
         }
 
+        if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(decryptedCredentialDTO.getCredential().getFormat())) {
+            CredentialFormatHandler credentialFormatHandler = credentialFormatHandlerFactory.getHandler(CredentialFormat.VC_SD_JWT.getFormat());
+            Map<String, Map<String, Object>> allClaims = (Map<String, Map<String, Object>>) credentialFormatHandler.extractAllCredentialProperties(decryptedCredentialDTO.getCredential());
+
+            publicClaimsMap = allClaims.get("publicClaims");
+            sdClaimsMap = allClaims.get("sdClaims");
+
+            if (publicClaimsMap != null) {
+                publicClaims = extractPublicClaimPaths(publicClaimsMap);
+            }
+
+            if (sdClaimsMap != null) {
+                sdClaims = extractSdClaimPaths(sdClaimsMap);
+            }
+
+        }
+
+
         return CredentialDTO.builder()
                 .credentialId(decryptedCredentialDTO.getId())
                 .credentialTypeDisplayName(credentialTypeDisplayName)
                 .credentialTypeLogo(credentialTypeLogo)
-                .format(decryptedCredentialDTO.getCredential()
-                .getFormat())
+                .format(decryptedCredentialDTO.getCredential().getFormat())
+                .claims(publicClaims)
+                .sdClaims(sdClaims)
                 .build();
     }
 
+    private List<String> extractPublicClaimPaths(Map<String, Object> publicClaimsMap) {
+        List<String> paths = new ArrayList<>();
+        Object credentialSubject = publicClaimsMap.get(CREDENTIAL_SUBJECT);
+        if (credentialSubject instanceof Map) {
+            Map<String, Object> csMap = (Map<String, Object>) credentialSubject;
+            collectPaths(csMap, "$", paths);
+        } else {
+            // Remove standard JWT claims and SD-JWT metadata
+            List<String> metadataKeys = Arrays.asList("vct", "cnf", "iss", "sub", "aud", "exp", "nbf", "iat", "jti", SD, "_sd_alg", "id");
+            metadataKeys.forEach(publicClaimsMap::remove);
+            collectPaths(publicClaimsMap, "$", paths);
+        }
+        return paths;
+    }
+
+    private List<String> extractSdClaimPaths(Map<String, Object> sdClaimsMap) {
+        List<String> paths = new ArrayList<>();
+        for (String key : sdClaimsMap.keySet()) {
+            String cleanKey = key.startsWith(CREDENTIAL_SUBJECT_PREFIX)
+                    ? key.substring(CREDENTIAL_SUBJECT_PREFIX.length())
+                    : key;
+            paths.add(JSON_PATH_PREFIX + cleanKey);
+        }
+        return paths;
+    }
+
+    private void collectPaths(Map<String, Object> publicClaimsMap, String prefix, List<String> paths) {
+        for (Map.Entry<String, Object> entry : publicClaimsMap.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            // Skip _sd keys
+            if (SD.equals(key)) {
+                continue;
+            }
+
+            String currentPath = prefix + "." + key;
+
+            if (value instanceof Map) {
+                collectPaths((Map<String, Object>) value, currentPath, paths);
+            } else if (value instanceof List<?> listValue) {
+                if (hasUniformKeys(listValue)) {
+                    paths.add(currentPath);
+                } else {
+                    paths.add(currentPath);
+                    for (Object item : listValue) {
+                        if (item instanceof Map<?, ?> mapItem) {
+                            collectPaths((Map<String, Object>) mapItem, currentPath, paths);
+                        }
+                    }
+                }
+            } else {
+                paths.add(currentPath);
+            }
+        }
+    }
+
+    private boolean hasUniformKeys(List<?> list) {
+        List<Set<Object>> keySets = list.stream()
+                .filter(item -> item instanceof Map<?, ?>)
+                .map(item -> {
+                    Map<?, ?> m = (Map<?, ?>) item;
+                    return new HashSet<Object>(m.keySet());
+                })
+                .collect(Collectors.toList());
+    
+        if (keySets.size() < 2 || keySets.size() != list.size()) {
+            return false;
+        }
+
+        Set<Object> intersectionKeys = new HashSet<>(keySets.getFirst());
+        keySets.forEach(intersectionKeys::retainAll);
+
+        return !intersectionKeys.isEmpty();
+    }
 }

--- a/src/main/java/io/mosip/mimoto/service/impl/LdpVcCredentialFormatHandler.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/LdpVcCredentialFormatHandler.java
@@ -111,6 +111,11 @@ public class LdpVcCredentialFormatHandler implements CredentialFormatHandler {
         return displayProperties;
     }
 
+    @Override
+    public Map<String, Object> extractAllCredentialProperties(VCCredentialResponse vcCredentialResponse) {
+        return objectMapper.convertValue(vcCredentialResponse.getCredential(), LinkedHashMap.class);
+    }
+
     private LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> buildFallbackDisplayProperties(
             Map<String, Object> credentialProperties,
             List<String> orderedKeys) {

--- a/src/main/java/io/mosip/mimoto/service/impl/VcSdJwtCredentialFormatHandler.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/VcSdJwtCredentialFormatHandler.java
@@ -21,6 +21,9 @@ import static io.mosip.mimoto.util.JwtUtils.parseJwtPayload;
 @Component("vc+sd-jwt")
 public class VcSdJwtCredentialFormatHandler implements CredentialFormatHandler {
 
+    private static final String KEY = "...";
+    private static final String SD = "_sd";
+
     private final ObjectMapper objectMapper;
 
     public VcSdJwtCredentialFormatHandler(ObjectMapper objectMapper) {
@@ -117,41 +120,28 @@ public class VcSdJwtCredentialFormatHandler implements CredentialFormatHandler {
         return displayProperties;
     }
 
-
+    @Override
+    public Map<String, Map<String, Object>> extractAllCredentialProperties(VCCredentialResponse vcCredentialResponse) {
+        Object credential = vcCredentialResponse.getCredential();
+        if (credential instanceof String) {
+            return extractAllPropertiesFromSdJwt((String) credential);
+        }
+        return Collections.emptyMap();
+    }
 
     public Map<String, Object> extractClaimsFromSdJwt(String sdJwtString) {
         try {
             SDJWT sdJwt = SDJWT.parse(sdJwtString);
-            Map<String, Object> claims = new LinkedHashMap<>();
 
-            // Parse JWT payload
-            String credentialJwt = sdJwt.getCredentialJwt();
-            if (credentialJwt != null) {
-                Map<String, Object> jwtPayload = parseJwtPayload(credentialJwt);
-                if (jwtPayload != null) {
-                    claims.putAll(jwtPayload);
-                }
-            }
+            // Extract public claims from the credential JWT
+            Map<String, Object> claims = extractPublicClaims(sdJwt);
 
-            // Add disclosures
-            List<Disclosure> disclosures = sdJwt.getDisclosures();
-            if (disclosures != null && !disclosures.isEmpty()) {
-                for (Disclosure disclosure : disclosures) {
-                    try {
-                        String claimName = disclosure.getClaimName();
-                        Object claimValue = disclosure.getClaimValue();
-
-                        if (claimName != null && claimValue != null) {
-                            claims.put(claimName, claimValue); // Add directly to claims
-                        }
-                    } catch (Exception e) {
-                        log.warn("Failed to process disclosure: {}", e.getMessage());
-                    }
-                }
-            }
+            // Extract disclosures and merge with claims
+            Map<String, Object> sdClaims = extractSdClaims(sdJwt);
+            claims.putAll(sdClaims);
 
             // Remove standard JWT claims and SD-JWT metadata
-            List<String> metadataKeys = Arrays.asList("vct", "cnf", "iss", "sub", "aud", "exp", "nbf", "iat", "jti", "_sd", "_sd_alg", "id");
+            List<String> metadataKeys = Arrays.asList("vct", "cnf", "iss", "sub", "aud", "exp", "nbf", "iat", "jti", SD, "_sd_alg", "id");
             metadataKeys.forEach(claims::remove);
 
             // Return claims directly as result
@@ -166,10 +156,138 @@ public class VcSdJwtCredentialFormatHandler implements CredentialFormatHandler {
         }
     }
 
-    private LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> buildFallbackDisplayProperties(
-            Map<String, Object> credentialProperties,
-            Set<String> orderedKeys) {
+    public Map<String, Map<String, Object>> extractAllPropertiesFromSdJwt(String sdJwtString) {
+        try {
+            SDJWT sdJwt = SDJWT.parse(sdJwtString);
 
+            Map<String, Map<String, Object>> claims = new LinkedHashMap<>();
+
+            // Extract public claims from the credential JWT
+            claims.put("publicClaims", extractPublicClaims(sdJwt));
+
+            // Extract disclosures and merge with claims
+            claims.put("sdClaims", extractSdClaimsForOVP(sdJwt));
+
+            return claims;
+
+        } catch (IllegalArgumentException e) {
+            log.error("Error parsing SD-JWT with Authlete library: {}", e.getMessage(), e);
+            return Collections.emptyMap();
+        } catch (Exception e) {
+            log.error("Unexpected error processing SD-JWT", e);
+            return Collections.emptyMap();
+        }
+    }
+
+    private Map<String, Object> extractPublicClaims(SDJWT sdJwt) {
+        String credentialJwt = sdJwt.getCredentialJwt();
+        Map<String, Object> publicClaims = new LinkedHashMap<>();
+        if (credentialJwt != null) {
+            Map<String, Object> jwtPayload = parseJwtPayload(credentialJwt);
+            if (jwtPayload != null) {
+                publicClaims.putAll(jwtPayload);
+            }
+        }
+        return publicClaims;
+    }
+
+    private Map<String, Object> extractSdClaims(SDJWT sdJwt) {
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        List<Disclosure> disclosures = sdJwt.getDisclosures();
+        if (disclosures != null && !disclosures.isEmpty()) {
+            for (Disclosure disclosure : disclosures) {
+                try {
+                    String claimName = disclosure.getClaimName();
+                    Object claimValue = disclosure.getClaimValue();
+
+                    if (claimName != null && claimValue != null) {
+                        sdClaims.put(claimName, claimValue);
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to process disclosure: {}", e.getMessage());
+                }
+            }
+        }
+        return sdClaims;
+    }
+
+    private Map<String, Object> extractSdClaimsForOVP(SDJWT sdJwt) {
+        Map<String, Disclosure> digestToDisclosure = new HashMap<>();
+        Map<String, String> digestToDisclosureB64 = new HashMap<>();
+        List<Disclosure> disclosures = sdJwt.getDisclosures();
+        if (disclosures != null) {
+            for (Disclosure disclosure : disclosures) {
+                String digest = disclosure.digest();
+                digestToDisclosure.put(digest, disclosure);
+                digestToDisclosureB64.put(digest, disclosure.getDisclosure());
+            }
+        }
+
+        String credentialJwt = sdJwt.getCredentialJwt();
+        Map<String, Object> payload = parseJwtPayload(credentialJwt);
+        if (payload == null || payload.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Object> pathToDisclosures = new LinkedHashMap<>();
+        resolveDisclosures(payload, "", Collections.emptyList(), digestToDisclosure, digestToDisclosureB64, pathToDisclosures);
+        return pathToDisclosures;
+    }
+
+    private void resolveDisclosures(Object value, String path, List<String> parentDisclosures, Map<String, Disclosure> digestToDisclosure, Map<String, String> digestToDisclosureB64, Map<String, Object> pathToDisclosures) {
+        if (value instanceof List) {
+            List<Object> list = (List<Object>) value;
+            for (int i = 0; i < list.size(); i++) {
+                Object item = list.get(i);
+                String currentPath = path + "[" + i + "]";
+                if (item instanceof Map) {
+                    Map<String, Object> mapItem = (Map<String, Object>) item;
+                    if (mapItem.size() == 1 && mapItem.containsKey(KEY)) {
+                        String digest = (String) mapItem.get(KEY);
+                        Disclosure disclosure = digestToDisclosure.get(digest);
+                        if (disclosure != null) {
+                            List<String> currentDisclosures = new ArrayList<>(parentDisclosures);
+                            currentDisclosures.add(digestToDisclosureB64.get(digest));
+                            pathToDisclosures.put(currentPath, currentDisclosures);
+                            resolveDisclosures(disclosure.getClaimValue(), currentPath, currentDisclosures, digestToDisclosure, digestToDisclosureB64, pathToDisclosures);
+                        }
+                        continue;
+                    }
+                }
+                resolveDisclosures(item, currentPath, parentDisclosures, digestToDisclosure, digestToDisclosureB64, pathToDisclosures);
+            }
+            return;
+        }
+
+        if (value instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) value;
+
+            Object sdDigestsObj = map.get(SD);
+            if (sdDigestsObj instanceof List) {
+                for (Object digestObj : (List<Object>) sdDigestsObj) {
+                    String digest = (String) digestObj;
+                    Disclosure disclosure = digestToDisclosure.get(digest);
+                    if (disclosure == null || disclosure.getClaimName() == null) continue;
+                    String claimName = disclosure.getClaimName();
+                    if (SD.equals(claimName) || KEY.equals(claimName)) continue;
+
+                    String fullPath = path.isEmpty() ? claimName : path + "." + claimName;
+                    List<String> currentDisclosures = new ArrayList<>(parentDisclosures);
+                    currentDisclosures.add(digestToDisclosureB64.get(digest));
+                    pathToDisclosures.put(fullPath, currentDisclosures);
+                    resolveDisclosures(disclosure.getClaimValue(), fullPath, currentDisclosures, digestToDisclosure, digestToDisclosureB64, pathToDisclosures);
+                }
+            }
+
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                if (SD.equals(entry.getKey())) continue;
+                String fullPath = path.isEmpty() ? entry.getKey() : path + "." + entry.getKey();
+                resolveDisclosures(entry.getValue(), fullPath, parentDisclosures, digestToDisclosure, digestToDisclosureB64, pathToDisclosures);
+            }
+        }
+    }
+
+    private LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> buildFallbackDisplayProperties(Map<String, Object> credentialProperties, Set<String> orderedKeys) {
         LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> displayProperties = new LinkedHashMap<>();
 
         // Use ordered keys from parameter (already includes all fields)

--- a/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/CredentialMatchingServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -49,6 +50,12 @@ public class CredentialMatchingServiceTest {
     @Mock
     private OpenID4VPService openID4VPService;
 
+    @Mock
+    private CredentialFormatHandlerFactory credentialFormatHandlerFactory;
+
+    @Mock
+    private CredentialFormatHandler credentialFormatHandler;
+
     private VerifiablePresentationSessionData sessionData;
     private String walletId;
     private String base64Key;
@@ -59,18 +66,34 @@ public class CredentialMatchingServiceTest {
     public void setUp() throws JsonProcessingException {
         walletId = "test-wallet-id";
         base64Key = "test-base64-key";
-
-        // Setup session data
         sessionData = new VerifiablePresentationSessionData();
-
-        // Setup presentation definition
         presentationDefinition = createMockPresentationDefinition();
-
-        // Setup wallet credentials
         walletCredentials = createMockWalletCredentials();
+
+        when(credentialFormatHandlerFactory.getHandler(eq("ldp_vc"))).thenReturn(credentialFormatHandler);
+        when(credentialFormatHandlerFactory.getHandler(eq(CredentialFormat.VC_SD_JWT.getFormat()))).thenReturn(credentialFormatHandler);
+
+        when(credentialFormatHandler.extractAllCredentialProperties(any(VCCredentialResponse.class)))
+                .thenAnswer(invocation -> {
+                    VCCredentialResponse vc = invocation.getArgument(0);
+                    String format = vc.getFormat();
+
+                    if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+                        Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+                        result.put("publicClaims", new LinkedHashMap<>());
+                        result.put("sdClaims", new LinkedHashMap<>());
+                        return result;
+                    }
+
+                    Object credential = vc.getCredential();
+                    if (credential instanceof Map) {
+                        return new LinkedHashMap<>((Map<?, ?>) credential);
+                    }
+                    return new LinkedHashMap<>();
+                });
     }
 
-   // @Test
+    @Test
     public void testGetMatchingCredentialsSuccess() throws Exception {
         // Arrange
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
@@ -93,7 +116,6 @@ public class CredentialMatchingServiceTest {
 
         verify(openID4VPService).resolvePresentationDefinition(any(), any(), anyBoolean());
         verify(walletCredentialService).getDecryptedCredentials(eq(walletId), any());
-        verify(dataProtectionService).decryptCredential(anyString(), eq(base64Key));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -124,16 +146,6 @@ public class CredentialMatchingServiceTest {
 
         // Act
         credentialMatchingService.getMatchingCredentials(sessionData, walletId, null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetMatchingCredentialsNullPresentationDefinition() throws Exception {
-        // Arrange
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(null);
-
-        // Act
-        credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -219,29 +231,6 @@ public class CredentialMatchingServiceTest {
     }
 
     @Test
-    public void testGetMatchingCredentialsIssuerConfigNotFound() throws Exception {
-        // Arrange
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(presentationDefinition);
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(walletCredentials);
-
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-        // Should still work but with default credential display name
-        if (!result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty()) {
-            assertEquals("Unknown Credential",
-                    result.getMatchingCredentialsResponse().getAvailableCredentials().get(0).getCredentialTypeDisplayName());
-        }
-    }
-
-    @Test
     public void testGetMatchingCredentialsWithConstraints() throws Exception {
         // Arrange
         PresentationDefinition pdWithConstraints = createMockPresentationDefinitionWithConstraints();
@@ -263,10 +252,8 @@ public class CredentialMatchingServiceTest {
     public void testGetMatchingCredentialsFormatMismatch() throws Exception {
         // Arrange
         PresentationDefinition pdWithFormat = createMockPresentationDefinitionWithSpecificFormat();
-        
-        // Create credentials with different format (vc+sd-jwt instead of ldp_vc)
         List<DecryptedCredentialDTO> credentialsWithDifferentFormat = createMockWalletCredentialsWithSdJwtFormat();
-        
+
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pdWithFormat);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
@@ -278,7 +265,6 @@ public class CredentialMatchingServiceTest {
 
         // Assert
         assertNotNull(result);
-        // Should not match due to format mismatch
         assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
@@ -318,7 +304,7 @@ public class CredentialMatchingServiceTest {
 
         // Assert
         assertNotNull(result);
-        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test
@@ -364,7 +350,7 @@ public class CredentialMatchingServiceTest {
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pdWithConstraints);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(walletCredentials); // credentials without matching subject
+                .thenReturn(walletCredentials);
 
         // Act
         MatchingCredentialsDTO result = credentialMatchingService
@@ -410,76 +396,6 @@ public class CredentialMatchingServiceTest {
         // Assert
         assertNotNull(result);
         assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
-    }
-
-    @Test
-    public void testGetMatchingCredentialsWithFilterMatching() throws Exception {
-        // Arrange
-        // Use a simpler presentation definition that doesn't require complex filter matching
-        PresentationDefinition pd = createMockPresentationDefinition();
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pd);
-        
-        // Create credentials with proper structure for basic matching
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithMapData();
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-        
-        // Mock issuer service to return a valid config
-        IssuerConfig mockIssuerConfig = createMockIssuerConfig();
-        when(issuersService.getIssuerConfig(eq("test-issuer-id"), eq("TestCredential")))
-                .thenReturn(mockIssuerConfig);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-        
-        // This test verifies that basic credential matching works
-        // The credentials should match because they have the required $.type field
-        assertFalse("Basic credential matching failed - credentials should match the presentation definition", 
-                   result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
-    }
-
-    @Test
-    public void testGetMatchingCredentialsWithFilterMatchingAdvanced() throws Exception {
-        // Arrange
-        // Create a presentation definition WITHOUT filters to test basic credential matching
-        // This will help isolate whether the issue is in filter matching or basic matching
-        Fields field = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
-        Constraints constraints = new Constraints(Collections.singletonList(field), null);
-        InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
-        PresentationDefinition pdWithoutFilter = new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
-        
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pdWithoutFilter);
-        
-        // Create credentials with a flatter structure for easier path matching
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithSimpleFilterData();
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-        
-        // Mock issuer service to return a valid config
-        IssuerConfig mockIssuerConfig = createMockIssuerConfig();
-        when(issuersService.getIssuerConfig(eq("test-issuer-id"), eq("TestCredential")))
-                .thenReturn(mockIssuerConfig);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-        
-        // This test verifies that basic credential matching works without filters
-        // If it fails, the issue is in the basic credential matching logic
-        // If it passes, the issue is specifically in the filter matching logic
-        assertFalse("Basic credential matching without filters failed - this indicates a fundamental issue with credential matching", 
-                   result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test
@@ -536,7 +452,7 @@ public class CredentialMatchingServiceTest {
         assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
-    @Test(expected = InvalidRequestException.class)
+    @Test
     public void testGetMatchingCredentialsWithSdJwtFormat() throws Exception {
         // Arrange
         PresentationDefinition pd = createMockPresentationDefinition();
@@ -544,10 +460,14 @@ public class CredentialMatchingServiceTest {
                 .thenReturn(pd);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
                 .thenReturn(createMockWalletCredentialsWithSdJwtFormat());
-        
-        
-        // Act & Assert - Should throw InvalidRequestException for unsupported SD-JWT format
-        credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService
+                .getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test(expected = InvalidRequestException.class)
@@ -556,13 +476,11 @@ public class CredentialMatchingServiceTest {
         PresentationDefinition pd = createMockPresentationDefinition();
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pd);
-        
         List<DecryptedCredentialDTO> dcSdJwtCredentials = createMockWalletCredentialsWithDcSdJwtFormat();
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
                 .thenReturn(dcSdJwtCredentials);
-        
-        
-        // Act & Assert - Should throw InvalidRequestException for unsupported DC+SD-JWT format
+
+        // Act
         credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
     }
 
@@ -624,16 +542,12 @@ public class CredentialMatchingServiceTest {
         // Assert
         assertNotNull(result);
         assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
-        // Should deduplicate credentials by ID
         Set<String> credentialIds = result.getMatchingCredentialsResponse().getAvailableCredentials()
                 .stream().map(CredentialDTO::getCredentialId).collect(Collectors.toSet());
-        assertEquals(2, credentialIds.size()); // Should have 2 unique credentials
+        assertEquals(2, credentialIds.size());
     }
 
-    // Helper methods to create mock objects
-
     private PresentationDefinition createMockPresentationDefinition() {
-
         Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
         Constraints constraints = new Constraints(Collections.singletonList(field), null);
         InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
@@ -642,25 +556,13 @@ public class CredentialMatchingServiceTest {
     }
 
     private PresentationDefinition createMockPresentationDefinitionWithConstraints() {
-        // Field 1: simple path
         Fields field1 = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
-
-        // Field 2: with path and filter
         Filter filter = new Filter("type", "String");
         Fields field2 = new Fields(Arrays.asList("$.credentialSubject.name"), null, null, null, filter, null);
-
-        // Constraints with both fields
         Constraints constraints = new Constraints(Arrays.asList(field1, field2), null);
-
-        // Input Descriptor with constraints
         InputDescriptor descriptor = new InputDescriptor("test-descriptor-with-constraints", null, null, null, constraints);
-
-        // Presentation Definition with descriptor
-        PresentationDefinition pd = new PresentationDefinition("test-presentation-definition-with-constraints", Arrays.asList(descriptor), null, null, null);
-
-        return pd;
+        return new PresentationDefinition("test-presentation-definition-with-constraints", Arrays.asList(descriptor), null, null, null);
     }
-
 
     private PresentationDefinition createMockPresentationDefinitionWithSpecificFormat() {
         Map<String, Map<String, List<String>>> format = new HashMap<>();
@@ -721,7 +623,6 @@ public class CredentialMatchingServiceTest {
         return response;
     }
 
-
     private Map<String, Object> createMockCredentialSubject() {
         Map<String, Object> subject = new HashMap<>();
         subject.put("id", "did:example:123456789");
@@ -771,7 +672,6 @@ public class CredentialMatchingServiceTest {
     }
 
     private PresentationDefinition createMockPresentationDefinitionWithNullConstraints() {
-        // Create constraints with null fields (not null constraints object)
         Constraints constraints = new Constraints(null, null);
         InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
         return new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
@@ -885,12 +785,11 @@ public class CredentialMatchingServiceTest {
         credential.setId("test-credential-id");
         credential.setWalletId(walletId);
 
-        // Create credential data with type that matches the presentation definition
         Map<String, Object> credentialData = new HashMap<>();
         credentialData.put("iss", "https://example.com");
         credentialData.put("sub", "did:example:123456789");
         credentialData.put("type", Arrays.asList("DataCredential", "TestCredential"));
-        
+
         VCCredentialResponse response = VCCredentialResponse.builder()
                 .format(CredentialFormat.DC_SD_JWT.getFormat())
                 .credential(credentialData)
@@ -934,12 +833,10 @@ public class CredentialMatchingServiceTest {
         return Arrays.asList(credential1, credential2);
     }
 
-
     private VCCredentialProperties createMockVCCredentialPropertiesWithProof() {
         VCCredentialProperties properties = new VCCredentialProperties();
         properties.setType(Arrays.asList("VerifiableCredential", "TestCredential"));
-        
-        // Create a mock proof object
+
         VCCredentialResponseProof proof = new VCCredentialResponseProof();
         proof.setType("Ed25519Signature2020");
         properties.setProof(proof);
@@ -952,16 +849,13 @@ public class CredentialMatchingServiceTest {
         credential.setId("test-credential-id");
         credential.setWalletId(walletId);
 
-        // Create credential data as Map (which is what the implementation expects for ldp_vc format)
         Map<String, Object> credentialData = new HashMap<>();
         credentialData.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
-        
-        // Create credentialSubject with name that contains "John" (filter pattern)
         Map<String, Object> subject = new HashMap<>();
         subject.put("id", "did:example:123456789");
-        subject.put("name", "John Doe"); // This should match filter looking for "John"
+        subject.put("name", "John Doe");
         credentialData.put("credentialSubject", subject);
-        
+
         VCCredentialResponse response = VCCredentialResponse.builder()
                 .format("ldp_vc")
                 .credential(credentialData)
@@ -984,12 +878,11 @@ public class CredentialMatchingServiceTest {
         credential.setId("test-credential-id");
         credential.setWalletId(walletId);
 
-        // Create credential data with a flatter structure for easier path matching
         Map<String, Object> credentialData = new HashMap<>();
         credentialData.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
-        credentialData.put("name", "John Doe"); // Direct field for $.name path
+        credentialData.put("name", "John Doe");
         credentialData.put("id", "did:example:123456789");
-        
+
         VCCredentialResponse response = VCCredentialResponse.builder()
                 .format("ldp_vc")
                 .credential(credentialData)
@@ -1007,67 +900,23 @@ public class CredentialMatchingServiceTest {
         return Arrays.asList(credential);
     }
 
-    // Test cases for evaluateJsonPath method through integration testing
     @Test
     public void testJsonPathEvaluationTypePathWithSampleData() throws Exception {
-        // Arrange - Using the exact sample data provided
+        // Arrange
         Map<String, Object> credentialData = new HashMap<>();
         credentialData.put("id", "did:rcw:2121a1df-29fe-496e-ae24-219dcOb3ac49");
         credentialData.put("type", Arrays.asList("VerifiableCredential", "LifeInsuranceCredential"));
-        
-        // Create presentation definition that requires the type field
+
         Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
         Constraints constraints = new Constraints(Collections.singletonList(field), null);
         InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
         PresentationDefinition pd = new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
-        
+
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pd);
-        
-        // Create credentials with the sample data
         List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithSampleData(credentialData);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
                 .thenReturn(credentials);
-        
-        // Mock issuer service
-        IssuerConfig mockIssuerConfig = createMockIssuerConfig();
-        when(issuersService.getIssuerConfig(eq("test-issuer-id"), eq("TestCredential")))
-                .thenReturn(mockIssuerConfig);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert - This tests that the JSON path evaluation works correctly
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-        assertFalse("JSON path evaluation failed - credentials should match the type field", 
-                   result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
-    }
-
-    @Test
-    public void testJsonPathEvaluationNestedPath() throws Exception {
-        // Arrange - Test nested path evaluation
-        Map<String, Object> credentialData = new HashMap<>();
-        Map<String, Object> credentialSubject = new HashMap<>();
-        credentialSubject.put("name", "John Doe");
-        credentialSubject.put("age", 30);
-        credentialData.put("credentialSubject", credentialSubject);
-        credentialData.put("type", Arrays.asList("VerifiableCredential", "IdentityCredential"));
-        
-        // Create presentation definition that requires nested field
-        Fields field = new Fields(Arrays.asList("$.credentialSubject.name"), null, null, null, null, null);
-        Constraints constraints = new Constraints(Collections.singletonList(field), null);
-        InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
-        PresentationDefinition pd = new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
-        
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pd);
-        
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithSampleData(credentialData);
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-        
         IssuerConfig mockIssuerConfig = createMockIssuerConfig();
         when(issuersService.getIssuerConfig(eq("test-issuer-id"), eq("TestCredential")))
                 .thenReturn(mockIssuerConfig);
@@ -1079,45 +928,74 @@ public class CredentialMatchingServiceTest {
         // Assert
         assertNotNull(result);
         assertNotNull(result.getMatchingCredentialsResponse());
-        assertFalse("Nested JSON path evaluation failed", 
-                   result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test
-    public void testJsonPathEvaluationNonExistentPath() throws Exception {
-        // Arrange - Test non-existent path handling
+    public void testJsonPathEvaluationNestedPath() throws Exception {
+        // Arrange
         Map<String, Object> credentialData = new HashMap<>();
-        credentialData.put("id", "did:rcw:2121a1df-29fe-496e-ae24-219dcOb3ac49");
-        credentialData.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
-        
-        // Create presentation definition that requires non-existent field
-        Fields field = new Fields(Arrays.asList("$.nonExistentField"), null, null, null, null, null);
+        Map<String, Object> credentialSubject = new HashMap<>();
+        credentialSubject.put("name", "John Doe");
+        credentialSubject.put("age", 30);
+        credentialData.put("credentialSubject", credentialSubject);
+        credentialData.put("type", Arrays.asList("VerifiableCredential", "IdentityCredential"));
+
+        Fields field = new Fields(Arrays.asList("$.credentialSubject.name"), null, null, null, null, null);
         Constraints constraints = new Constraints(Collections.singletonList(field), null);
         InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
         PresentationDefinition pd = new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
-        
+
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pd);
-        
         List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithSampleData(credentialData);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
                 .thenReturn(credentials);
-        
-        
+        IssuerConfig mockIssuerConfig = createMockIssuerConfig();
+        when(issuersService.getIssuerConfig(eq("test-issuer-id"), eq("TestCredential")))
+                .thenReturn(mockIssuerConfig);
+
         // Act
         MatchingCredentialsDTO result = credentialMatchingService
                 .getMatchingCredentials(sessionData, walletId, base64Key);
 
-        // Assert - Should not match due to non-existent path
+        // Assert
         assertNotNull(result);
         assertNotNull(result.getMatchingCredentialsResponse());
-        assertTrue("Non-existent path should result in no matches", 
-                  result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testJsonPathEvaluationNonExistentPath() throws Exception {
+        // Arrange
+        Map<String, Object> credentialData = new HashMap<>();
+        credentialData.put("id", "did:rcw:2121a1df-29fe-496e-ae24-219dcOb3ac49");
+        credentialData.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
+
+        Fields field = new Fields(Arrays.asList("$.nonExistentField"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
+                .thenReturn(pd);
+        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithSampleData(credentialData);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(credentials);
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService
+                .getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertNotNull(result);
+        assertNotNull(result.getMatchingCredentialsResponse());
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test
     public void testJsonPathEvaluationComplexNestedStructure() throws Exception {
-        // Arrange - Test complex nested structure
+        // Arrange
         Map<String, Object> credentialData = new HashMap<>();
         Map<String, Object> credentialSubject = new HashMap<>();
         Map<String, Object> address = new HashMap<>();
@@ -1127,20 +1005,17 @@ public class CredentialMatchingServiceTest {
         credentialSubject.put("name", "John Doe");
         credentialData.put("credentialSubject", credentialSubject);
         credentialData.put("type", Arrays.asList("VerifiableCredential", "IdentityCredential"));
-        
-        // Create presentation definition that requires deeply nested field
+
         Fields field = new Fields(Arrays.asList("$.credentialSubject.address.city"), null, null, null, null, null);
         Constraints constraints = new Constraints(Collections.singletonList(field), null);
         InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
         PresentationDefinition pd = new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
-        
+
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pd);
-        
         List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithSampleData(credentialData);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
                 .thenReturn(credentials);
-        
         IssuerConfig mockIssuerConfig = createMockIssuerConfig();
         when(issuersService.getIssuerConfig(eq("test-issuer-id"), eq("TestCredential")))
                 .thenReturn(mockIssuerConfig);
@@ -1152,31 +1027,26 @@ public class CredentialMatchingServiceTest {
         // Assert
         assertNotNull(result);
         assertNotNull(result.getMatchingCredentialsResponse());
-        assertFalse("Complex nested JSON path evaluation failed", 
-                   result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
     @Test
     public void testJsonPathEvaluationListIndexPath() throws Exception {
-        // Arrange - Test list index path evaluation
+        // Arrange
         Map<String, Object> credentialData = new HashMap<>();
         credentialData.put("items", Arrays.asList("item1", "item2", "item3"));
         credentialData.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
-        
-        // Create presentation definition that requires list index
+
         Fields field = new Fields(Arrays.asList("$.items.1"), null, null, null, null, null);
         Constraints constraints = new Constraints(Collections.singletonList(field), null);
         InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
         PresentationDefinition pd = new PresentationDefinition("test-presentation-definition", Arrays.asList(descriptor), null, null, null);
-        
+
         when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
                 .thenReturn(pd);
-        
         List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithSampleData(credentialData);
         when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
                 .thenReturn(credentials);
-        
-        IssuerConfig mockIssuerConfig = createMockIssuerConfig();
 
         // Act
         MatchingCredentialsDTO result = credentialMatchingService
@@ -1185,11 +1055,9 @@ public class CredentialMatchingServiceTest {
         // Assert
         assertNotNull(result);
         assertNotNull(result.getMatchingCredentialsResponse());
-        assertTrue("List index JSON path evaluation failed",
-                   result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
     }
 
-    // Helper method to create credentials with custom data
     private List<DecryptedCredentialDTO> createMockWalletCredentialsWithSampleData(Map<String, Object> credentialData) throws JsonProcessingException {
         DecryptedCredentialDTO credential = new DecryptedCredentialDTO();
         credential.setId("test-credential-id");
@@ -1212,7 +1080,6 @@ public class CredentialMatchingServiceTest {
         return Arrays.asList(credential);
     }
 
-    // Test cases for null checks and input validation
     @Test
     public void testGetMatchingCredentialsNullPresentationDefinitionFromService() throws Exception {
         // Arrange
@@ -1224,137 +1091,12 @@ public class CredentialMatchingServiceTest {
             credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
         });
         
-        assertEquals("Presentation definition not found in session data", exception.getMessage());
-    }
-
-
-    @Test
-    public void testMatchesConstraintsNullFields() throws Exception {
-        // Arrange
-        PresentationDefinition pd = createMockPresentationDefinition();
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pd);
-        
-        // Create credentials with null fields in constraints
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithMapData();
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-
-        // Create presentation definition with null fields
-        Constraints constraints = new Constraints(null, null);
-        InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
-        PresentationDefinition pdWithNullFields = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pdWithNullFields);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert - Should handle null fields gracefully
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-    }
-
-    @Test
-    public void testMatchesFormatNullDescriptorFormat() throws Exception {
-        // Arrange
-        // Create input descriptor with null format but valid constraints
-        Constraints constraints = new Constraints(null, null);
-        InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
-        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
-        
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pd);
-        
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithMapData();
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert - Should handle null format gracefully
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-    }
-
-    @Test
-    public void testMatchesFieldPathNullMatches() throws Exception {
-        // Arrange
-        PresentationDefinition pd = createMockPresentationDefinition();
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pd);
-        
-        // Create credentials that will result in null matches
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithMapData();
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert - Should handle null matches gracefully
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-    }
-
-    @Test
-    public void testMatchesFilterNullFilter() throws Exception {
-        // Arrange
-        // Create presentation definition with null filter
-        Fields field = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
-        Constraints constraints = new Constraints(Collections.singletonList(field), null);
-        InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
-        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
-        
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pd);
-        
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithMapData();
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert - Should handle null filter gracefully
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
-    }
-
-    @Test
-    public void testExtractRequiredClaimsNullPath() throws Exception {
-        // Arrange
-        // Create presentation definition with empty path list to test null path handling
-        Fields field = new Fields(Collections.emptyList(), null, null, null, null, null);
-        Constraints constraints = new Constraints(Collections.singletonList(field), null);
-        InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
-        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
-        
-        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean()))
-                .thenReturn(pd);
-        
-        List<DecryptedCredentialDTO> credentials = createMockWalletCredentialsWithMapData();
-        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
-                .thenReturn(credentials);
-
-        // Act
-        MatchingCredentialsDTO result = credentialMatchingService
-                .getMatchingCredentials(sessionData, walletId, base64Key);
-
-        // Assert - Should handle null path gracefully
-        assertNotNull(result);
-        assertNotNull(result.getMatchingCredentialsResponse());
+        assertEquals("Presentation definition cannot be null", exception.getMessage());
     }
 
     @Test
     public void testExtractRequiredClaimsBlankPath() throws Exception {
         // Arrange
-        // Create presentation definition with blank path
         Fields field = new Fields(Arrays.asList("   "), null, null, null, null, null);
         Constraints constraints = new Constraints(Collections.singletonList(field), null);
         InputDescriptor descriptor = new InputDescriptor("test-descriptor", null, null, null, constraints);
@@ -1371,8 +1113,1132 @@ public class CredentialMatchingServiceTest {
         MatchingCredentialsDTO result = credentialMatchingService
                 .getMatchingCredentials(sessionData, walletId, base64Key);
 
-        // Assert - Should handle blank path gracefully
+        // Assert
         assertNotNull(result);
         assertNotNull(result.getMatchingCredentialsResponse());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenAlgorithmMatchesCredentialIsSelected() throws Exception {
+        // Arrange
+        PresentationDefinition pd = createSdJwtPresentationDefinition(Arrays.asList("HS256"));
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+
+        Map<String, Object> publicClaims = new LinkedHashMap<>();
+        publicClaims.put("type", Arrays.asList("VerifiableCredential", "TestCredential"));
+        setupSdJwtHandlerMock(publicClaims, new LinkedHashMap<>());
+
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_HS256)));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertEquals(CredentialFormat.VC_SD_JWT.getFormat(),
+                result.getMatchingCredentialsResponse().getAvailableCredentials().get(0).getFormat());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenAlgorithmDoesNotMatchCredentialNotSelected() throws Exception {
+        // Arrange
+        PresentationDefinition pd = createSdJwtPresentationDefinition(Arrays.asList("ES256"));
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_HS256)));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenNoAlgValuesInFormatCredentialIsSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), new HashMap<>());
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        Map<String, Object> publicClaims = new LinkedHashMap<>();
+        publicClaims.put("type", Arrays.asList("VerifiableCredential"));
+        setupSdJwtHandlerMock(publicClaims, new LinkedHashMap<>());
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_HS256)));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenCredentialIsNullCredentialNotSelected() throws Exception {
+        // Arrange
+        PresentationDefinition pd = createSdJwtPresentationDefinition(Arrays.asList("HS256"));
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(null)));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenCredentialIsNotStringCredentialNotSelected() throws Exception {
+        // Arrange
+        PresentationDefinition pd = createSdJwtPresentationDefinition(Arrays.asList("HS256"));
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+
+        DecryptedCredentialDTO cred = new DecryptedCredentialDTO();
+        cred.setId("sd-jwt-cred");
+        cred.setWalletId(walletId);
+        cred.setCredential(VCCredentialResponse.builder()
+                .format(CredentialFormat.VC_SD_JWT.getFormat())
+                .credential(Map.of("key", "value"))
+                .build());
+        CredentialMetadata metadata = new CredentialMetadata();
+        metadata.setIssuerId("test-issuer-id");
+        metadata.setCredentialType("TestCredential");
+        cred.setCredentialMetadata(metadata);
+        cred.setCreatedAt(Instant.now());
+        cred.setUpdatedAt(Instant.now());
+
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(cred));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenFormatConfigValueIsNullCredentialNotSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), Map.of("jwt_alg_values", List.of("ES256")));
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_HS256)));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenJwtHeaderMissingAlgCredentialNotSelected() throws Exception {
+        // Arrange
+        PresentationDefinition pd = createSdJwtPresentationDefinition(Arrays.asList("HS256"));
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_NO_ALG)));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenEmptyJwtStringCredentialNotSelected() throws Exception {
+        // Arrange
+        PresentationDefinition pd = createSdJwtPresentationDefinition(Arrays.asList("HS256"));
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential("   ")));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesSdJwtFormatWhenJwtHeaderAlgIsNonStringCredentialNotSelected() throws Exception {
+        // Arrange
+        PresentationDefinition pd = createSdJwtPresentationDefinition(Arrays.asList("HS256"));
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_NON_STRING_ALG)));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testGetCredentialDataWhenSdJwtExtractsNullCredentialNotSelected() throws Exception {
+        // Arrange
+        Fields field = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_HS256)));
+        when(credentialFormatHandler.extractAllCredentialProperties(any(VCCredentialResponse.class)))
+                .thenReturn(null);
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testGetCredentialDataWhenSdJwtFlattensPropertiesCredentialSelected() throws Exception {
+        // Arrange
+        Fields field = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_HS256)));
+
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("name", "John");
+        setupSdJwtHandlerMock(new LinkedHashMap<>(), sdClaims);
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    
+    @Test
+    public void testBuildAvailableCredentialWhenSdJwtWithNullClaimsReturnsEmptyClaimLists() throws Exception {
+        // Arrange
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(null, null));
+
+        // Assert
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        assertTrue(credential.getClaims().isEmpty());
+        assertTrue(credential.getSdClaims().isEmpty());
+        assertEquals(CredentialFormat.VC_SD_JWT.getFormat(), credential.getFormat());
+    }
+
+    @Test
+    public void testBuildAvailableCredentialWhenSdJwtWithCredentialSubjectExtractsFromSubject() throws Exception {
+        Map<String, Object> publicClaims = new LinkedHashMap<>();
+        Map<String, Object> subject = new LinkedHashMap<>();
+        subject.put("name", "John");
+        subject.put("age", 30);
+        subject.put("_sd", Arrays.asList("hash1", "hash2"));
+        Map<String, Object> address = new LinkedHashMap<>();
+        address.put("street", "123 Main St");
+        address.put("city", "NYC");
+        subject.put("address", address);
+        List<Map<String, Object>> contacts = Arrays.asList(
+                createMapOf("type", "email", "value", "john@example.com"),
+                createMapOf("type", "phone", "value", "555-1234"));
+        subject.put("contacts", contacts);
+        List<Object> privileges = Arrays.asList(
+                createMapOf("vehicle_code", "C", "issue_date", "2020-01-01"));
+        subject.put("privileges", privileges);
+        List<Object> tags = new ArrayList<>();
+        tags.add(createMapOf("code", "A", "label", "TagA"));
+        tags.add(createMapOf("code", "B", "label", "TagB"));
+        tags.add("plain-string");
+        subject.put("tags", tags);
+        List<Map<String, Object>> disjoint = Arrays.asList(
+                createMapOf("alpha", 1),
+                createMapOf("beta", 2));
+        subject.put("disjoint", disjoint);
+        publicClaims.put("credentialSubject", subject);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(publicClaims, new LinkedHashMap<>()));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        assertTrue(credential.getClaims().contains("$.name"));
+        assertTrue(credential.getClaims().contains("$.age"));
+        assertTrue(credential.getClaims().contains("$.address.street"));
+        assertTrue(credential.getClaims().contains("$.address.city"));
+        assertTrue(credential.getClaims().contains("$.contacts"));
+        assertFalse(credential.getClaims().contains("$.contacts.type"));
+        assertFalse(credential.getClaims().contains("$.contacts.value"));
+        assertTrue(credential.getClaims().contains("$.privileges"));
+        assertTrue(credential.getClaims().contains("$.privileges.vehicle_code"));
+        assertTrue(credential.getClaims().contains("$.privileges.issue_date"));
+        assertTrue(credential.getClaims().contains("$.tags"));
+        assertTrue(credential.getClaims().contains("$.tags.code"));
+        assertTrue(credential.getClaims().contains("$.tags.label"));
+        assertTrue(credential.getClaims().contains("$.disjoint"));
+        assertTrue(credential.getClaims().contains("$.disjoint.alpha"));
+        assertTrue(credential.getClaims().contains("$.disjoint.beta"));
+        assertFalse(credential.getClaims().contains("$._sd"));
+        assertFalse(credential.getClaims().contains("$.address"));
+    }
+
+    @Test
+    public void testBuildAvailableCredentialWhenSdJwtWithoutCredentialSubjectRemovesMetadataAndExtracts() throws Exception {
+        // Arrange
+        Map<String, Object> publicClaims = new LinkedHashMap<>();
+        publicClaims.put("vct", "IdentityCredential");
+        publicClaims.put("iss", "https://example.com");
+        publicClaims.put("cnf", new LinkedHashMap<>(Map.of("jwk", "key")));
+        publicClaims.put("sub", "did:example:123");
+        publicClaims.put("iat", 1234567890);
+        publicClaims.put("exp", 1234567899);
+        publicClaims.put("nbf", 1234567880);
+        publicClaims.put("jti", "urn:uuid:abc");
+        publicClaims.put("aud", "https://verifier.com");
+        publicClaims.put("_sd", Arrays.asList("hash1"));
+        publicClaims.put("_sd_alg", "sha-256");
+        publicClaims.put("id", "did:example:123");
+        publicClaims.put("given_name", "John");
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(publicClaims, new LinkedHashMap<>()));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        assertTrue(credential.getClaims().contains("$.given_name"));
+        assertFalse(credential.getClaims().stream().anyMatch(c ->
+                c.contains("vct") || c.contains("iss") || c.contains("cnf") || c.contains("sub") ||
+                c.contains("_sd") || c.contains("_sd_alg") || c.contains("id")));
+    }
+
+    @Test
+    public void testBuildAvailableCredentialWhenSdJwtWithSdClaimsExtractsSdClaimPaths() throws Exception {
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("family_name", "Doe");
+        sdClaims.put("birth_date", "1990-01-01");
+        sdClaims.put("credentialSubject.NumberOfCAR", 5);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        assertEquals(3, credential.getSdClaims().size());
+        assertTrue(credential.getSdClaims().contains("$.family_name"));
+        assertTrue(credential.getSdClaims().contains("$.birth_date"));
+        assertTrue(credential.getSdClaims().contains("$.NumberOfCAR"));
+    }
+
+    @Test
+    public void testBuildAvailableCredentialWhenSdJwtWithIssuerConfigExceptionUsesDefaultDisplayName() throws Exception {
+        // Arrange
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), new LinkedHashMap<>()));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        assertEquals("Unknown Credential", credential.getCredentialTypeDisplayName());
+        assertNull(credential.getCredentialTypeLogo());
+    }
+
+    @Test
+    public void testCollectPathsWhenMapHasScalarValuesCollectsLeafPaths() throws Exception {
+        // Arrange
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("given_name", "John");
+        sdClaims.put("family_name", "Doe");
+        sdClaims.put("age", 30);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(3, paths.size());
+        assertTrue(paths.containsAll(Arrays.asList("$.given_name", "$.family_name", "$.age")));
+    }
+
+    @Test
+    public void testExtractSdClaimPathsWhenMapHasNestedMapProducesTopLevelKey() throws Exception {
+        Map<String, Object> address = new LinkedHashMap<>();
+        address.put("street", "123 Main St");
+        address.put("city", "NYC");
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("address", address);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.address"));
+    }
+
+    @Test
+    public void testExtractSdClaimPathsWhenMapHasSdKeyIncludesSdKey() throws Exception {
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("name", "John");
+        sdClaims.put("_sd", Arrays.asList("hash1", "hash2"));
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(2, paths.size());
+        assertTrue(paths.contains("$.name"));
+        assertTrue(paths.contains("$._sd"));
+    }
+
+    @Test
+    public void testCollectPathsWhenListHasUniformKeysStopsAtListLevel() throws Exception {
+        // Arrange
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        List<Map<String, Object>> genderList = Arrays.asList(
+                createMapOf("code", "M", "value", "Male"),
+                createMapOf("code", "F", "value", "Female"));
+        sdClaims.put("gender", genderList);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertTrue(paths.contains("$.gender"));
+        assertFalse(paths.contains("$.gender.code"));
+        assertFalse(paths.contains("$.gender.value"));
+        assertEquals(1, paths.size());
+    }
+
+    @Test
+    public void testExtractSdClaimPathsWhenListHasSingleMapItemProducesTopLevelKey() throws Exception {
+        Map<String, Object> privilege = new LinkedHashMap<>();
+        privilege.put("vehicle_category_code", "C");
+        privilege.put("issue_date", "2020-01-01");
+
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("driving_privileges", Arrays.asList(privilege));
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.driving_privileges"));
+    }
+
+    @Test
+    public void testCollectPathsWhenListHasNonMapItemsSkipsNonMapItems() throws Exception {
+        // Arrange
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("tags", Arrays.asList("tag1", "tag2", "tag3"));
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.tags"));
+    }
+
+    @Test
+    public void testExtractSdClaimPathsWhenListItemsHaveNoCommonKeysProducesTopLevelKey() throws Exception {
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        List<Map<String, Object>> items = Arrays.asList(
+                createMapOf("alpha", 1),
+                createMapOf("beta", 2));
+        sdClaims.put("mixed", items);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.mixed"));
+    }
+
+    @Test
+    public void testExtractSdClaimPathsComplexDrivingPrivilegesProducesTopLevelKey() throws Exception {
+        Map<String, Object> privilege = new LinkedHashMap<>();
+        privilege.put("vehicle_category_code", "C");
+        privilege.put("issue_date", "2020-01-01");
+        privilege.put("expiry_date", "2025-01-01");
+        List<Map<String, Object>> codes = Arrays.asList(
+                createMapOf("code", "A", "value", "V1"),
+                createMapOf("code", "B", "value", "V2"));
+        privilege.put("codes", codes);
+
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("driving_privileges", List.of(privilege));
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.driving_privileges"));
+    }
+
+    @Test
+    public void testExtractSdClaimPathsWhenListContainsMixedTypesProducesTopLevelKey() throws Exception {
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        List<Object> mixedList = new ArrayList<>();
+        mixedList.add(createMapOf("key1", "val1"));
+        mixedList.add("plain-string");
+        mixedList.add(42);
+        sdClaims.put("mixed_types", mixedList);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.mixed_types"));
+    }
+
+    @Test
+    public void testCollectPathsWhenEmptyMapProducesNoPaths() throws Exception {
+        // Arrange
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), new LinkedHashMap<>()));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        assertTrue(credential.getSdClaims().isEmpty());
+        assertTrue(credential.getClaims().isEmpty());
+    }
+
+    @Test
+    public void testCollectPathsWhenListWithPartiallyOverlappingKeysTreatedAsUniform() throws Exception {
+        // Arrange
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        List<Map<String, Object>> codes = Arrays.asList(
+                createMapOf("code", "A", "value", "V1", "sign", "+"),
+                createMapOf("code", "B", "value", "V2"));
+        sdClaims.put("codes", codes);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertTrue(paths.contains("$.codes"));
+        assertFalse(paths.contains("$.codes.code"));
+        assertFalse(paths.contains("$.codes.value"));
+        assertFalse(paths.contains("$.codes.sign"));
+        assertEquals(1, paths.size());
+    }
+
+    @Test
+    public void testCollectPathsWhenEmptyListProducesPathButNoRecursion() throws Exception {
+        // Arrange
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("empty_list", new ArrayList<>());
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        // Assert
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.empty_list"));
+    }
+
+    @Test
+    public void testExtractSdClaimPathsWhenDeeplyNestedMapsProducesTopLevelKey() throws Exception {
+        Map<String, Object> level3 = new LinkedHashMap<>();
+        level3.put("deep_value", "found");
+        Map<String, Object> level2 = new LinkedHashMap<>();
+        level2.put("level3", level3);
+        Map<String, Object> level1 = new LinkedHashMap<>();
+        level1.put("level2", level2);
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        sdClaims.put("level1", level1);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.level1"));
+    }
+
+  
+    @Test
+    public void testMatchesFormatWhenLdpVcProofTypeNullCredentialNotSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        Map<String, List<String>> ldpVcFormat = new HashMap<>();
+        ldpVcFormat.put("proof_type", Arrays.asList("Ed25519Signature2020"));
+        format.put("ldp_vc", ldpVcFormat);
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        VCCredentialProperties propsWithNullProof = new VCCredentialProperties();
+        propsWithNullProof.setType(Arrays.asList("VerifiableCredential"));
+        propsWithNullProof.setProof(null);
+        doReturn(propsWithNullProof).when(objectMapper).convertValue(any(), eq(VCCredentialProperties.class));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesFormatWhenLdpVcProofTypeListEmptyCredentialSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        Map<String, List<String>> ldpVcFormat = new HashMap<>();
+        ldpVcFormat.put("proof_type", Collections.emptyList());
+        format.put("ldp_vc", ldpVcFormat);
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        VCCredentialProperties props = new VCCredentialProperties();
+        props.setType(Arrays.asList("VerifiableCredential"));
+        doReturn(props).when(objectMapper).convertValue(any(), eq(VCCredentialProperties.class));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesFormatWhenLdpVcRequiredProofTypesNullCredentialSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        Map<String, List<String>> ldpVcFormat = new HashMap<>();
+        ldpVcFormat.put("proof_type", null);
+        format.put("ldp_vc", ldpVcFormat);
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        VCCredentialProperties props = new VCCredentialProperties();
+        props.setType(Arrays.asList("VerifiableCredential"));
+        doReturn(props).when(objectMapper).convertValue(any(), eq(VCCredentialProperties.class));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesFormatWhenLdpVcNullLdpVcFormatCredentialSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put("ldp_vc", null);
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesFormatWhenLdpVcProofTypeMismatchCredentialNotSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        Map<String, List<String>> ldpVcFormat = new HashMap<>();
+        ldpVcFormat.put("proof_type", Arrays.asList("Ed25519Signature2020"));
+        format.put("ldp_vc", ldpVcFormat);
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMatchingFormat());
+
+        VCCredentialProperties propsWithWrongProof = new VCCredentialProperties();
+        propsWithWrongProof.setType(Arrays.asList("VerifiableCredential"));
+        VCCredentialResponseProof wrongProof = new VCCredentialResponseProof();
+        wrongProof.setType("EcdsaSecp256k1Signature2019");
+        propsWithWrongProof.setProof(wrongProof);
+        when(objectMapper.convertValue(any(), eq(VCCredentialProperties.class))).thenReturn(propsWithWrongProof);
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesFormatWhenLdpVcCredentialAndDescriptorLacksLdpVcKeyCredentialNotSelected() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), new HashMap<>());
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+   
+    @Test
+    public void testEvaluateJsonPathWhenPathDoesNotStartWithDollarDotNoMatch() throws Exception {
+        // Arrange
+        Fields field = new Fields(Arrays.asList("type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testEvaluateJsonPathWhenJsonPathValueIsNullNoMatch() throws Exception {
+        // Arrange
+        Map<String, Object> credentialData = new HashMap<>();
+        credentialData.put("name", null);
+        credentialData.put("type", Arrays.asList("VerifiableCredential"));
+
+        Fields field = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithSampleData(credentialData));
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testEvaluateJsonPathWhenResultIsSingleValueWrapsInList() throws Exception {
+        // Arrange
+        Fields nameField = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(nameField), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithSimpleFilterData());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertFalse(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+   
+    @Test
+    public void testExtractClaimsFromFieldsWhenFieldsContainNullSkipsNullFields() throws Exception {
+        // Arrange
+        List<Fields> fieldsList = new ArrayList<>();
+        fieldsList.add(null);
+        fieldsList.add(new Fields(Arrays.asList("$.type"), null, null, null, null, null));
+        Constraints constraints = new Constraints(fieldsList, null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("type"));
+    }
+
+    @Test
+    public void testExtractClaimsFromFieldsWhenFieldsIsNullReturnsEmptyList() throws Exception {
+        // Arrange
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), new HashMap<>());
+
+        Constraints constraints = new Constraints(null, null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, format, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().isEmpty());
+    }
+
+    @Test
+    public void testExtractRequiredClaimsWhenDeduplicateEnabledRemovesDuplicates() throws Exception {
+        // Arrange
+        Fields field1 = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints1 = new Constraints(Collections.singletonList(field1), null);
+        InputDescriptor desc1 = new InputDescriptor("desc-1", null, null, null, constraints1);
+
+        Fields field2 = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints2 = new Constraints(Collections.singletonList(field2), null);
+        InputDescriptor desc2 = new InputDescriptor("desc-2", null, null, null, constraints2);
+
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(desc1, desc2), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertEquals(1, result.getMatchingCredentialsResponse().getMissingClaims().size());
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("type"));
+    }
+
+
+    @Test
+    public void testExtractSdJwtAlgorithmWhenSdJwtStringIsNullReturnsNull() throws Exception {
+        // Arrange
+        Method method = CredentialMatchingServiceImpl.class.getDeclaredMethod("extractSdJwtAlgorithm", String.class);
+        method.setAccessible(true);
+
+        // Act
+        String result = (String) method.invoke(credentialMatchingService, (String) null);
+
+        // Assert
+        assertNull(result);
+    }
+
+    @Test
+    public void testMatchesConstraintsWhenFieldsAreNullReturnsTrue() throws Exception {
+        // Arrange
+        Method method = CredentialMatchingServiceImpl.class.getDeclaredMethod(
+                "matchesConstraints", VCCredentialResponse.class, Constraints.class);
+        method.setAccessible(true);
+
+        VCCredentialResponse vc = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(new HashMap<>())
+                .build();
+        Constraints constraints = new Constraints(null, null);
+
+        // Act
+        boolean result = (boolean) method.invoke(credentialMatchingService, vc, constraints);
+
+        // Assert
+        assertTrue(result);
+    }
+
+    @Test
+    public void testEvaluateJsonPathWhenPathIsNullReturnsEmptyList() throws Exception {
+        // Arrange
+        Fields field = new Fields(Collections.singletonList(null), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testEvaluateJsonPathWhenJsonIsNullReturnsEmptyList() throws Exception {
+        // Arrange
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(createMockWalletCredentialsWithMapData());
+        when(credentialFormatHandler.extractAllCredentialProperties(any(VCCredentialResponse.class)))
+                .thenReturn(null);
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getAvailableCredentials().isEmpty());
+    }
+
+    @Test
+    public void testMatchesFieldPathWhenPathNotFoundInCredentialReturnsFalse() throws Exception {
+        // Arrange
+        Method method = CredentialMatchingServiceImpl.class.getDeclaredMethod(
+                "matchesFieldPath", VCCredentialResponse.class, String.class, Filter.class);
+        method.setAccessible(true);
+
+        VCCredentialResponse vc = VCCredentialResponse.builder()
+                .format("ldp_vc")
+                .credential(new HashMap<>())
+                .build();
+
+        // Act
+        boolean result = (boolean) method.invoke(credentialMatchingService, vc, "$.nonexistent", null);
+
+        // Assert
+        assertFalse(result);
+    }
+
+    @Test
+    public void testExtractRequiredClaimsWhenDescriptorHasNullFieldsFilteredOut() throws Exception {
+        // Arrange
+        Constraints constraintsWithNullFields = new Constraints(null, null);
+        InputDescriptor descNullFields = new InputDescriptor("desc-null", null, null, null, constraintsWithNullFields);
+
+        Fields field = new Fields(Arrays.asList("$.name"), null, null, null, null, null);
+        Constraints constraintsWithFields = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descWithFields = new InputDescriptor("desc-valid", null, null, null, constraintsWithFields);
+
+        PresentationDefinition pd = new PresentationDefinition(
+                "test-pd", Arrays.asList(descNullFields, descWithFields), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("name"));
+        assertEquals(1, result.getMatchingCredentialsResponse().getMissingClaims().size());
+    }
+
+    @Test
+    public void testExtractClaimKeyFromPathWhenTailStartsWithDollarStrippsDollarPrefix() throws Exception {
+        // Arrange
+        Fields field = new Fields(Arrays.asList("$.$id"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("test-pd", Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        MatchingCredentialsDTO result = credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+
+        // Assert
+        assertTrue(result.getMatchingCredentialsResponse().getMissingClaims().contains("id"));
+    }
+
+    @Test
+    public void testExtractSdClaimPathsWhenListHasMapsAndNonMapsProducesTopLevelKey() throws Exception {
+        Map<String, Object> sdClaims = new LinkedHashMap<>();
+        List<Object> mixedList = new ArrayList<>();
+        mixedList.add(createMapOf("code", "A", "value", "V1"));
+        mixedList.add(createMapOf("code", "B", "value", "V2"));
+        mixedList.add("not-a-map");
+        sdClaims.put("data", mixedList);
+
+        MatchingCredentialsDTO result = executeSdJwtNoConstraintFlow(
+                createSdJwtAllClaimsMap(new LinkedHashMap<>(), sdClaims));
+
+        CredentialDTO credential = result.getMatchingCredentialsResponse().getAvailableCredentials().get(0);
+        List<String> paths = credential.getSdClaims();
+        assertEquals(1, paths.size());
+        assertTrue(paths.contains("$.data"));
+    }
+
+    private static final String SD_JWT_HS256 =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0In0.sig";
+
+    private static final String SD_JWT_NO_ALG =
+            "eyJ0eXAiOiJKV1QifQ.eyJpc3MiOiJ0ZXN0In0.sig";
+
+    private static final String SD_JWT_NON_STRING_ALG =
+            "eyJhbGciOjEyM30.eyJpc3MiOiJ0ZXN0In0.sig";
+
+    private PresentationDefinition createSdJwtPresentationDefinition(List<String> algorithmValues) {
+        Map<String, Map<String, List<String>>> format = new HashMap<>();
+        Map<String, List<String>> sdJwtFormat = new HashMap<>();
+        sdJwtFormat.put("sd-jwt_alg_values", algorithmValues);
+        format.put(CredentialFormat.VC_SD_JWT.getFormat(), sdJwtFormat);
+
+        Fields field = new Fields(Arrays.asList("$.type"), null, null, null, null, null);
+        Constraints constraints = new Constraints(Collections.singletonList(field), null);
+        InputDescriptor descriptor = new InputDescriptor("sd-jwt-descriptor", null, null, format, constraints);
+        return new PresentationDefinition("sd-jwt-pd", Arrays.asList(descriptor), null, null, null);
+    }
+
+    private DecryptedCredentialDTO createDecryptedSdJwtCredential(Object credentialPayload) {
+        DecryptedCredentialDTO credential = new DecryptedCredentialDTO();
+        credential.setId("sd-jwt-credential-id");
+        credential.setWalletId(walletId);
+
+        VCCredentialResponse response = VCCredentialResponse.builder()
+                .format(CredentialFormat.VC_SD_JWT.getFormat())
+                .credential(credentialPayload)
+                .build();
+        credential.setCredential(response);
+
+        CredentialMetadata metadata = new CredentialMetadata();
+        metadata.setIssuerId("test-issuer-id");
+        metadata.setCredentialType("TestCredential");
+        credential.setCredentialMetadata(metadata);
+        credential.setCreatedAt(Instant.now());
+        credential.setUpdatedAt(Instant.now());
+
+        return credential;
+    }
+
+    private void setupSdJwtHandlerMock(Map<String, Object> publicClaims, Map<String, Object> sdClaims) {
+        when(credentialFormatHandler.extractAllCredentialProperties(any(VCCredentialResponse.class)))
+                .thenAnswer(invocation -> {
+                    VCCredentialResponse vc = invocation.getArgument(0);
+                    String format = vc.getFormat();
+
+                    if (CredentialFormat.VC_SD_JWT.getFormat().equalsIgnoreCase(format)) {
+                        Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+                        result.put("publicClaims", new LinkedHashMap<>(publicClaims));
+                        result.put("sdClaims", new LinkedHashMap<>(sdClaims));
+                        return result;
+                    }
+                    Object cred = vc.getCredential();
+                    if (cred instanceof Map) {
+                        return new LinkedHashMap<>((Map<?, ?>) cred);
+                    }
+                    return new LinkedHashMap<>();
+                });
+    }
+
+    private MatchingCredentialsDTO executeSdJwtNoConstraintFlow(
+            Map<String, Map<String, Object>> handlerReturn) throws Exception {
+        Constraints constraints = new Constraints(null, null);
+        InputDescriptor descriptor = new InputDescriptor("sd-jwt-test", null, null, null, constraints);
+        PresentationDefinition pd = new PresentationDefinition("sd-jwt-pd",
+                Arrays.asList(descriptor), null, null, null);
+
+        when(openID4VPService.resolvePresentationDefinition(any(), any(), anyBoolean())).thenReturn(pd);
+        when(walletCredentialService.getDecryptedCredentials(eq(walletId), any()))
+                .thenReturn(Arrays.asList(createDecryptedSdJwtCredential(SD_JWT_HS256)));
+        when(credentialFormatHandler.extractAllCredentialProperties(any(VCCredentialResponse.class)))
+                .thenAnswer(invocation -> handlerReturn);
+
+        return credentialMatchingService.getMatchingCredentials(sessionData, walletId, base64Key);
+    }
+
+    private Map<String, Map<String, Object>> createSdJwtAllClaimsMap(
+            Map<String, Object> publicClaims, Map<String, Object> sdClaims) {
+        Map<String, Map<String, Object>> allClaims = new LinkedHashMap<>();
+        allClaims.put("publicClaims",
+                publicClaims != null ? new LinkedHashMap<>(publicClaims) : null);
+        allClaims.put("sdClaims",
+                sdClaims != null ? new LinkedHashMap<>(sdClaims) : null);
+        return allClaims;
+    }
+
+    private Map<String, Object> createMapOf(Object... keyValues) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return map;
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/LdpVcCredentialFormatHandlerTest.java
+++ b/src/test/java/io/mosip/mimoto/service/LdpVcCredentialFormatHandlerTest.java
@@ -331,6 +331,76 @@ class LdpVcCredentialFormatHandlerTest {
         assertEquals(CredentialFormat.LDP_VC.getFormat(), result);
     }
 
+    @Test
+    void extractAllCredentialPropertiesWithMapCredentialReturnsLinkedHashMap() {
+        // Arrange
+        Map<String, Object> credentialMap = new LinkedHashMap<>();
+        credentialMap.put("type", Arrays.asList("VerifiableCredential"));
+        credentialMap.put("credentialSubject", Map.of("name", "John"));
+        vcCredentialResponse.setCredential(credentialMap);
+
+        // Act
+        Map<String, Object> result = ldpVcCredentialFormatHandler.extractAllCredentialProperties(vcCredentialResponse);
+
+        // Assert
+        assertNotNull(result);
+        assertTrue(result instanceof LinkedHashMap);
+        assertTrue(result.containsKey("type"));
+        assertTrue(result.containsKey("credentialSubject"));
+    }
+
+    @Test
+    void loadDisplayPropertiesFromWellknownWhenOrderHasKeyNotInCredentialPropertiesSkipsIt() {
+        // Arrange - order has "extraKey" not present in credentialProperties
+        Map<String, Object> credentialProperties = new HashMap<>();
+        credentialProperties.put("firstName", "John");
+
+        Map<String, CredentialDisplayResponseDto> credentialSubjectConfig = createCredentialSubjectConfig();
+        credentialDefinition.setCredentialSubject(credentialSubjectConfig);
+        credentialsSupportedResponse.setCredentialDefinition(credentialDefinition);
+        credentialsSupportedResponse.setOrder(Arrays.asList("firstName", "nonExistentKey"));
+
+        try (MockedStatic<LocaleUtils> mockedLocaleUtils = mockStatic(LocaleUtils.class)) {
+            mockedLocaleUtils.when(() -> LocaleUtils.resolveLocaleWithFallback(any(), eq("en")))
+                    .thenReturn("en");
+            mockedLocaleUtils.when(() -> LocaleUtils.matchesLocale(eq("en"), eq("en")))
+                    .thenReturn(true);
+
+            // Act
+            LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> result =
+                    ldpVcCredentialFormatHandler.loadDisplayPropertiesFromWellknown(
+                            credentialProperties, credentialsSupportedResponse, "en");
+
+            // Assert - nonExistentKey skipped (display null for it since not in credentialProperties)
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertTrue(result.containsKey("firstName"));
+            assertFalse(result.containsKey("nonExistentKey"));
+        }
+    }
+
+    @Test
+    void buildFallbackDisplayPropertiesWhenOrderedKeysIsNullUsesCredentialPropertiesKeySet() {
+        // Arrange - null credentialDefinition triggers fallback; null order
+        Map<String, Object> credentialProperties = new LinkedHashMap<>();
+        credentialProperties.put("name", "John");
+        credentialProperties.put("age", 30);
+
+        credentialsSupportedResponse.setCredentialDefinition(null);
+        credentialsSupportedResponse.setOrder(null);
+
+        // Act
+        LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> result =
+                ldpVcCredentialFormatHandler.loadDisplayPropertiesFromWellknown(
+                        credentialProperties, credentialsSupportedResponse, "en");
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.containsKey("name"));
+        assertTrue(result.containsKey("age"));
+    }
+
     // Helper methods
     private Map<String, CredentialDisplayResponseDto> createCredentialSubjectConfig() {
         Map<String, CredentialDisplayResponseDto> config = new LinkedHashMap<>();

--- a/src/test/java/io/mosip/mimoto/service/VcSdJwtCredentialFormatHandlerTest.java
+++ b/src/test/java/io/mosip/mimoto/service/VcSdJwtCredentialFormatHandlerTest.java
@@ -531,6 +531,638 @@ class VcSdJwtCredentialFormatHandlerTest {
         assertEquals("en", lastNameDisplay.getLocale());
     }
 
+    // ============================================================
+    // Tests for extractAllCredentialProperties
+    // ============================================================
+
+    @Test
+    void extractAllCredentialPropertiesWhenCredentialIsStringReturnsProperties() {
+        vcCredentialResponse.setCredential(sampleSdJwtString);
+
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+            when(mockSdJwt.getDisclosures()).thenReturn(null);
+
+            Map<String, Object> jwtPayload = new LinkedHashMap<>();
+            jwtPayload.put("name", "John");
+            jwtPayload.put("iss", "https://example.com");
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(jwtPayload);
+
+            Map<String, Map<String, Object>> result = (Map<String, Map<String, Object>>)
+                    vcSdJwtCredentialFormatHandler.extractAllCredentialProperties(vcCredentialResponse);
+
+            assertNotNull(result);
+            assertTrue(result.containsKey("publicClaims"));
+            assertTrue(result.containsKey("sdClaims"));
+            assertEquals("John", result.get("publicClaims").get("name"));
+        }
+    }
+
+    @Test
+    void extractAllCredentialPropertiesWhenCredentialIsNotStringReturnsEmptyMap() {
+        vcCredentialResponse.setCredential(new HashMap<>());
+
+        Map<String, ?> result = (Map<String, ?>) vcSdJwtCredentialFormatHandler.extractAllCredentialProperties(vcCredentialResponse);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    // ============================================================
+    // Tests for extractAllPropertiesFromSdJwt
+    // ============================================================
+
+    @Test
+    void extractAllPropertiesFromSdJwtWhenIllegalArgExceptionReturnsEmptyMap() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class)) {
+            mockedSdJwt.when(() -> SDJWT.parse("bad-jwt"))
+                    .thenThrow(new IllegalArgumentException("Invalid SD-JWT"));
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt("bad-jwt");
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWhenGenericExceptionReturnsEmptyMap() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class)) {
+            mockedSdJwt.when(() -> SDJWT.parse("bad-jwt"))
+                    .thenThrow(new RuntimeException("Unexpected"));
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt("bad-jwt");
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWhenNullPayloadReturnsSdClaimsEmpty() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+            when(mockSdJwt.getDisclosures()).thenReturn(null);
+
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(null);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertTrue(result.get("publicClaims").isEmpty());
+            assertTrue(result.get("sdClaims").isEmpty());
+        }
+    }
+
+    // ============================================================
+    // Tests for resolveDisclosures via extractAllPropertiesFromSdJwt
+    // ============================================================
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithSdDigestsInPayloadResolvesSdClaims() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure disclosure = mock(Disclosure.class);
+            when(disclosure.digest()).thenReturn("digest1");
+            when(disclosure.getDisclosure()).thenReturn("base64disclosure1");
+            when(disclosure.getClaimName()).thenReturn("given_name");
+            when(disclosure.getClaimValue()).thenReturn("John");
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(disclosure));
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("_sd", Arrays.asList("digest1"));
+            payload.put("iss", "https://example.com");
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            Map<String, Object> sdClaims = result.get("sdClaims");
+            assertTrue(sdClaims.containsKey("given_name"));
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithNullDisclosureForDigestSkipsDigest() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+            when(mockSdJwt.getDisclosures()).thenReturn(Collections.emptyList());
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("_sd", Arrays.asList("unknownDigest"));
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertTrue(result.get("sdClaims").isEmpty());
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWhenClaimNameIsSdOrKeySkipsDigest() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure sdDisclosure = mock(Disclosure.class);
+            when(sdDisclosure.digest()).thenReturn("digest_sd");
+            when(sdDisclosure.getDisclosure()).thenReturn("b64sd");
+            when(sdDisclosure.getClaimName()).thenReturn("_sd");
+
+            Disclosure keyDisclosure = mock(Disclosure.class);
+            when(keyDisclosure.digest()).thenReturn("digest_key");
+            when(keyDisclosure.getDisclosure()).thenReturn("b64key");
+            when(keyDisclosure.getClaimName()).thenReturn("...");
+
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(sdDisclosure, keyDisclosure));
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("_sd", Arrays.asList("digest_sd", "digest_key"));
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            Map<String, Object> sdClaims = result.get("sdClaims");
+            assertFalse(sdClaims.containsKey("_sd"));
+            assertFalse(sdClaims.containsKey("..."));
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithNestedMapContainingSdDigestsResolvesNestedPaths() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure disclosure = mock(Disclosure.class);
+            when(disclosure.digest()).thenReturn("nested_digest");
+            when(disclosure.getDisclosure()).thenReturn("b64nested");
+            when(disclosure.getClaimName()).thenReturn("city");
+            when(disclosure.getClaimValue()).thenReturn("Berlin");
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(disclosure));
+
+            Map<String, Object> addressMap = new LinkedHashMap<>();
+            addressMap.put("_sd", Arrays.asList("nested_digest"));
+            addressMap.put("country", "Germany");
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("address", addressMap);
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            Map<String, Object> sdClaims = result.get("sdClaims");
+            assertTrue(sdClaims.containsKey("address.city"));
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithArrayDisclosureResolvesArrayItems() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure disclosure = mock(Disclosure.class);
+            when(disclosure.digest()).thenReturn("arr_digest");
+            when(disclosure.getDisclosure()).thenReturn("b64arr");
+            when(disclosure.getClaimValue()).thenReturn("disclosed_item");
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(disclosure));
+
+            // Array with a disclosure marker {"...": "arr_digest"} and a regular item
+            Map<String, Object> disclosureMarker = new LinkedHashMap<>();
+            disclosureMarker.put("...", "arr_digest");
+
+            List<Object> arrayWithDisclosure = new ArrayList<>();
+            arrayWithDisclosure.add(disclosureMarker);
+            arrayWithDisclosure.add("regular_item");
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("nationalities", arrayWithDisclosure);
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            Map<String, Object> sdClaims = result.get("sdClaims");
+            assertTrue(sdClaims.containsKey("nationalities[0]"));
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithArrayDisclosureNotFoundSkipsMarker() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+            when(mockSdJwt.getDisclosures()).thenReturn(Collections.emptyList());
+
+            Map<String, Object> disclosureMarker = new LinkedHashMap<>();
+            disclosureMarker.put("...", "unknown_digest");
+
+            List<Object> arrayWithDisclosure = new ArrayList<>();
+            arrayWithDisclosure.add(disclosureMarker);
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("items", arrayWithDisclosure);
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertTrue(result.get("sdClaims").isEmpty());
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithArrayContainingRegularMapRecursesIntoMap() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure disclosure = mock(Disclosure.class);
+            when(disclosure.digest()).thenReturn("inner_digest");
+            when(disclosure.getDisclosure()).thenReturn("b64inner");
+            when(disclosure.getClaimName()).thenReturn("secret");
+            when(disclosure.getClaimValue()).thenReturn("value");
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(disclosure));
+
+            // Regular map (not a disclosure marker) inside a list, containing _sd
+            Map<String, Object> innerMap = new LinkedHashMap<>();
+            innerMap.put("_sd", Arrays.asList("inner_digest"));
+            innerMap.put("visible", "yes");
+
+            List<Object> listValue = new ArrayList<>();
+            listValue.add(innerMap);
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("entries", listValue);
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            Map<String, Object> sdClaims = result.get("sdClaims");
+            assertTrue(sdClaims.containsKey("entries[0].secret"));
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithEmptyPayloadReturnsSdClaimsEmpty() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+            when(mockSdJwt.getDisclosures()).thenReturn(null);
+
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString))
+                    .thenReturn(new HashMap<>());
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertTrue(result.get("sdClaims").isEmpty());
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWhenDisclosureClaimNameNullSkipsDisclosure() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure disclosure = mock(Disclosure.class);
+            when(disclosure.digest()).thenReturn("digest_null_name");
+            when(disclosure.getDisclosure()).thenReturn("b64null");
+            when(disclosure.getClaimName()).thenReturn(null);
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(disclosure));
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("_sd", Arrays.asList("digest_null_name"));
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertTrue(result.get("sdClaims").isEmpty());
+        }
+    }
+
+    @Test
+    void extractAllPropertiesFromSdJwtWithFiveLevelsOfNestedDisclosuresResolvesAllLevels() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Map<String, Object> level5Value = new LinkedHashMap<>();
+            level5Value.put("deep_key", "deep_value");
+
+            Disclosure d5 = mock(Disclosure.class);
+            when(d5.digest()).thenReturn("d5");
+            when(d5.getDisclosure()).thenReturn("b64d5");
+            when(d5.getClaimName()).thenReturn("l5");
+            when(d5.getClaimValue()).thenReturn(level5Value);
+
+            Map<String, Object> level4Value = new LinkedHashMap<>();
+            level4Value.put("_sd", Arrays.asList("d5"));
+
+            Disclosure d4 = mock(Disclosure.class);
+            when(d4.digest()).thenReturn("d4");
+            when(d4.getDisclosure()).thenReturn("b64d4");
+            when(d4.getClaimName()).thenReturn("l4");
+            when(d4.getClaimValue()).thenReturn(level4Value);
+
+            Map<String, Object> level3Value = new LinkedHashMap<>();
+            level3Value.put("_sd", Arrays.asList("d4"));
+
+            Disclosure d3 = mock(Disclosure.class);
+            when(d3.digest()).thenReturn("d3");
+            when(d3.getDisclosure()).thenReturn("b64d3");
+            when(d3.getClaimName()).thenReturn("l3");
+            when(d3.getClaimValue()).thenReturn(level3Value);
+
+            Map<String, Object> level2Value = new LinkedHashMap<>();
+            level2Value.put("_sd", Arrays.asList("d3"));
+
+            Disclosure d2 = mock(Disclosure.class);
+            when(d2.digest()).thenReturn("d2");
+            when(d2.getDisclosure()).thenReturn("b64d2");
+            when(d2.getClaimName()).thenReturn("l2");
+            when(d2.getClaimValue()).thenReturn(level2Value);
+
+            Map<String, Object> level1Value = new LinkedHashMap<>();
+            level1Value.put("_sd", Arrays.asList("d2"));
+
+            Disclosure d1 = mock(Disclosure.class);
+            when(d1.digest()).thenReturn("d1");
+            when(d1.getDisclosure()).thenReturn("b64d1");
+            when(d1.getClaimName()).thenReturn("l1");
+            when(d1.getClaimValue()).thenReturn(level1Value);
+
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(d1, d2, d3, d4, d5));
+
+            Map<String, Object> payload = new LinkedHashMap<>();
+            payload.put("_sd", Arrays.asList("d1"));
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(payload);
+
+            Map<String, Map<String, Object>> result = vcSdJwtCredentialFormatHandler.extractAllPropertiesFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            Map<String, Object> sdClaims = result.get("sdClaims");
+            assertTrue(sdClaims.containsKey("l1"));
+            assertTrue(sdClaims.containsKey("l1.l2"));
+            assertTrue(sdClaims.containsKey("l1.l2.l3"));
+            assertTrue(sdClaims.containsKey("l1.l2.l3.l4"));
+            assertTrue(sdClaims.containsKey("l1.l2.l3.l4.l5"));
+            assertEquals(5, sdClaims.size());
+        }
+    }
+
+    // ============================================================
+    // Tests for extractSdClaims uncovered branches (via extractClaimsFromSdJwt)
+    // ============================================================
+
+    @Test
+    void extractClaimsFromSdJwtWhenDisclosuresNullReturnsPublicClaimsOnly() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+            when(mockSdJwt.getDisclosures()).thenReturn(null);
+
+            Map<String, Object> jwtPayload = new LinkedHashMap<>();
+            jwtPayload.put("name", "John");
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(jwtPayload);
+
+            Map<String, Object> result = vcSdJwtCredentialFormatHandler.extractClaimsFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertEquals("John", result.get("name"));
+        }
+    }
+
+    @Test
+    void extractClaimsFromSdJwtWhenDisclosureClaimNameNullSkipsDisclosure() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure disclosure = mock(Disclosure.class);
+            when(disclosure.getClaimName()).thenReturn(null);
+            when(disclosure.getClaimValue()).thenReturn("someValue");
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(disclosure));
+
+            Map<String, Object> jwtPayload = new LinkedHashMap<>();
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(jwtPayload);
+
+            Map<String, Object> result = vcSdJwtCredentialFormatHandler.extractClaimsFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertFalse(result.containsValue("someValue"));
+        }
+    }
+
+    @Test
+    void extractClaimsFromSdJwtWhenDisclosureClaimValueNullSkipsDisclosure() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure disclosure = mock(Disclosure.class);
+            when(disclosure.getClaimName()).thenReturn("age");
+            when(disclosure.getClaimValue()).thenReturn(null);
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(disclosure));
+
+            Map<String, Object> jwtPayload = new LinkedHashMap<>();
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(jwtPayload);
+
+            Map<String, Object> result = vcSdJwtCredentialFormatHandler.extractClaimsFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertFalse(result.containsKey("age"));
+        }
+    }
+
+    @Test
+    void extractClaimsFromSdJwtWhenDisclosureThrowsExceptionSkipsAndContinues() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+
+            Disclosure badDisclosure = mock(Disclosure.class);
+            when(badDisclosure.getClaimName()).thenThrow(new RuntimeException("decode error"));
+
+            Disclosure goodDisclosure = mock(Disclosure.class);
+            when(goodDisclosure.getClaimName()).thenReturn("name");
+            when(goodDisclosure.getClaimValue()).thenReturn("Alice");
+
+            when(mockSdJwt.getDisclosures()).thenReturn(Arrays.asList(badDisclosure, goodDisclosure));
+
+            Map<String, Object> jwtPayload = new LinkedHashMap<>();
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(jwtPayload);
+
+            Map<String, Object> result = vcSdJwtCredentialFormatHandler.extractClaimsFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertEquals("Alice", result.get("name"));
+        }
+    }
+
+    @Test
+    void extractClaimsFromSdJwtWhenGenericExceptionReturnsEmptyMap() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class)) {
+            mockedSdJwt.when(() -> SDJWT.parse("crash-jwt"))
+                    .thenThrow(new RuntimeException("Unexpected crash"));
+
+            Map<String, Object> result = vcSdJwtCredentialFormatHandler.extractClaimsFromSdJwt("crash-jwt");
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    @Test
+    void extractClaimsFromSdJwtWhenJwtPayloadNullReturnsEmptyPublicClaims() {
+        try (MockedStatic<SDJWT> mockedSdJwt = mockStatic(SDJWT.class);
+             MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+
+            SDJWT mockSdJwt = mock(SDJWT.class);
+            mockedSdJwt.when(() -> SDJWT.parse(sampleSdJwtString)).thenReturn(mockSdJwt);
+            when(mockSdJwt.getCredentialJwt()).thenReturn(sampleJwtString);
+            when(mockSdJwt.getDisclosures()).thenReturn(Collections.emptyList());
+
+            mockedJwtUtils.when(() -> JwtUtils.parseJwtPayload(sampleJwtString)).thenReturn(null);
+
+            Map<String, Object> result = vcSdJwtCredentialFormatHandler.extractClaimsFromSdJwt(sampleSdJwtString);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    // ============================================================
+    // Tests for loadDisplayPropertiesFromWellknown uncovered branches
+    // ============================================================
+
+    @Test
+    void loadDisplayPropertiesFromWellknownWhenValueNullInOrderedKeysSkipsField() {
+        // Arrange - credentialProperties has a key with null value
+        Map<String, Object> credentialProperties = new HashMap<>();
+        credentialProperties.put("name", "John");
+        credentialProperties.put("address", null);
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("name", new HashMap<>());
+        claims.put("address", new HashMap<>());
+        credentialsSupportedResponse.setClaims(claims);
+        credentialsSupportedResponse.setOrder(Arrays.asList("name", "address"));
+
+        CredentialDisplayResponseDto nameDto = createCredentialDisplayResponseDto("Name", "en");
+        CredentialDisplayResponseDto addressDto = createCredentialDisplayResponseDto("Address", "en");
+        when(objectMapper.convertValue(any(), eq(CredentialDisplayResponseDto.class)))
+                .thenReturn(nameDto, addressDto);
+
+        try (MockedStatic<LocaleUtils> mockedLocaleUtils = mockStatic(LocaleUtils.class)) {
+            mockedLocaleUtils.when(() -> LocaleUtils.resolveLocaleWithFallback(any(), eq("en")))
+                    .thenReturn("en");
+            mockedLocaleUtils.when(() -> LocaleUtils.matchesLocale(eq("en"), eq("en")))
+                    .thenReturn(true);
+
+            LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> result =
+                    vcSdJwtCredentialFormatHandler.loadDisplayPropertiesFromWellknown(
+                            credentialProperties, credentialsSupportedResponse, "en");
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertTrue(result.containsKey("name"));
+            assertFalse(result.containsKey("address"));
+        }
+    }
+
+    @Test
+    void loadDisplayPropertiesFromWellknownWhenDisplayNullFallsBackToGeneratedDisplay() {
+        // Arrange - orderedKeys has a key not in claims config (display not found in localizedDisplayMap)
+        Map<String, Object> credentialProperties = new HashMap<>();
+        credentialProperties.put("name", "John");
+        credentialProperties.put("extraField", "extraValue");
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("name", new HashMap<>());
+        credentialsSupportedResponse.setClaims(claims);
+        credentialsSupportedResponse.setOrder(Arrays.asList("name", "extraField"));
+
+        try (MockedStatic<LocaleUtils> mockedLocaleUtils = mockStatic(LocaleUtils.class)) {
+            mockedLocaleUtils.when(() -> LocaleUtils.resolveLocaleWithFallback(any(), eq("en")))
+                    .thenReturn("en");
+            mockedLocaleUtils.when(() -> LocaleUtils.matchesLocale(eq("en"), eq("en")))
+                    .thenReturn(true);
+
+            LinkedHashMap<String, Map<CredentialIssuerDisplayResponse, Object>> result =
+                    vcSdJwtCredentialFormatHandler.loadDisplayPropertiesFromWellknown(
+                            credentialProperties, credentialsSupportedResponse, "en");
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertTrue(result.containsKey("extraField"));
+
+            CredentialIssuerDisplayResponse extraDisplay = result.get("extraField").keySet().iterator().next();
+            assertEquals("Extra Field", extraDisplay.getName());
+            assertEquals("en", extraDisplay.getLocale());
+        }
+    }
+
     // Helper methods
     private Map<String, Object> createSampleClaims() {
         Map<String, Object> claims = new HashMap<>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for SD-JWT (Selective Disclosure JWT) credentials in credential matching and property extraction.
  * Enhanced credential property extraction to handle both public and selective disclosure claims.

* **Improvements**
  * Expanded credential format handling with dedicated support for SD-JWT algorithm validation.
  * Improved credential matching logic with delegated property extraction for better credential format compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->