### PR TITLE
fix(openid4vci): update get credential for v1 vcresponse

### DIFF
--- a/src/main/java/io/mosip/mimoto/dto/mimoto/V1Credential.java
+++ b/src/main/java/io/mosip/mimoto/dto/mimoto/V1Credential.java
@@ -1,0 +1,8 @@
+package io.mosip.mimoto.dto.mimoto;
+
+import lombok.Data;
+
+@Data
+public class V1Credential {
+    private Object credential;
+}

--- a/src/main/java/io/mosip/mimoto/dto/mimoto/V1VCCredentialResponse.java
+++ b/src/main/java/io/mosip/mimoto/dto/mimoto/V1VCCredentialResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Builder
 public class V1VCCredentialResponse {
 
-    private List<Object> credentials;
+    private List<V1Credential> credentials;
 
     private String error;
 

--- a/src/main/java/io/mosip/mimoto/service/impl/V1VCDownloadHandler.java
+++ b/src/main/java/io/mosip/mimoto/service/impl/V1VCDownloadHandler.java
@@ -6,6 +6,7 @@ import io.mosip.mimoto.dto.mimoto.CredentialIssuerWellKnownResponse;
 import io.mosip.mimoto.dto.mimoto.V1VCCredentialRequest;
 import io.mosip.mimoto.dto.mimoto.V1VCCredentialResponse;
 import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
+import io.mosip.mimoto.dto.mimoto.V1Credential;
 import io.mosip.mimoto.exception.CredentialProcessingException;
 import io.mosip.mimoto.exception.ExternalServiceUnavailableException;
 import io.mosip.mimoto.exception.InvalidCredentialResourceException;
@@ -63,7 +64,7 @@ public class V1VCDownloadHandler implements VCDownloadHandler {
                     String.format(DOWNLOAD_FAILURE_MESSAGE, issuerId, credentialConfigurationId) + " - " + errorDetail);
         }
 
-        List<Object> credentials = response.getCredentials();
+        List<V1Credential> credentials = response.getCredentials();
         if (credentials == null || credentials.isEmpty()) {
             throw new InvalidCredentialResourceException(EMPTY_CREDENTIAL_MESSAGE);
         }
@@ -71,7 +72,7 @@ public class V1VCDownloadHandler implements VCDownloadHandler {
         String format = credentialIssuerWellKnownResponse.getCredentialConfigurationsSupported().get(credentialConfigurationId).getFormat();
 
         log.debug("V1 VC Credential Response received for issuerId: {}", issuerId);
-        return new VCCredentialResponse(format, credentials.getFirst());
+        return new VCCredentialResponse(format, credentials.getFirst().getCredential());
     }
 
     private V1VCCredentialRequest buildCredentialRequest(IssuerDTO issuerDTO, String credentialConfigurationId, CredentialIssuerWellKnownResponse wellKnownResponse, String walletId, String base64Key, boolean isLoginFlow) throws CredentialProcessingException {

--- a/src/test/java/io/mosip/mimoto/service/V1VCDownloadHandlerTest.java
+++ b/src/test/java/io/mosip/mimoto/service/V1VCDownloadHandlerTest.java
@@ -3,6 +3,7 @@ package io.mosip.mimoto.service;
 import io.mosip.mimoto.dto.IssuerDTO;
 import io.mosip.mimoto.dto.idp.TokenResponseDTO;
 import io.mosip.mimoto.dto.mimoto.*;
+import io.mosip.mimoto.dto.mimoto.V1Credential;
 import io.mosip.mimoto.exception.CredentialProcessingException;
 import io.mosip.mimoto.exception.ExternalServiceUnavailableException;
 import io.mosip.mimoto.exception.InvalidCredentialResourceException;
@@ -80,6 +81,12 @@ class V1VCDownloadHandlerTest {
                 .build();
     }
 
+    private V1Credential v1Credential(Object credentialValue) {
+        V1Credential cred = new V1Credential();
+        cred.setCredential(credentialValue);
+        return cred;
+    }
+
     @Test
     void shouldReturnVCCredentialResponseOnSuccessfulDownload() throws Exception {
         V1VCCredentialRequest request = buildRequest("jwt-token");
@@ -89,7 +96,7 @@ class V1VCDownloadHandlerTest {
                 .thenReturn(request);
 
         V1VCCredentialResponse mockResponse = V1VCCredentialResponse.builder()
-                .credentials(List.of("eyJhbGciOiJFUzI1NiJ9.credential-payload.signature"))
+                .credentials(List.of(v1Credential("eyJhbGciOiJFUzI1NiJ9.credential-payload.signature")))
                 .build();
 
         when(restApiClient.postApiWithErrorResponse(eq(CREDENTIAL_ENDPOINT), eq(MediaType.APPLICATION_JSON),
@@ -113,7 +120,7 @@ class V1VCDownloadHandlerTest {
                 .thenReturn(request);
 
         V1VCCredentialResponse mockResponse = V1VCCredentialResponse.builder()
-                .credentials(List.of("first-credential", "second-credential", "third-credential"))
+                .credentials(List.of(v1Credential("first-credential"), v1Credential("second-credential"), v1Credential("third-credential")))
                 .build();
 
         when(restApiClient.postApiWithErrorResponse(eq(CREDENTIAL_ENDPOINT), eq(MediaType.APPLICATION_JSON),
@@ -136,7 +143,7 @@ class V1VCDownloadHandlerTest {
                 .thenReturn(request);
 
         V1VCCredentialResponse mockResponse = V1VCCredentialResponse.builder()
-                .credentials(List.of("login-credential-data"))
+                .credentials(List.of(v1Credential("login-credential-data")))
                 .build();
 
         when(restApiClient.postApiWithErrorResponse(eq(CREDENTIAL_ENDPOINT), eq(MediaType.APPLICATION_JSON),
@@ -179,7 +186,7 @@ class V1VCDownloadHandlerTest {
                 .build();
 
         V1VCCredentialResponse successResponse = V1VCCredentialResponse.builder()
-                .credentials(List.of("retry-credential-data"))
+                .credentials(List.of(v1Credential("retry-credential-data")))
                 .build();
 
         when(restApiClient.postApiWithErrorResponse(eq(CREDENTIAL_ENDPOINT), eq(MediaType.APPLICATION_JSON),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured credential response data model to use strongly-typed objects instead of generic types for improved consistency and validation
  * Updated credential payload extraction and handling logic to align with the new data structure

* **Tests**
  * Updated test fixtures to validate the strengthened credential data model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->