### PR TITLE
feat: add spec_version to Verifier

### DIFF
--- a/docker-compose/config/mimoto-trusted-verifiers.json
+++ b/docker-compose/config/mimoto-trusted-verifiers.json
@@ -9,7 +9,8 @@
         "https://injiverify.collab.mosip.net/v1/verify/vp-submission/vp-direct-post"
       ],
       "jwks_uri": "https://injiverify.collab.mosip.net/.well-known/jwks.json",
-      "allow_unsigned_request": false
+      "allow_unsigned_request": false,
+      "spec_version": "draft23"
     }
   ]
 }

--- a/docs/api-documentation-openapi.json
+++ b/docs/api-documentation-openapi.json
@@ -175,6 +175,17 @@
                                                         "items": {
                                                             "type": "string"
                                                         }
+                                                    },
+                                                    "allow_unsigned_request": {
+                                                        "type": "boolean",
+                                                        "description": "Indicates whether the verifier allows unsigned requests or not.",
+                                                        "default": false
+                                                    },
+                                                    "spec_version": {
+                                                        "type": "string",
+                                                        "enum": ["draft23", "v1"],
+                                                        "description": "OpenID4VP specification version supported by the Verifier.",
+                                                        "default": "v1"
                                                     }
                                                 }
                                             }
@@ -192,7 +203,9 @@
                                                     ],
                                                     "response_uris": [
                                                         "https://injiverify.collab.mosip.net/redirect"
-                                                    ]
+                                                    ],
+                                                    "allow_unsigned_request": false,
+                                                    "spec_version": "v1"
                                                 }
                                             ]
                                         }

--- a/src/main/java/io/mosip/mimoto/dto/openid/SpecVersion.java
+++ b/src/main/java/io/mosip/mimoto/dto/openid/SpecVersion.java
@@ -1,0 +1,19 @@
+package io.mosip.mimoto.dto.openid;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum SpecVersion {
+    V1_0("v1"),
+    DRAFT_23("draft23");
+
+    private final String version;
+
+    SpecVersion(String version) {
+        this.version = version;
+    }
+
+    @JsonValue
+    public String getVersion() {
+        return version;
+    }
+}

--- a/src/main/java/io/mosip/mimoto/dto/openid/VerifierDTO.java
+++ b/src/main/java/io/mosip/mimoto/dto/openid/VerifierDTO.java
@@ -39,5 +39,10 @@ public class VerifierDTO {
     @Schema(description = "Flag to indicate if unsigned Authorization Request is allowed")
     @Default
     Boolean allowUnsignedRequest = false;
+
+    @JsonProperty("spec_version")
+    @Schema(description = "OpenID4VP specification version supported by the Verifier")
+    @Default
+    SpecVersion specVersion = SpecVersion.V1_0;
 }
 

--- a/src/main/resources/mimoto-trusted-verifiers.json
+++ b/src/main/resources/mimoto-trusted-verifiers.json
@@ -9,7 +9,8 @@
         "https://injiverify.collab.mosip.net/v1/verify/vp-submission/vp-direct-post"
       ],
       "jwks_uri": "https://injiverify.collab.mosip.net/.well-known/jwks.json",
-      "allow_unsigned_request": true
+      "allow_unsigned_request": true,
+      "spec_version": "draft23"
     }
   ]
 }

--- a/src/test/java/io/mosip/mimoto/controller/VerifiersControllerTest.java
+++ b/src/test/java/io/mosip/mimoto/controller/VerifiersControllerTest.java
@@ -1,5 +1,6 @@
 package io.mosip.mimoto.controller;
 
+import io.mosip.mimoto.dto.openid.SpecVersion;
 import io.mosip.mimoto.dto.openid.VerifierDTO;
 import io.mosip.mimoto.dto.openid.VerifiersDTO;
 import io.mosip.mimoto.exception.ApiNotAccessibleException;
@@ -85,6 +86,7 @@ public class VerifiersControllerTest {
                 .responseUris(Collections.singletonList("https://test-responseUri"))
                 .jwksUri("https://test/.well-known/jwks.json")
                 .allowUnsignedRequest(true)
+                .specVersion(SpecVersion.DRAFT_23)
                 .build();
 
         VerifiersDTO trustedVerifiers = VerifiersDTO.builder()
@@ -97,6 +99,7 @@ public class VerifiersControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.response.verifiers[0].allow_unsigned_request").value(true))
                 .andExpect(jsonPath("$.response.verifiers[0].client_id").value("test-clientId"))
+                .andExpect(jsonPath("$.response.verifiers[0].spec_version").value("draft23"))
                 .andExpect(jsonPath("$.response.verifiers[0].jwks_uri").value("https://test/.well-known/jwks.json"));
     }
 
@@ -118,6 +121,7 @@ public class VerifiersControllerTest {
         mockMvc.perform(get("/verifiers").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.response.verifiers[0].allow_unsigned_request").value(false)) // allow_unsigned_request is not passed means it should take default value false
+                .andExpect(jsonPath("$.response.verifiers[0].spec_version").value("v1")) // spec version is not passed means it should take default value v1
                 .andExpect(jsonPath("$.response.verifiers[0].jwks_uri").doesNotExist()); // jwks_uri is not passed means it should not be present in trusted verifiers
     }
 }

--- a/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/PresentationServiceTest.java
@@ -6,6 +6,7 @@ import io.mosip.mimoto.constant.CredentialFormat;
 import io.mosip.mimoto.dto.mimoto.VCCredentialProperties;
 import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
 import io.mosip.mimoto.dto.mimoto.VCCredentialResponseProof;
+import io.mosip.mimoto.dto.openid.SpecVersion;
 import io.mosip.mimoto.dto.openid.VerifierDTO;
 import io.mosip.mimoto.dto.openid.VerifiersDTO;
 import io.mosip.mimoto.dto.openid.presentation.FieldDTO;
@@ -77,7 +78,8 @@ public class PresentationServiceTest {
                 List.of("redirect-uri"),
                 List.of("https%3A%2F%2Finji-verify.collab.mosip.net%2Fverifier%2Fvp-response"),
                 null,
-                false
+                false,
+                SpecVersion.V1_0
         );
         verifiersDTO = new VerifiersDTO();
         verifiersDTO.setVerifiers(List.of(verifierDTO));

--- a/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
+++ b/src/test/java/io/mosip/mimoto/service/WalletPresentationServiceTest.java
@@ -12,6 +12,7 @@ import io.mosip.mimoto.constant.OpenID4VPConstants;
 import io.mosip.mimoto.constant.SigningAlgorithm;
 import io.mosip.mimoto.dto.*;
 import io.mosip.mimoto.dto.mimoto.VCCredentialResponse;
+import io.mosip.mimoto.dto.openid.SpecVersion;
 import io.mosip.mimoto.dto.openid.VerifierDTO;
 import io.mosip.mimoto.dto.openid.VerifiersDTO;
 import io.mosip.mimoto.dto.resident.VerifiablePresentationSessionData;
@@ -102,7 +103,8 @@ public class WalletPresentationServiceTest {
                 List.of("https://verifier.com/response"),
                 List.of("https://verifier.com/jwks"),
                 null,
-                false
+                false,
+                SpecVersion.V1_0
         );
         verifiersDTO = new VerifiersDTO();
         verifiersDTO.setVerifiers(List.of(verifierDTO));


### PR DESCRIPTION
- spec_version field indicates the specification version currently followed by the Verifier.
- The default value for this field will be v1

Fixes: https://github.com/inji/inji-wallet/issues/2444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verifiers can now declare an OpenID4VP specification version (default "v1", supports "draft23"), exposed as spec_version in API responses.

* **Documentation**
  * OpenAPI docs updated to include spec_version and allow_unsigned_request fields and examples for the /verifiers response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->