### PR TITLE
chore: bump up mimoto version to 1.0.0-alpha.1-SNAPSHOT

### DIFF
--- a/api-test/README.md
+++ b/api-test/README.md
@@ -96,7 +96,7 @@ To execute the tests using Jar, use the following steps:
 
 2. Run the automation test suite JAR file:
    ```
-   java -jar -Dmodules=mimoto -Denv.user=api-internal.<env_name> -Denv.endpoint=<base_env> -Denv.testLevel=smokeAndRegression -jar apitest-mimoto-0.20.0-SNAPSHOT-jar-with-dependencies.jar
+   java -jar -Dmodules=mimoto -Denv.user=api-internal.<env_name> -Denv.endpoint=<base_env> -Denv.testLevel=smokeAndRegression -jar apitest-mimoto-1.0.0-alpha.1-SNAPSHOT-jar-with-dependencies.jar
    ```
    
 # Using Eclipse IDE
@@ -157,7 +157,7 @@ To execute the tests using Eclipse IDE, use the following steps:
 - **env.user**: Replace `<env_name>` with the appropriate environment name (e.g., `dev`, `qa`, etc.).
 - **env.endpoint**: The environment where the application under test is deployed. Replace `<base_env>` with the correct base URL for the environment (e.g., `https://api-internal.<env_name>.mosip.net`).
 - **env.testLevel**: Set this to `smoke` to run only smoke test cases, or `smokeAndRegression` to run both smoke and regression tests.
-- **jar**: Specify the name of the JAR file to execute. The version will change according to the development code version. For example, the current version may look like `apitest-mimoto-0.20.0-SNAPSHOT-jar-with-dependencies.jar`.
+- **jar**: Specify the name of the JAR file to execute. The version will change according to the development code version. For example, the current version may look like `apitest-mimoto-1.0.0-alpha.1-SNAPSHOT-jar-with-dependencies.jar`.
 
 ### Build and Run Info
 

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.6.0</version>
 		</dependency>
 	</dependencies>
 

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-mimoto</name>
 	<description>Parent project of apitest-mimoto</description>
 	<url>https://github.com/inji/mimoto</url>
-	<version>0.20.0-SNAPSHOT</version>
+	<version>1.0.0-alpha.1-SNAPSHOT</version>
 
 	<licenses>
 		<license>
@@ -61,7 +61,7 @@
 		<maven.source.plugin.version>2.2.1</maven.source.plugin.version>
 
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
-		<fileName>apitest-mimoto-0.20.0-SNAPSHOT-jar-with-dependencies</fileName>
+		<fileName>apitest-mimoto-1.0.0-alpha.1-SNAPSHOT-jar-with-dependencies</fileName>
 	</properties>
 
 	<dependencies>

--- a/db_scripts/init_values.yaml
+++ b/db_scripts/init_values.yaml
@@ -17,4 +17,4 @@ databases:
         key: postgres-password
     dml: 1
     repoUrl: https://github.com/mosip/mimoto.git
-    branch: develop
+    branch: release-1.0.x

--- a/deploy/mimoto-apitestrig/values.yaml
+++ b/deploy/mimoto-apitestrig/values.yaml
@@ -11,7 +11,7 @@ modules:
     enabled: true
     image:
       repository: injistack/apitest-mimoto
-      tag: develop
+      tag: 1.0.x
       pullPolicy: Always
   masterdata:
     enabled: false

--- a/deploy/mimoto-apitestrig/values.yaml
+++ b/deploy/mimoto-apitestrig/values.yaml
@@ -10,7 +10,7 @@ modules:
   mimoto:
     enabled: true
     image:
-      repository: injistack/apitest-mimoto
+      repository: injistackqa/apitest-mimoto
       tag: 1.0.x
       pullPolicy: Always
   masterdata:

--- a/deploy/mimoto/install.sh
+++ b/deploy/mimoto/install.sh
@@ -7,7 +7,7 @@ if [ $# -ge 1 ] ; then
 fi
 
 NS=injiweb
-CHART_VERSION=0.0.1-develop
+CHART_VERSION=1.0.0-alpha.1-develop
 KEYGEN_CHART_VERSION=1.3.0-beta.2
 SOFTHSM_NS=softhsm
 SOFTHSM_CHART_VERSION=1.3.0-beta.2

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: 'injistackdev/mimoto:develop'
+    image: 'injistackdev/mimoto:1.0.x'
     user: root
     ports:
       - '8099:8099'

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: 'injistackdev/mimoto:1.0.x'
+    image: 'injistackqa/mimoto:1.0.x'
     user: root
     ports:
       - '8099:8099'

--- a/helm/mimoto/Chart.yaml
+++ b/helm/mimoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimoto
 description: A Helm chart for INJI mimoto Application
 type: application
-version: 1.0.0-develop
+version: 1.0.0-alpha.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mimoto/Chart.yaml
+++ b/helm/mimoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimoto
 description: A Helm chart for INJI mimoto Application
 type: application
-version: 0.0.1-develop
+version: 1.0.0-alpha.1-SNAPSHOT
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mimoto/Chart.yaml
+++ b/helm/mimoto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimoto
 description: A Helm chart for INJI mimoto Application
 type: application
-version: 1.0.0-alpha.1-SNAPSHOT
+version: 1.0.0-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/mimoto/values.yaml
+++ b/helm/mimoto/values.yaml
@@ -53,7 +53,7 @@ service:
 
 image:
   registry: docker.io
-  repository: injistackdev/mimoto
+  repository: injistackqa/mimoto
   tag: 1.0.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/helm/mimoto/values.yaml
+++ b/helm/mimoto/values.yaml
@@ -54,7 +54,7 @@ service:
 image:
   registry: docker.io
   repository: injistackdev/mimoto
-  tag: develop
+  tag: 1.0.x
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji</groupId>
     <artifactId>mimoto</artifactId>
-    <version>0.22.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.1-SNAPSHOT</version>
     <name>mimoto</name>
     <url>https://github.com/inji/mimoto</url>
     <description>Mobile server backend supporting Inji.</description>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project and artifact versions to the new **1.0.0 alpha snapshot** line.
  * Switched deployment/container image references to the **1.0.x** release track.
  * Updated Helm chart versioning and image tag to match **1.0.x**.
  * Refreshed database initialization and API test packaging to align with the **new release branch/version**.
* **Documentation**
  * Updated the “Using Jar” example command to reference the newer packaged artifact/version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->