### PR TITLE
fix: align Maven and CI license metadata with Apache 2.0

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       SERVICE_LOCATION: ./
       BUILD_ARTIFACT: mimoto
+      LICENSE_NAME: 'Apache 2.0'
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}
       OSSRH_SECRET: ${{ secrets.OSSRH_SECRET }}
@@ -115,6 +116,7 @@ jobs:
     with:
       SERVICE_LOCATION: ./api-test
       BUILD_ARTIFACT: apitest-mimoto
+      LICENSE_NAME: 'Apache 2.0'
     secrets:
       OSSRH_USER: ${{ secrets.OSSRH_USER }}
       OSSRH_SECRET: ${{ secrets.OSSRH_SECRET }}

--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -12,8 +12,8 @@
 
 	<licenses>
 		<license>
-			<name>MPL 2.0</name>
-			<url>https://www.mozilla.org/en-US/MPL/2.0/</url>
+			<name>Apache 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
 		</license>
 	</licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 
     <licenses>
         <license>
-            <name>MPL 2.0</name>
-            <url>https://www.mozilla.org/en-US/MPL/2.0/</url>
+            <name>Apache 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
     <scm>


### PR DESCRIPTION
fix: align Maven and CI license metadata with Apache 2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project and API test license metadata from Mozilla Public License 2.0 to Apache License 2.0.
  * Updated automated Maven builds to use Apache 2.0 licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->